### PR TITLE
Add strategic vision docs: world-from-data thesis and Doodle Dungeon game concept

### DIFF
--- a/EXPANSION_IDEAS.md
+++ b/EXPANSION_IDEAS.md
@@ -1,0 +1,244 @@
+# IKore Engine — Expansion Ideas: Finding a Unique Identity
+
+> **Purpose of this document.** IKore Engine is technically competent, but in its
+> current form it is hard to distinguish from the hundreds of other hobby
+> OpenGL/C++ ECS engines on GitHub. This document proposes a *point of view* —
+> a niche where IKore would be the obvious choice — and a concrete, phased plan
+> to get there, grounded in the code that already exists.
+
+---
+
+## 1. Honest assessment of where the engine is today
+
+**What is actually implemented in `src/` (verified in code):**
+
+- A working **Entity-Component System** in two flavors: a `shared_ptr`-per-component
+  OOP style (`Entity::addComponent<T>()`) and a pooled variant
+  (`EntityPool`, `PooledEntityManager`).
+- Components: `Transform`, `Mesh`, `Material`, `Renderable`, `Velocity`,
+  `Physics` (Bullet), `LOD`, `Animation` (Assimp skeletal), `AI` (FSM:
+  patrol/chase/flee/guard/wander), `Sound`/`Audio` (OpenAL 3D), `Particle`,
+  `Network`.
+- Rendering: forward renderer with **shadow mapping** (directional + point),
+  **frustum culling**, a **GPU/compute particle system**, post-processing
+  (**bloom, SSAO, FXAA**), and a skybox.
+- Engine services: **scene graph**, **serialization**, **event system**,
+  logger, and an **ECS micro-benchmark**.
+
+**What the issue tracker *claims* but is NOT in the source tree:**
+
+- Terrain (deformation, blending, heightmaps), water/buoyancy, weather physics,
+  destructibles, and the whole **"map translation" milestone**
+  (SVG→3D, procedural roads, OSM-style city generation, randomized object
+  variation). These issues are marked *closed*, but `grep` finds **no surviving
+  code** for terrain, water, weather, SVG, or heightmaps. They were planned and
+  abandoned (or reverted).
+
+**What is entirely missing:**
+
+- **No editor / in-engine UI / tooling.** Every issue in "Milestone 7: UI &
+  Debugging" (#53–#63: FPS overlay, debug console, entity inspector, scene
+  hierarchy viewer, input remapping, HUD/menus) is still **open**.
+- **No scripting layer** (no Lua / AngelScript / WASM). Everything is hard-coded C++.
+- **No PBR / modern rendering path** (it is classic Phong/Blinn forward shading).
+
+### The core problem
+
+> IKore is a **general-purpose engine with no reason to exist** next to Godot,
+> Unreal, Bevy, or the next hobby engine. Every feature it has is a feature those
+> engines have, done better. To become interesting it needs a *thesis* — one
+> thing it does that mainstream engines do **not**.
+
+The good news: the **most distinctive idea in the project's own history — turning
+real-world / 2D data into living 3D worlds — was never actually built.** That is
+the gap to lean into.
+
+---
+
+## 2. The thesis: *"The engine that builds living worlds from real data."*
+
+Instead of competing as a general game engine, position IKore as a
+**world-from-data simulation engine**: feed it 2D/real-world inputs (floor plans,
+city maps, GIS data, tilemaps), and it produces a navigable, physically simulated
+3D world populated by autonomous agents — with the ability to pause, rewind,
+replay, and export the simulation.
+
+This is a real, under-served niche (architectural walkthroughs, urban/traffic
+simulation, crowd modeling, digital twins, rapid game-level prototyping from real
+maps) and it is *coherent with the engine's own abandoned roadmap*. Three pillars
+make it unique, and each one builds directly on code that already exists:
+
+| Pillar | Builds on existing code | Why it's unique |
+|---|---|---|
+| **A. World-from-Data pipeline** | scene graph, `MeshComponent` procedural builders, serialization | Few hobby engines ingest SVG/GeoJSON/CAD and extrude playable 3D worlds |
+| **B. Agent simulation at scale + time control** | `AIComponent`, `EventSystem`, Bullet physics, `EntityPool` | Pause/rewind/replay of thousands of deterministic agents is rare |
+| **C. AI-native authoring & NPCs** | `AIComponent` (FSM), `EventSystem`, `NetworkComponent` | LLM-assisted scene authoring + LLM/behavior-tree NPCs is genuinely 2026-modern |
+
+The rest of the document details these three flagship/supporting directions, plus
+the **foundations** they require, and ends with a concrete 8-week vertical slice.
+
+---
+
+## 3. Tier 1 — Flagship differentiator: the World-from-Data pipeline
+
+**Goal:** `ikore import city.osm` (or `floorplan.svg`, or `level.tmx`) → a fully
+navigable 3D scene with walls, roads, props, collision, and a baked nav-mesh.
+
+### Phases
+
+1. **SVG / vector floor plans → 3D interiors.**
+   Parse SVG paths; extrude walls to height; cut doors/windows from layer
+   metadata; generate floor/ceiling geometry. Output entities through the
+   existing scene graph + `MeshComponent`. (This was issue #71, never built.)
+2. **GeoJSON / OpenStreetMap → city blocks.**
+   Buildings from footprint polygons (extrude by `height`/`levels` tags), roads
+   from way geometry with curve smoothing and intersection stitching (issue #72),
+   water/parks as flat textured regions.
+3. **Tilemaps (Tiled `.tmx`) → 3D levels.**
+   Map tile layers to prefabs; object layers to entity spawns. The fastest path
+   to a usable demo and the friendliest to game devs.
+4. **Procedural dressing.**
+   Randomized rotation/scale/placement of props with overlap avoidance
+   (issue #73); biome/material rules per region.
+5. **Navigation baking.**
+   Generate a nav-mesh from the produced geometry so agents (Pillar B) can move.
+
+### Why this is the right flagship
+- It is the project's *own* original differentiator, currently unbuilt.
+- It immediately produces impressive, shareable demos ("I imported my city and
+  walked through it") — great for stars/visibility.
+- It reuses the scene graph, procedural mesh builders, and serialization that
+  already work.
+- It creates a reason to choose IKore over Godot/Unreal for a whole class of
+  users (GIS, architecture, simulation, viz).
+
+### Rough effort
+SVG interiors: ~2–3 weeks. Tilemaps: ~1 week. GeoJSON/OSM: ~3–4 weeks.
+Nav-mesh: ~2 weeks (or integrate Recast/Detour).
+
+---
+
+## 4. Tier 2 — Supporting differentiators
+
+### 4A. Agent simulation at scale, with time control
+Turn the FSM `AIComponent` into a **simulation substrate**:
+- **Deterministic fixed-step update** so runs are reproducible.
+- **Time control**: pause, step, variable speed, and **rewind/replay** via
+  ring-buffered state snapshots (the serialization system is the seed).
+- **Scale**: thousands of agents (crowds, traffic, ecosystems). This *requires*
+  the data-oriented ECS in §5.1 — the current `shared_ptr`-per-component model
+  will not hold thousands of agents at frame rate.
+- **Data export**: dump per-tick agent state to CSV/JSON for analysis.
+
+*Unique because* mainstream game engines optimize for a few hero characters, not
+reproducible, rewindable simulation of large populations.
+
+### 4B. AI-native authoring and NPCs (the 2026 hook)
+- **Natural-language scene authoring**: "add a market square with 8 stalls and a
+  fountain" → the engine places entities via the World-from-Data primitives.
+- **LLM-driven NPCs**: replace/augment the FSM with goal-oriented agents that
+  have memory and emit/consume `EventSystem` events; behavior-tree fallback when
+  offline. Use the latest Claude models (e.g. `claude-opus-4-8`) behind a thin,
+  swappable `IBrain` interface so the engine never hard-depends on one provider.
+- **Procedural quests/dialogue** generated from world state.
+
+*Unique because* very few open C++ engines ship an AI-native authoring + NPC
+layer, and IKore already has the `AIComponent`/`EventSystem`/`NetworkComponent`
+scaffolding to host it.
+
+### 4C. Deterministic replay & rollback netcode
+Extend `NetworkComponent` toward **deterministic lockstep + rollback**
+(GGPO-style). Pairs naturally with 4A's deterministic core and gives credible
+multiplayer *and* reproducible simulations.
+
+*Unique because* rollback netcode is rare in indie/hobby engines and is a strong
+draw for both competitive games and distributed simulation.
+
+---
+
+## 5. Tier 3 — Foundations that unlock the above
+
+These are not unique on their own, but the flagship cannot ship without them.
+
+### 5.1 Data-oriented (archetype) ECS  *(highest-leverage foundation)*
+The current ECS stores each component behind a `shared_ptr` on the entity —
+pointer-chasing, cache-unfriendly, and a hard ceiling on agent counts. Move to an
+**archetype/SoA storage** with system queries iterating contiguous arrays.
+The existing `ECSBenchmark` can prove the before/after numbers. This single change
+is what makes "thousands of agents" (4A) and large imported cities (Tier 1)
+viable.
+
+### 5.2 Scripting + hot reload
+Embed **Lua** (or AngelScript) and expose components/events. Add **hot reload**
+of scripts, shaders, and assets. This turns IKore from "recompile to change
+anything" into a live creator loop, and lets non-C++ users drive the
+World-from-Data pipeline.
+
+### 5.3 In-engine editor (closes the open backlog)
+Integrate **Dear ImGui** and knock out the entire stalled Milestone 7 in one
+coherent push:
+- FPS / perf overlay (#53), debug console with commands (#54), entity inspector
+  with live edit (#56), scene hierarchy viewer (#59), input remapping (#60),
+  HUD/menus (#55, #58), benchmarking UI (#62).
+An editor is table-stakes for anyone to *use* the world-building pipeline.
+
+### 5.4 Rendering modernization *(optional, "catch-up" not "unique")*
+PBR materials + IBL, a clustered/deferred path, and basic GI. Worthwhile for
+visual credibility of imported worlds, but it does not differentiate on its own —
+prioritize it below Tiers 1–2.
+
+---
+
+## 6. Concrete first step: an 8-week "vertical slice" that proves the identity
+
+Ship one end-to-end demo that no generic engine ships out of the box:
+
+> **"Import a real neighborhood from OpenStreetMap, walk through it, and watch
+> 500 autonomous pedestrians navigate it — then rewind time."**
+
+| Weeks | Deliverable |
+|---|---|
+| 1–2 | Archetype ECS conversion of the hot path (§5.1); validate with `ECSBenchmark` |
+| 2–3 | Tilemap **or** SVG importer → scene graph entities (§3, smallest viable) |
+| 4–5 | GeoJSON/OSM building+road import; nav-mesh bake (§3) |
+| 5–6 | Deterministic fixed-step + 500 crowd agents on the nav-mesh (§4A) |
+| 6–7 | ImGui overlay: FPS, entity inspector, **rewind/replay** scrubber (§5.3, §4A) |
+| 7–8 | Polish, record a demo GIF, write a tutorial in the README |
+
+That single demo is the elevator pitch the project currently lacks.
+
+---
+
+## 7. Quick wins (do these regardless of direction)
+
+These are low-effort, high-signal improvements that make the repo credible enough
+for any of the above to attract contributors:
+
+1. **Repo hygiene.** The root holds ~30 one-off `fix_*.sh`, `test_*.sh`, and
+   `*_IMPLEMENTATION.md` files plus committed build dirs (`build_ci/`,
+   `build_test/`) and binaries (`test_ai_component`, `test_openal_3d_audio_fallback`).
+   Move docs to `docs/`, tests to `tests/`, delete committed build artifacts, and
+   add them to `.gitignore`. This alone makes the project look maintained.
+2. **One real README.** Replace the build-only README with: what the engine is,
+   the thesis (§2), a screenshot/GIF, and a feature matrix of what truly works.
+3. **Reconcile the issue tracker with reality.** Re-open (or honestly close with a
+   note) the terrain/water/weather/map issues whose code is not in the tree, so
+   the backlog reflects the actual state.
+4. **A `samples/` folder** with 2–3 runnable scenes, so a newcomer sees results in
+   one command.
+5. **FPS + entity-count overlay (#53, ImGui).** Smallest possible step toward the
+   editor, and instantly useful.
+
+---
+
+## 8. Summary — pick a lane
+
+If IKore tries to be a better general-purpose engine, it loses. If it becomes
+**the engine that turns real-world and 2D data into living, rewindable, AI-driven
+3D simulations**, it occupies a niche the big engines ignore — and it does so by
+*finishing the vision it already started* and *building on the systems it already
+has*.
+
+**Recommended order:** §5.1 archetype ECS → §3 one importer → §4A crowd + time
+control → §5.3 ImGui editor → then §4B AI-native layer and §4C netcode as the
+project matures. Start with the §6 vertical slice.

--- a/PHONE_GAME_CONCEPT.md
+++ b/PHONE_GAME_CONCEPT.md
@@ -1,0 +1,204 @@
+# Concept: "Doodle Dungeon" — turn hand-drawn floor plans into playable game maps
+
+> A consumer mobile game built on IKore's **world-from-data** thesis
+> (see `EXPANSION_IDEAS.md`). The player draws a floor plan on paper, snaps a
+> photo, and seconds later is walking and playing inside their own drawing in 3D.
+> The drawing is not just geometry — drawn symbols are a tiny visual language that
+> places doors, enemies, loot, and the exit.
+
+*(Working title only — other names: PaperWorlds, Sketch2World, Crayon Castle.)*
+
+---
+
+## 1. The magic moment
+
+> "I scribbled a maze on a napkin, took a picture, and ten seconds later my kid
+> was running through it being chased by slimes."
+
+Everything in this concept serves that one 10-second loop:
+
+**Draw → Snap → Play → Share.**
+
+The shareable artifact is unbeatable for social reach: a side-by-side of the
+**paper drawing** and the **3D level it became** is exactly the kind of clip that
+travels on TikTok/Instagram/YouTube Shorts. The product markets itself.
+
+---
+
+## 2. Why this is genuinely unique
+
+- "Mario Maker for the real world" — user-generated levels, but the authoring tool
+  is a **pencil and paper**, which everyone already has and enjoys.
+- Almost no competitor does **photo-of-a-drawing → 3D playable game**. (There are
+  coloring-page AR apps and floor-plan *measurement* apps, but not a *game* loop.)
+- Strong family / education angle: it rewards creativity and is safe, screen-light
+  authoring (you draw on paper, not on a screen).
+- It is the consumer face of a serious technology (the world-from-data pipeline),
+  so the same core powers both a fun game and, later, "pro" use cases
+  (architecture, sim, education).
+
+---
+
+## 3. The drawing *is* a language (the clever part)
+
+The level is more than walls. A small set of easy-to-draw symbols becomes gameplay,
+so a child can author a full level with a pencil:
+
+| You draw… | It becomes… |
+|---|---|
+| Connected lines / closed shapes | Walls and rooms (extruded to 3D) |
+| A gap in a wall | A doorway / passage |
+| `S` (or a star) | Player start |
+| `X` (or a flag) | Exit / goal |
+| A small circle | Coin / collectible |
+| A spiky blob | Enemy spawn |
+| A wavy/zigzag line | Trap / hazard (lava, spikes) |
+| `+` | Health / pickup |
+| A square with a slash | Locked door (needs a key) |
+
+This "symbol = object" mapping is the design heart: it keeps authoring effortless
+*and* gives the game depth. The symbol set should start tiny (start, exit, enemy,
+coin) and grow with the game's progression.
+
+---
+
+## 4. What you actually *do* — game loop
+
+A map is not a game, so pick a core verb. Recommended first mode, in priority order:
+
+1. **Top-down dungeon crawler** (twin-stick): explore your floor plan, grab coins,
+   dodge/fight enemies, reach the exit. Easiest to make fun, reads well at any
+   drawing quality, classic and broadly appealing. **← start here.**
+2. **First/third-person explorer**: "walk inside your drawing." Highest wow-factor
+   for the share clip; great as a secondary "tour" mode.
+3. **Stealth / hide-and-seek vs. AI agents**: leans on IKore's `AIComponent` +
+   crowd simulation.
+4. **Tower defense**: enemies path through your rooms — leans on the nav-mesh.
+5. **Async multiplayer**: publish your map, friends play it with a share code;
+   leaderboards for fastest clear. Leans on `NetworkComponent`. This is the
+   long-term retention engine (endless UGC).
+
+---
+
+## 5. The hard core: hand-drawing → playable map (the moat)
+
+This computer-vision pipeline is the make-or-break and the defensible IP. Stages:
+
+1. **Capture & rectify.** Detect the paper quad in the camera frame; perspective-
+   warp to a clean top-down image (homography). Auto-crop, white-balance.
+2. **Binarize & clean.** Grayscale → adaptive threshold → denoise → deskew so a
+   phone photo under any lighting becomes crisp black-on-white.
+3. **Vectorize walls.** Detect line segments (e.g. Hough transform) and/or trace
+   contours; merge collinear segments; **snap to grid and to 0/45/90° angles** so
+   wobbly hand lines become clean architecture. Simplify with Douglas–Peucker.
+4. **Build topology.** Close polygons into rooms; treat wall gaps as doorways;
+   build a room-connectivity graph. Reject/repair unclosed or ambiguous regions.
+5. **Recognize symbols.** Classify the drawn icons (start/exit/enemy/coin/…). Start
+   with simple shape heuristics + template matching; graduate to a small on-device
+   CNN trained on crowdsourced doodles as data accumulates. **This is where ML and
+   the long-term data moat live** — every level players draw is training data.
+6. **Emit the scene.** Produce IKore's intermediate scene description (see §7),
+   which the engine extrudes to 3D, populates with entities, and bakes a nav-mesh
+   from.
+
+**De-risking order (critical):** do NOT start with messy camera input.
+- **Phase 0:** on-screen finger/stylus drawing → vectors are exact, no CV needed.
+  Proves the *game* loop immediately.
+- **Phase 1:** photo of a **clean, grid-paper, orthogonal** drawing.
+- **Phase 2:** robust to freehand, lighting, angle, and color.
+Each phase is shippable and teaches you what real drawings look like.
+
+---
+
+## 6. The honest tension: IKore is a *desktop* engine
+
+IKore today is **C++ + desktop OpenGL** (GLFW, classic GL — verified: no OpenGL ES,
+no EGL, no Android/iOS, no touch input, no OpenCV). It cannot ship to phones as-is.
+There are three viable paths; the recommendation combines them:
+
+| Path | What it means | Verdict |
+|---|---|---|
+| **A. Port IKore to mobile** | Add an OpenGL ES 3.0 / Vulkan backend, touch input, Android (NDK) + iOS build | Real work; do it *after* the loop is proven |
+| **B. Extract the converter as a portable C++ library** | The IP is the *drawing→scene* pipeline, not the renderer. Ship it as a standalone lib usable from any mobile app/engine | **Smartest hedge** — value isn't locked to the renderer |
+| **C. Prototype on desktop first** | Mouse-draw or load-photo → extrude → play, all in the engine you already have | **Start here** — proves the magic in days, not months |
+
+**Recommendation:** **C → B → A.** Prove the loop on desktop with what already
+exists; factor the drawing→scene converter into a clean library; only then invest
+in the mobile renderer port (or pair the library with a mobile-native/Flutter/
+Unity shell if that ships faster).
+
+This keeps the bet cheap until the fun is proven, and ensures the core IP is
+reusable no matter which renderer wins.
+
+---
+
+## 7. How it maps onto code that already exists
+
+The desktop proof-of-concept (Phase 0) needs almost no new engine systems:
+
+- **Intermediate scene format** → reuse `SerializationData` / `JsonFormat`
+  (`src/Serialization.h`). The converter outputs JSON; the engine loads it.
+- **Walls/floors** → `MeshComponent::createCube` / `createPlane`
+  (`src/core/components/MeshComponent.h`) extruded along wall polylines.
+- **Scene assembly** → the existing scene graph (`SceneGraphSystem`) +
+  entity/component system.
+- **Collision & movement** → `PhysicsComponent` (Bullet) for walls + a player body.
+- **Enemies** → `AIComponent` (patrol/chase already implemented).
+- **Sound/feel** → OpenAL `SoundComponent`; particles for coins/hits.
+- **Share/multiplayer (later)** → `NetworkComponent`.
+
+The *new* code is the **drawing→scene converter** (§5) — which is also the
+flagship importer from `EXPANSION_IDEAS.md`. The game and the engine roadmap are
+the same project.
+
+---
+
+## 8. MVP — the smallest thing that proves the magic
+
+**Desktop "Doodle Dungeon" PoC (Phase 0), buildable on current IKore:**
+
+1. A simple draw surface (mouse) on a grid: draw wall segments + place 4 symbols
+   (start, exit, coin, enemy). *(Or: hand-author a small JSON level to start even faster.)*
+2. Converter: wall segments → wall polygons → 3D geometry; symbols → entity spawns;
+   write the JSON scene.
+3. Load the scene; spawn a player with collision; top-down camera.
+4. Core loop: move, collect coins, avoid one `AIComponent` enemy, reach the exit → "You win."
+5. A "tour mode" first-person camera for the wow-shot.
+
+If that loop is fun with a *mouse-drawn* box-and-line map, the camera/CV and mobile
+work are justified. If it isn't, you've spent days, not months.
+
+---
+
+## 9. Phased roadmap
+
+| Phase | Scope | Outcome |
+|---|---|---|
+| **0. Desktop loop** | On-screen/JSON drawing → 3D → playable (MVP §8) | Proves the fun, reuses existing engine |
+| **1. Clean-photo CV** | Photo of grid/orthogonal drawing → vectors (§5 steps 1–4) | Proves "paper → game" with constrained input |
+| **2. Converter library** | Extract drawing→scene as portable C++ lib (Path B) | Reusable IP, testable in isolation |
+| **3. Mobile shell** | OpenGL ES backend + touch, or mobile-native shell around the lib | Runs on a phone |
+| **4. Symbol ML + robustness** | On-device symbol CNN; freehand/lighting robustness (§5 step 5) | Handles real kids' drawings |
+| **5. UGC & social** | Share codes, level browser, leaderboards (`NetworkComponent`) | Retention + viral loop |
+
+---
+
+## 10. Top risks
+
+1. **CV robustness on real drawings** — biggest risk. Mitigate with the
+   Phase 0→2 ramp and grid-paper guidance; collect drawings as training data.
+2. **Mobile port cost** — mitigate with Path B/C (don't port until proven).
+3. **"Map ≠ game"** — mitigate by nailing one fun verb (top-down crawler) before
+   adding modes.
+4. **Scope creep** — the symbol set and game modes can balloon; ship the 4-symbol,
+   one-mode MVP first.
+
+---
+
+## 11. Bottom line
+
+The phone-game framing is the perfect consumer expression of the world-from-data
+thesis: it makes the technology *delightful and shareable*, and the make-or-break
+core (drawing → 3D scene) is **the same importer the engine needs anyway**. Start
+with the desktop PoC (§8) on the engine that already exists, keep the converter
+renderer-agnostic, and only pay for mobile once the magic is proven.

--- a/PHONE_GAME_DESIGN.md
+++ b/PHONE_GAME_DESIGN.md
@@ -1,0 +1,313 @@
+# Doodle Dungeon — Deep Design & Market Analysis
+
+> Companion to `PHONE_GAME_CONCEPT.md`. This document does the homework before any
+> code: it researches the competition, sharpens the wedge, specifies the full
+> drawing-symbol language, lays out a concrete game-design spec, and picks a
+> monetization model — all grounded in current market data (sources at the end).
+
+---
+
+## 1. The sharpened wedge (read this first)
+
+The original pitch — "draw on paper, snap a photo, play your drawing" — is **not
+novel**. At least three shipping products already do exactly that loop. **But every
+one of them produces a 2D game** (platformer / arcade / physics). Separately, "turn
+a floor plan into 3D" is a *solved* problem — but only in architecture/real-estate
+tools that produce **static visualizations, not games**.
+
+> **The white space nobody occupies: a hand-drawn *floor plan* → a *3D place you
+> explore and play in*.** That intersection is precisely what a 3D engine like
+> IKore is built for, and it is invisible to both the 2D "draw-a-game" apps and the
+> non-game floor-plan tools.
+
+Reframe the product accordingly: **you are not drawing a *game*, you are drawing a
+*place*** — a dungeon, a house, a spaceship — and then living inside it in 3D.
+That single word ("place," not "game") is the whole differentiation.
+
+A lucky bonus: **floor plans literally *are* dungeon maps.** "Rooms connected by
+corridors" is the native grammar of the entire dungeon-crawler genre, so the
+spatial structure of a floor plan maps onto a fun game with almost no translation.
+
+---
+
+## 2. Market & competitor research
+
+### 2.1 Category A — "draw your own game" apps (direct loop, but 2D)
+
+| Product | What it does | Model | Limit / opening |
+|---|---|---|---|
+| **Pixicade** (Abacus Brands) | Draw on paper → photo → 2D game. Templates: platformer, **maze**, slingshot, brick-breaker, 2-player. Sold as a physical marker **kit** for kids 6–12; award-winning (Newsweek STEM, Mom's Choice) | Physical kit + app, IAP ("snowflakes") | **2D only**; template-bound; some reviews cite confusing premium currency |
+| **Draw Your Game Infinite** (Korrisoft) | Draw on paper → photo → 2D physics platformer. **Color = behavior**: black static, red danger, green bouncy, blue movable | Free-to-play + IAP | **2D only**; fixed physics-platformer genre |
+| **DoodleMatic** | Draw → photo → playable 2D game; community sharing | App | **2D only** |
+
+**Key takeaways:**
+- The "snap a drawing and play it" loop is validated and *liked* — but it has
+  calcified around **2D arcade/physics**.
+- **Color-coding beats shape recognition.** Draw Your Game's 4-color language is a
+  deliberate CV-robustness choice — segmenting by color is far more reliable on
+  messy drawings than classifying hand-drawn shapes. **We should adopt this.**
+- **The physical kit (Pixicade) is both a revenue channel and a CV hack** —
+  controlled marker colors and paper make recognition dramatically easier.
+
+### 2.2 Category B — floor plan → 3D (solved, but not games)
+
+Polycam (LiDAR room scan), magicplan (AR corner detection), Planner 5D (AI room
+scan), floor-plan.ai and Coohom (**upload a photo of a hand-drawn sketch → 3D via
+auto-wall-detection**). These prove the conversion is **feasible today** and give
+us prior art to learn from — but they output **furniture-planning visualizations**,
+not anything playable (no goals, enemies, movement, scoring, or sharing).
+
+### 2.3 Category C — sketch → 3D *asset* AI (adjacent)
+
+Meshy, Sloyd.ai ("drawing to dungeon"), Alpha3D, Adobe **Aqua** (kid-friendly 2D→3D
+with AR). These make 3D **objects/models**, not navigable **spaces**. Useful later
+as a way to turn doodled *props* into meshes; not a competitor to the core loop.
+
+### 2.4 Market validation for the model
+
+- **UGC + sharing is a proven engine.** Super Mario Maker had **7M+ user courses
+  played 600M+ times by 2016**, with a simple "stars" approval mechanic driving
+  organic, word-of-mouth marketing. Our share-a-map loop targets the same dynamic.
+- **Kids creative-STEM has real commercial pull** — Pixicade's awards and retail
+  presence show parents pay for "creativity → play" products.
+
+### 2.5 The competitive map (where we sit)
+
+```
+            2D / arcade            3D / spatial
+          ┌──────────────────┬──────────────────────┐
+ GAME     │ Pixicade,        │   ★ DOODLE DUNGEON ★  │  ← empty quadrant
+ (play)   │ Draw Your Game,  │   (our wedge)         │
+          │ DoodleMatic      │                       │
+          ├──────────────────┼──────────────────────┤
+ NOT a    │ (n/a)            │ Polycam, magicplan,   │
+ game     │                  │ floor-plan.ai, Coohom │
+          └──────────────────┴──────────────────────┘
+```
+
+**Primary threat:** an incumbent (esp. Pixicade, which already has a "Maze Maker")
+adds a 3D mode. **Our moat against that:** a 3D engine purpose-built for
+world-from-data, a floor-plan-native symbol language, and a UGC community — i.e.
+depth they'd have to rebuild. Speed and focus matter.
+
+---
+
+## 3. Positioning & audience
+
+Two viable audiences; they imply different art, tone, and **monetization**:
+
+| | **Kids 6–12 (creative/STEM)** | **Teens/Adults (UGC dungeon-makers)** |
+|---|---|---|
+| Hook | "Your drawing comes to life in 3D" | "Sketch a dungeon, share it, top the leaderboard" |
+| Tone/art | Bright, friendly, safe | Stylized dungeon/roguelite |
+| Distribution | Apple **Kids Category**, retail kit | Standard F2P, social/UGC virality |
+| Monetization | **Premium / kit / parent-gated** (ads largely banned — see §6) | **Hybrid F2P** (ads + IAP) viable |
+| Compliance | Heavy (COPPA/GDPR-K) | Standard |
+
+**Recommendation:** launch for **teens/adults first** (the "dungeon-maker" framing).
+Reasons: monetization is far less constrained (§6), UGC virality is stronger in that
+demographic, and the dungeon aesthetic makes "floor plan = level" feel intentional
+rather than mundane. Add a **Kids Mode + physical kit** as a second act once the
+core loop and CV are proven — that's where Pixicade's playbook (and revenue) lives,
+but it carries the compliance burden.
+
+---
+
+## 4. The symbol language (full specification)
+
+### 4.1 Design principles
+1. **A child can draw every symbol** with a single pen, first try.
+2. **Robust to CV before clever.** Prefer features that survive a blurry photo.
+3. **Unambiguous.** No two symbols collide after line-simplification.
+4. **Progressive.** Start with ~5 symbols; unlock more as the player levels up — this
+   doubles as onboarding (you can't be overwhelmed by a vocabulary you haven't
+   unlocked yet).
+
+### 4.2 The hybrid scheme: **color = class, shape = subtype**
+Adopt Draw Your Game's color insight, but extend it for 3D. **Color carries the
+robust, must-not-fail signal** (is this a wall? an enemy? loot?); **shape refines it**
+when recognition is confident, and degrades gracefully to a sensible default when
+it isn't.
+
+| Color | Class | Why |
+|---|---|---|
+| **Black** | Structure (walls, doors) | The bulk of every drawing; highest-contrast |
+| **Red** | Threats (enemies, hazards) | Universally reads as "danger" |
+| **Green** | Goals & collectibles | Reads as "good/go" |
+| **Blue** | Interactive (doors that open, switches, keys, water) | Distinct, cool-toned |
+| **(pencil/uncolored)** | Auto-detected walls | Lets pure-pencil drawings still work |
+
+### 4.3 The vocabulary
+
+**Tier 1 — taught in the first 60 seconds (everyone starts here):**
+
+| Draw | Color | Becomes |
+|---|---|---|
+| Lines / closed shapes | Black | Walls + rooms (extruded to 3D) |
+| Gap in a wall | — | Doorway / passage |
+| `S` or a star | Green | Player start |
+| `X` or a flag | Green | Exit / goal |
+| Small filled dot | Green | Coin / collectible |
+| Spiky blob | Red | Basic enemy spawn |
+
+**Tier 2 — unlocked by playing:**
+
+| Draw | Color | Becomes |
+|---|---|---|
+| Wavy / zigzag fill | Red | Hazard floor (lava, spikes) |
+| Double line / "=" across a gap | Blue | Door that opens (with a key) |
+| Small key shape | Blue | Key (opens matching door) |
+| Triangle cluster | Red | Ranged/turret enemy |
+| `+` | Green | Health pickup |
+| Spiral | Blue | Teleporter (pairs nearest two) |
+
+**Tier 3 — advanced authoring:**
+
+| Draw | Color | Becomes |
+|---|---|---|
+| Number `1`–`3` in a room | Black | **Floor height / elevation** (verticality — multi-storey!) |
+| Hatched region | Black | Stairs/ramp between heights |
+| Circle with a face | Blue | NPC (gives a line of text / quest) |
+| Box outline | Blue | Pushable crate (physics) |
+| `~` region | Blue | Water (swim/slow) |
+
+> **Verticality (Tier 3) is a stealth differentiator.** Because IKore is true 3D,
+> writing a small "2" in a room can raise it a storey — something *no* 2D
+> competitor can express. A flat floor plan becomes a multi-level space.
+
+### 4.4 Drawing rules & CV-robustness aids
+- **Guide paper.** Offer a free printable (and the §6 physical kit) with a faint grid
+  and a color legend — massively improves recognition, like Pixicade's kit.
+- **Snap-to-grid + angle-snapping** turns wobbly lines into clean architecture.
+- **Confidence + repair UI.** If a symbol is ambiguous, the app shows its
+  interpretation as editable icons *before* play ("we found 3 enemies and 2 coins —
+  tap to fix"). Never fail silently; turn correction into part of the fun.
+- **Graceful defaults.** Unknown red mark → basic enemy; unknown green → coin;
+  unclosed black region → best-effort wall with a highlighted warning.
+
+---
+
+## 5. Game-design spec
+
+### 5.1 Core fantasy
+> "I designed this place, and now I'm *inside* it — and so is everyone I share it with."
+
+### 5.2 Core loops
+- **Micro (seconds–minutes):** Draw → scan → **review/fix symbols** → play → tweak the
+  paper → re-scan. Fast iteration is the addiction.
+- **Macro (sessions):** Play → earn XP → **unlock new symbols/themes/characters** →
+  author more ambitious maps → **publish & get stars** → climb leaderboards.
+
+### 5.3 Primary mode: 3D dungeon crawl (ship this first)
+- **Camera:** over-the-shoulder / adjustable top-down-3D. Reads clearly regardless of
+  drawing quality and shows off the 3D wow without demanding twitch precision.
+- **Verbs:** move, dodge, attack/interact, collect, reach the exit.
+- **Why first:** easiest to make *fun* on an arbitrary floor plan; "rooms + corridors
+  + enemies + loot + exit" is a complete game with the Tier-1 vocabulary alone.
+
+### 5.4 Secondary modes (post-launch, same maps)
+First-person **Tour mode** (the money shot for share clips) · **Stealth/escape** vs.
+`AIComponent` agents · **Tower defense** (enemies path your corridors) · **Race/
+time-attack** (leaderboard fuel) · **Co-op/async multiplayer** via share codes.
+
+### 5.5 Difficulty — *derived from the drawing*
+No difficulty slider; the map *is* the difficulty. Derive a star rating from
+enemy density, path length, hazard coverage, and key/lock depth, and surface it so
+authors can self-balance ("this map is rated ★★★★☆ Brutal").
+
+### 5.6 Meta-progression & retention
+- **XP & symbol unlocks** (Tier 1→3) give a reason to keep playing and authoring.
+- **Themes/skins** (Dungeon, Haunted House, Spaceship, Neon City) reskin the *same*
+  geometry — cheap content, strong personalization, natural IAP.
+- **UGC + "stars"** (proven by Mario Maker): publish maps, browse by Hot/New/Top, award
+  stars, follow creators.
+- **Weekly drawing prompts/challenges** ("draw a castle") → curated feed → fresh
+  content engine without us building levels.
+- **Share code + side-by-side clip** (paper ↔ 3D) as the built-in virality hook.
+
+### 5.7 Onboarding
+First run ships a **pre-printed trace sheet**: the player traces a tiny 3-room map,
+scans it, and is playing in <90 seconds — guaranteeing the magic moment lands before
+they face a blank page.
+
+### 5.8 The biggest design risk (state it plainly)
+**A real floor plan is not automatically a fun level.** Mitigations: (a) the symbol
+language injects game content (enemies/loot/goals/keys) onto any space; (b) the
+converter *embellishes* — themed lighting, props, verticality; (c) the **dungeon
+framing** makes rooms-and-corridors a feature, not a bug; (d) the difficulty
+rating + fix-up UI nudge authors toward playable layouts. **This must be validated
+in the desktop PoC before any mobile spend.**
+
+---
+
+## 6. Monetization
+
+### 6.1 Benchmarks (2025–2026)
+- **Hybrid-casual ARPDAU ≈ $0.15–0.50**, *4–7× higher than hypercasual* ($0.03–0.08);
+  casual target ≈ $0.80; Party/Match genres reach the highest ARPU ($4.90 / $2.99).
+- **Rewarded video = ~62% of mobile-game ad revenue**, with 2–3× the engagement of
+  interstitials — the *only* ad format players tolerate.
+- Hybrid-casual typically runs a **~45/55 IAP/ads split**; hybrid IAP grew ~100% YoY
+  (>$345M H1 2025).
+
+### 6.2 The kids constraint changes everything
+If we target the **Kids** audience/category, **ads are effectively off the table**:
+Apple's Kids Category forbids third-party ad SDKs and analytics and requires parental
+gates; the 2025 COPPA rule (in force April 22, 2026) makes biometric data PII and
+demands separate consent to share kids' data with advertisers; **AppLovin stopped
+serving ads to COPPA users in Jan 2025**. Best practice for kids' apps is to **avoid
+in-game ads entirely** and monetize via premium/subscription/parent-gated IAP.
+
+### 6.3 Recommended model — by audience
+
+**Teens/adults (primary launch):** **hybrid free-to-play.**
+- **Rewarded video only** (never forced interstitials mid-creation): optional "watch
+  to unlock a theme for a day," "revive," "extra map slot."
+- **IAP, cosmetic & convenience — never pay-to-win:** theme/skin packs, character
+  skins, symbol-style packs, extra cloud map slots, "remove ads."
+- **Optional subscription** ("Architect's Pass"): all themes, unlimited cloud maps,
+  early symbols, creator analytics.
+
+**Kids (second act):** **premium + physical kit, no ads.**
+- Paid app or a parent-gated one-time unlock; **Pixicade-style physical marker kit**
+  as the hero retail SKU (doubles as the CV-robustness aid from §4.4); optional
+  family subscription for cloud storage. All purchases behind a parental gate.
+
+### 6.4 Guardrails (non-negotiable)
+No pay-to-win, no manipulative currencies, no ads in the kids build, IAP always
+skippable and clearly labeled, COPPA/GDPR-K compliance designed in from day one.
+
+---
+
+## 7. Risks & open questions
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| "Is exploring a floor plan actually fun?" | **High** | Validate in desktop PoC first (§5.8) |
+| CV robustness on real drawings | **High** | Color-coding (§4.2), guide paper/kit, confidence+repair UI, Phase 0→2 ramp |
+| Incumbent (Pixicade) adds 3D | Medium | Move fast; depth via 3D engine + verticality + UGC moat |
+| Mobile port cost (IKore is desktop) | Medium | Prove on desktop; keep converter renderer-agnostic (see concept doc) |
+| Kids-compliance overhead | Medium | Launch adult-first; add kids mode deliberately later |
+
+---
+
+## 8. What this means for the build (unchanged first step)
+
+None of this alters the first technical move from `PHONE_GAME_CONCEPT.md`: build the
+**renderer-agnostic converter core** and prove the loop on desktop. This research
+only *constrains the design* of that core:
+- Input model = **color-class + shape-subtype** (§4.2), not shape-only.
+- Output = a **3D, optionally multi-storey** scene (verticality from Tier-3 symbols).
+- Success metric for the PoC = **"is the resulting 3D space fun to move through?"**
+  (§5.8) — the make-or-break question, answered cheaply before any mobile spend.
+
+---
+
+## 9. Sources
+
+- Draw-a-game apps: [Draw Your Game Infinite (Google Play)](https://play.google.com/store/apps/details?id=com.korrisoft.draw.your.game), [Pixicade (App Store)](https://apps.apple.com/us/app/pixicade-game-creator/id1532289517), [Pixicade (Abacus Brands)](https://www.abacusbrands.com/products/pixicade), [DoodleMatic review](https://btr.michaelkwan.com/2020/12/09/doodlematic-review/), [Pixicade review (GeekDad)](https://geekdad.com/2021/02/games-from-pixicade-are-as-unlimited-as-your-imagination/)
+- Floor plan → 3D (incl. hand-drawn): [floor-plan.ai](https://floor-plan.ai/floor-plan-to-3d), [Coohom](https://www.coohom.com/article/convert-2d-floor-plan-to-3d-model-free-online), [Polycam](https://poly.cam/floor-plans), [magicplan](https://magicplan.app/blog/room-scan-cad), [Planner 5D](https://planner5d.com/ai)
+- Sketch → 3D assets: [Sloyd.ai "drawing to dungeon"](https://www.sloyd.ai/blog/from-drawing-to-dungeon-turn-fantasy-sketches-into-3d-maps), [Meshy sketch-to-3D](https://www.meshy.ai/blog/sketch-to-3d), [Adobe Aqua](https://aqua.adobe.com/learn/3d-drawing-apps)
+- UGC market validation: [Super Mario Maker (Wikipedia)](https://en.wikipedia.org/wiki/Super_Mario_Maker), [Why Mario Maker is the perfect UGC tool (Lurkit)](https://www.lurkit.gg/blog/why-nintendos-mario-maker-is-the-perfect-ugc-marketing-tool)
+- Monetization benchmarks: [Hybrid casual 2026 guide (Game Growth Advisor)](https://gamegrowthadvisor.com/blog/2026-04-16-hybrid-casual-game-design-strategy-2026/), [ARPDAU by genre (Juego)](https://www.juegostudio.com/blog/arpdau-benchmarks-by-game-genre), [Tenjin Ad Monetization 2026](https://tenjin.com/blog/ad-mon-gaming-2026/)
+- Kids monetization & compliance: [Monetization for kids apps & COPPA (Openback)](https://openback.com/blog/monetization-for-kids-apps-how-to-be-profitable-and-coppa-compliant/), [Ad monetization in kids games (GameBiz)](https://www.gamebizconsulting.com/blog/ad-monetization-in-kids-games-and-apps-how-to-do-it-right), [COPPA 2025 guide (Promise Legal)](https://blog.promise.legal/startup-central/coppa-compliance-in-2025-a-practical-guide-for-tech-edtech-and-kids-apps/), [COPPA/GDPR-K for kids' games (Fish in a Bottle)](https://www.fishinabottle.com/blog/what-does-coppa-and-gdpr-k-compliance-mean-for-childrens-games-fish-in-a-bottle)

--- a/README.md
+++ b/README.md
@@ -3,12 +3,71 @@
 [![CI/CD Pipeline](https://github.com/Ikey168/IKore-Engine/actions/workflows/ci.yml/badge.svg)](https://github.com/Ikey168/IKore-Engine/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/Ikey168/IKore-Engine/actions/workflows/analysis.yml/badge.svg)](https://github.com/Ikey168/IKore-Engine/actions/workflows/analysis.yml)
 [![Documentation](https://github.com/Ikey168/IKore-Engine/actions/workflows/docs.yml/badge.svg)](https://github.com/Ikey168/IKore-Engine/actions/workflows/docs.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-IKore Engine is a modern, flexible 3D game engine built with OpenGL and C++.
+**IKore Engine** is a modern 3D game engine written in C++17 and OpenGL, built
+around an Entity-Component System with physics, audio, animation, and a forward
+renderer with shadows and post-processing.
+
+> **Where it's headed.** IKore is evolving from a general-purpose engine toward a
+> focused identity: **building living 3D worlds from real data** — turning
+> floor plans, maps, and sketches into navigable, simulated spaces. See
+> [`EXPANSION_IDEAS.md`](EXPANSION_IDEAS.md) for the thesis and
+> [`PHONE_GAME_CONCEPT.md`](PHONE_GAME_CONCEPT.md) /
+> [`PHONE_GAME_DESIGN.md`](PHONE_GAME_DESIGN.md) for the flagship use case
+> (a phone game that turns hand-drawn floor plans into playable 3D maps).
+
+---
+
+## Features
+
+Everything below is implemented in the source tree today.
+
+### Core architecture
+- **Entity-Component System** with both a `shared_ptr`-based component model and a
+  pooled variant (`EntityPool` / `PooledEntityManager`) for high entity counts.
+- **Scene graph** with parent/child transforms.
+- **Event system** for decoupled entity communication.
+- **JSON serialization** of scenes and components.
+- **Logging** and an **ECS micro-benchmark** harness.
+
+### Components
+`Transform` · `Mesh` (procedural cube/plane/sphere builders) · `Material` ·
+`Renderable` · `Velocity` · `Physics` (Bullet) · `LOD` ·
+`Animation` (skeletal, via Assimp) · `AI` (FSM: patrol / chase / flee / guard /
+wander) · `Sound` / `Audio` (3D positional, OpenAL) · `Particle` · `Network`.
+
+### Rendering
+- Forward renderer (Phong/Blinn lighting).
+- **Shadow mapping** — directional and point (cubemap) shadows.
+- **Frustum culling**.
+- **GPU/compute-shader particle system**.
+- **Post-processing**: bloom, SSAO, FXAA.
+- Skybox.
+
+### Audio
+- 3D positional audio with distance attenuation (OpenAL).
+
+---
+
+## Tech stack
+
+- **Language:** C++17
+- **Graphics:** OpenGL, [GLFW](https://github.com/glfw/glfw),
+  [GLAD](https://github.com/Dav1dde/glad), [GLM](https://github.com/g-truc/glm)
+- **Physics:** [Bullet3](https://github.com/bulletphysics/bullet3)
+- **Audio:** OpenAL
+- **Model/animation loading:** [Assimp](https://github.com/assimp/assimp) (OBJ, FBX)
+- **Image loading:** [stb_image](https://github.com/nothings/stb)
+- **Build:** CMake (dependencies fetched automatically via `FetchContent`)
+
+---
 
 ## Building
 
-IKore Engine uses CMake to manage its dependencies and generate native project files.
+IKore Engine uses CMake. GLFW, GLAD, GLM, stb_image, Assimp, and Bullet are
+downloaded automatically at configure time via `FetchContent`. OpenAL is located
+via your system package manager (`pkg-config`).
 
 ```bash
 # From the repository root
@@ -31,4 +90,59 @@ mkdir build && cd build
 cmake .. -G Xcode
 ```
 
-GLFW, GLAD, GLM and stb_image are downloaded automatically at configure time via FetchContent and should work on Linux, macOS and Windows.
+> **Linux audio prerequisite:** install OpenAL development headers, e.g.
+> `sudo apt-get install libopenal-dev` (Debian/Ubuntu).
+
+---
+
+## Project structure
+
+```
+src/
+  core/                Engine core: ECS, Entity, Transform, EventSystem, Logger
+    components/         Component implementations (Transform, Mesh, Material, …)
+  scene/               Scene graph & scene management
+  audio/               OpenAL 3D audio engine and ambient zones
+  shaders/             GLSL shaders (shadows, bloom, SSAO, FXAA, particles, …)
+  demos/               Standalone demos
+  tests/               Component/system tests
+  main.cpp             Entry point / sample application
+assets/                Models, textures, and other runtime assets
+docs/                  Implementation notes per subsystem
+```
+
+Per-subsystem implementation notes live in the root `*_IMPLEMENTATION.md` files
+and in [`docs/`](docs/).
+
+---
+
+## Roadmap & vision
+
+IKore's near-term direction is to differentiate around **world-from-data**:
+
+1. **Foundations** — a data-oriented (archetype) ECS, scripting + hot reload, and
+   an in-engine editor (ImGui) that closes the open UI/debugging backlog.
+2. **Flagship importer** — turn 2D/vector inputs (SVG floor plans, tilemaps, and
+   later GeoJSON/OpenStreetMap) into 3D scenes with collision and navigation.
+3. **Simulation & AI** — large-scale agent simulation with time control
+   (pause / rewind / replay) and an AI-native authoring/NPC layer.
+
+The full strategy and rationale are in:
+- [`EXPANSION_IDEAS.md`](EXPANSION_IDEAS.md) — the engine's unique-identity thesis.
+- [`PHONE_GAME_CONCEPT.md`](PHONE_GAME_CONCEPT.md) — the consumer flagship concept.
+- [`PHONE_GAME_DESIGN.md`](PHONE_GAME_DESIGN.md) — deep design + market analysis.
+
+---
+
+## Contributing
+
+Issues and pull requests are welcome. Development happens against feature branches;
+CI (build, CodeQL analysis, and docs) runs on every push. Please keep new code
+consistent with the surrounding style and add tests under `src/tests/` where it
+makes sense.
+
+---
+
+## License
+
+Released under the [MIT License](LICENSE). © 2025 Ikey168.


### PR DESCRIPTION
## Summary

This PR adds three comprehensive strategic documents that define IKore's unique identity and flagship use case, plus updates the README to reflect the engine's new direction.

## Changes

### New documents

- **`EXPANSION_IDEAS.md`** — A detailed thesis repositioning IKore from a general-purpose engine toward a focused niche: **"the engine that builds living worlds from real data."** Includes:
  - Honest assessment of what is actually implemented vs. what the issue tracker claims
  - Three pillars of differentiation: world-from-data pipeline, agent simulation at scale with time control, and AI-native authoring
  - Concrete phased roadmap (Tiers 1–3) with effort estimates
  - An 8-week vertical slice (import OSM → walk through a city → watch 500 agents navigate it → rewind time)
  - Quick wins for repo hygiene and credibility

- **`PHONE_GAME_CONCEPT.md`** — A consumer-facing game concept ("Doodle Dungeon") that is the flagship expression of the world-from-data thesis:
  - Draw a floor plan on paper → snap a photo → play inside your drawing in 3D
  - A tiny visual language (symbols for walls, doors, enemies, loot, exits) that makes authoring effortless
  - Phased roadmap from desktop PoC (Phase 0) through mobile (Phase 3) and UGC (Phase 5)
  - Maps directly onto existing IKore systems (scene graph, ECS, physics, AI, serialization)

- **`PHONE_GAME_DESIGN.md`** — Deep design and market analysis:
  - Competitive research across three categories (2D draw-a-game apps, floor-plan-to-3D tools, sketch-to-3D asset AI)
  - Sharpened positioning: the white space is "hand-drawn floor plan → 3D place you explore and play in"
  - Full symbol language specification (Tier 1–3, color-class + shape-subtype hybrid scheme)
  - Game-design spec (core fantasy, loops, primary/secondary modes, difficulty derivation, meta-progression)
  - Monetization model (hybrid F2P for teens/adults; premium + kit for kids; detailed COPPA/GDPR-K compliance notes)
  - Risk matrix and sources

### README updates

- Expanded opening to clarify IKore's evolving identity and link to the three new strategy docs
- Added a "Features" section documenting what is actually implemented (ECS variants, components, rendering, audio)
- Added "Tech stack" section with dependency list
- Expanded "Building" section with audio prerequisites and system requirements
- Added "Project structure" with directory layout and reference to implementation notes
- Added "Roadmap & vision" section that ties back to the three strategy documents
- Added "Contributing" and "License" sections
- Added MIT license badge

## Rationale

IKore has been a general-purpose engine with no clear differentiation. These documents establish:

1. **A coherent thesis** — the engine's unique identity is world-from-data (turning 2D/real-world inputs into navigable 3D spaces), which was in the original roadmap but never built.

2. **A flagship use case** — Doodle Dungeon (hand-drawn floor plans → playable 3D maps) is both a compelling consumer product and a perfect validation of the world-from-data pipeline.

3. **A concrete roadmap** — the 8-week vertical slice in EXPANSION_IDEAS.md and the phased game roadmap in PHONE_GAME_CONCEPT.md give contributors and stakeholders a clear path forward.

4. **Market validation** — PHONE_GAME_DESIGN.md provides competitive research, positioning, and monetization strategy grounded in current market data, reducing execution risk.

The README updates make the project's direction and actual capabilities transparent to newcomers, replacing vague claims with specifics.

## Implementation notes

- All three documents are design/strategy artifacts; no engine code changes.
- The documents are cross-linked and reference existing IKore systems (scene graph, ECS, physics, AI, serialization) to show how the vision builds