### PR TITLE
Add CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(IKoreEngine LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+
+# GLFW
+FetchContent_Declare(
+  glfw
+  GIT_REPOSITORY https://github.com/glfw/glfw.git
+  GIT_TAG        3.3.8
+)
+FetchContent_MakeAvailable(glfw)
+
+# GLAD
+FetchContent_Declare(
+  glad
+  GIT_REPOSITORY https://github.com/Dav1dde/glad.git
+  GIT_TAG        v0.1.36
+)
+FetchContent_MakeAvailable(glad)
+
+find_package(OpenGL REQUIRED)
+
+add_executable(IKore src/main.cpp)
+
+target_link_libraries(IKore PRIVATE glfw glad OpenGL::GL)
+
+if(MSVC)
+    target_compile_options(IKore PRIVATE /W4)
+else()
+    target_compile_options(IKore PRIVATE -Wall -Wextra -pedantic)
+endif()
+
+# Multi-platform options
+if (APPLE)
+    target_link_libraries(IKore PRIVATE "-framework Cocoa" "-framework IOKit" "-framework CoreVideo")
+endif()
+
+install(TARGETS IKore RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # IKore Engine
 IKore Engine is a modern, flexible 3D game engine built with OpenGL and C++.
-## Building
-Use CMake to configure and compile the source code.
 
+## Building
+
+IKore Engine uses CMake to manage its dependencies and generate native project files.
+
+```bash
+# From the repository root
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+On Windows you can generate Visual Studio project files instead:
+
+```powershell
+mkdir build && cd build
+cmake .. -G "Visual Studio 17 2022"
+```
+
+On macOS you can generate Xcode projects:
+
+```bash
+mkdir build && cd build
+cmake .. -G Xcode
+```
+
+This setup downloads GLFW and GLAD at configure time and should work on Linux, macOS and Windows.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,40 @@
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+#include <iostream>
+
+int main() {
+    if (!glfwInit()) {
+        std::cerr << "Failed to initialize GLFW\n";
+        return -1;
+    }
+
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+#ifdef __APPLE__
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+#endif
+
+    GLFWwindow* window = glfwCreateWindow(800, 600, "IKore Engine", nullptr, nullptr);
+    if (!window) {
+        std::cerr << "Failed to create GLFW window\n";
+        glfwTerminate();
+        return -1;
+    }
+    glfwMakeContextCurrent(window);
+
+    if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+        std::cerr << "Failed to initialize GLAD\n";
+        return -1;
+    }
+
+    while (!glfwWindowShouldClose(window)) {
+        glClear(GL_COLOR_BUFFER_BIT);
+        glfwSwapBuffers(window);
+        glfwPollEvents();
+    }
+
+    glfwDestroyWindow(window);
+    glfwTerminate();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add CMakeLists.txt with FetchContent for GLFW and GLAD
- add demo `src/main.cpp` using GLFW and GLAD
- document multi-platform build steps for Windows and macOS

## Testing
- `cmake -S . -B build`
- `cmake --build build`
This pull request introduces the initial setup for the IKore Engine, a modern 3D game engine built with OpenGL and C++. It includes the configuration of the build system, documentation for building the project, and the creation of a minimal example to initialize and render a blank window using GLFW and GLAD.

### Build System Setup:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1-R43): Added CMake configuration to set up the project, specify C++17 as the standard, fetch dependencies (GLFW and GLAD), link OpenGL, and manage multi-platform compatibility. Includes installation rules for the executable.

### Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R29): Updated the README to include detailed instructions for building the project using CMake on Linux, Windows, and macOS. Added examples for generating platform-specific project files.

### Minimal Example:

* [`src/main.cpp`](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R1-R40): Added a basic implementation to initialize GLFW, load OpenGL functions using GLAD, and create a window that renders a blank screen. Includes error handling for initialization failures.