### PR TITLE
Add GLM and stb_image with FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 
 # GLFW
+set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
   glfw
   GIT_REPOSITORY https://github.com/glfw/glfw.git
@@ -16,6 +20,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(glfw)
 
 # GLAD
+set(GLAD_INSTALL OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
   glad
   GIT_REPOSITORY https://github.com/Dav1dde/glad.git
@@ -23,11 +28,32 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(glad)
 
+# GLM
+FetchContent_Declare(
+  glm
+  GIT_REPOSITORY https://github.com/g-truc/glm.git
+  GIT_TAG        0.9.9.8
+)
+FetchContent_MakeAvailable(glm)
+
+# stb_image
+FetchContent_Declare(
+  stb
+  GIT_REPOSITORY https://github.com/nothings/stb.git
+  GIT_TAG        f58f558c120e9b32c217290b80bad1a0729fbb2c
+)
+FetchContent_GetProperties(stb)
+if(NOT stb_POPULATED)
+  FetchContent_Populate(stb)
+  add_library(stb INTERFACE)
+  target_include_directories(stb INTERFACE ${stb_SOURCE_DIR})
+endif()
+
 find_package(OpenGL REQUIRED)
 
 add_executable(IKore src/main.cpp)
 
-target_link_libraries(IKore PRIVATE glfw glad OpenGL::GL)
+target_link_libraries(IKore PRIVATE glfw glad glm stb OpenGL::GL)
 
 if(MSVC)
     target_compile_options(IKore PRIVATE /W4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,15 +45,15 @@ FetchContent_Declare(
 FetchContent_GetProperties(stb)
 if(NOT stb_POPULATED)
   FetchContent_Populate(stb)
-  add_library(stb INTERFACE)
-  target_include_directories(stb INTERFACE ${stb_SOURCE_DIR})
+  add_library(stb_image INTERFACE)
+  target_include_directories(stb_image INTERFACE ${stb_SOURCE_DIR})
 endif()
 
 find_package(OpenGL REQUIRED)
 
 add_executable(IKore src/main.cpp)
 
-target_link_libraries(IKore PRIVATE glfw glad glm stb OpenGL::GL)
+target_link_libraries(IKore PRIVATE glfw glad glm stb_image OpenGL::GL)
 
 if(MSVC)
     target_compile_options(IKore PRIVATE /W4)

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ mkdir build && cd build
 cmake .. -G Xcode
 ```
 
-This setup downloads GLFW and GLAD at configure time and should work on Linux, macOS and Windows.
+GLFW, GLAD, GLM and stb_image are downloaded automatically at configure time via FetchContent and should work on Linux, macOS and Windows.


### PR DESCRIPTION
## Summary
- integrate GLM via FetchContent
- integrate stb_image via FetchContent and an interface library
- disable GLFW/GLAD examples and tests when fetching
- clarify dependency note in README

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_6842e9c3a36083208658da7eed6a35be