### PR TITLE
feat(ecs): archetype/SoA component storage with stable handles (#140)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,7 +386,7 @@ add_executable(test_particle_component
 )
 target_link_libraries(test_particle_component PRIVATE glad glfw glm::glm stb_image OpenGL::GL)
 
-# Archetype ECS test (Milestone 8 / #140) — header-only module, no extra deps
+# Archetype ECS test (Milestone 8 / #140) - header-only module, no extra deps
 add_executable(test_archetype_ecs
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_archetype_ecs.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,11 @@ add_executable(test_particle_component
 )
 target_link_libraries(test_particle_component PRIVATE glad glfw glm::glm stb_image OpenGL::GL)
 
+# Archetype ECS test (Milestone 8 / #140) — header-only module, no extra deps
+add_executable(test_archetype_ecs
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_archetype_ecs.cpp
+)
+
 if(MSVC)
     target_compile_options(IKore PRIVATE /W4)
 else()

--- a/src/core/ecs/Archetype.h
+++ b/src/core/ecs/Archetype.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "core/ecs/Component.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <new>
+#include <vector>
+
+/**
+ * @file Archetype.h
+ * @brief Contiguous (SoA) component storage grouped by component signature.
+ *
+ * Part of Milestone 8 (issue #140). All entities that share the exact same set
+ * of component types live in one Archetype. Within an archetype each component
+ * type gets its own contiguous Column, and a parallel @c entities array records
+ * which entity owns each row. This is the structure-of-arrays layout that makes
+ * iteration cache-friendly.
+ *
+ * Rows are kept densely packed: removing a row swaps the last row into the gap
+ * (swap-remove), so columns never develop holes.
+ */
+namespace IKore {
+namespace ecs {
+
+/**
+ * @brief A type-erased, growable, contiguous array of one component type.
+ *
+ * Owns an aligned byte buffer and the live elements within it. Move-only; copy
+ * is disabled because the type-erased payload cannot be safely copied here.
+ */
+class Column {
+public:
+    Column() = default;
+    explicit Column(const ComponentInfo* info) : m_info(info) {}
+
+    Column(const Column&) = delete;
+    Column& operator=(const Column&) = delete;
+
+    Column(Column&& other) noexcept { swap(other); }
+    Column& operator=(Column&& other) noexcept {
+        if (this != &other) {
+            destroyAll();
+            release();
+            swap(other);
+        }
+        return *this;
+    }
+
+    ~Column() {
+        destroyAll();
+        release();
+    }
+
+    std::size_t size() const { return m_count; }
+    const ComponentInfo* info() const { return m_info; }
+
+    /// Pointer to the element at @p row (no bounds checking).
+    void* at(std::size_t row) const { return m_data + row * m_info->size; }
+
+    /**
+     * @brief Move-construct a new element at the end from @p src.
+     * @return the row index of the appended element.
+     *
+     * @p src is left in a moved-from state; the caller still owns and must
+     * destroy it (directly or via its own column's removal).
+     */
+    std::size_t pushMove(void* src) {
+        reserve(m_count + 1);
+        m_info->moveConstruct(at(m_count), src);
+        return m_count++;
+    }
+
+    /// Swap-remove the element at @p row, keeping the column densely packed.
+    void removeSwap(std::size_t row) {
+        const std::size_t last = m_count - 1;
+        m_info->destroy(at(row));
+        if (row != last) {
+            m_info->moveConstruct(at(row), at(last));
+            m_info->destroy(at(last));
+        }
+        --m_count;
+    }
+
+private:
+    void swap(Column& o) noexcept {
+        std::swap(m_info, o.m_info);
+        std::swap(m_data, o.m_data);
+        std::swap(m_count, o.m_count);
+        std::swap(m_capacity, o.m_capacity);
+    }
+
+    void reserve(std::size_t needed) {
+        if (needed <= m_capacity) return;
+        std::size_t cap = m_capacity ? m_capacity * 2 : 4;
+        if (cap < needed) cap = needed;
+        auto* nd = static_cast<std::byte*>(
+            ::operator new(cap * m_info->size, std::align_val_t(m_info->align)));
+        for (std::size_t i = 0; i < m_count; ++i) {
+            m_info->moveConstruct(nd + i * m_info->size, at(i));
+            m_info->destroy(at(i));
+        }
+        release();
+        m_data = nd;
+        m_capacity = cap;
+    }
+
+    void destroyAll() {
+        if (!m_info || !m_data) return;
+        for (std::size_t i = 0; i < m_count; ++i) m_info->destroy(at(i));
+        m_count = 0;
+    }
+
+    void release() {
+        if (m_data) {
+            ::operator delete(m_data, std::align_val_t(m_info->align));
+            m_data = nullptr;
+            m_capacity = 0;
+        }
+    }
+
+    const ComponentInfo* m_info{nullptr};
+    std::byte* m_data{nullptr};
+    std::size_t m_count{0};
+    std::size_t m_capacity{0};
+};
+
+/**
+ * @brief A group of entities sharing the same (sorted) component signature.
+ *
+ * Archetype instances are owned by the Registry via unique_ptr so their address
+ * is stable; the Registry stores a raw Archetype* per entity record.
+ */
+struct Archetype {
+    std::vector<ComponentId> signature;   ///< Sorted component ids (unique key).
+    std::vector<Column> columns;          ///< One column per signature entry.
+    std::vector<std::uint32_t> entities;  ///< Entity slot index per row.
+
+    /// Index of the column for @p id, or -1 if this archetype lacks it.
+    int columnIndex(ComponentId id) const {
+        for (std::size_t i = 0; i < signature.size(); ++i) {
+            if (signature[i] == id) return static_cast<int>(i);
+        }
+        return -1;
+    }
+
+    bool has(ComponentId id) const { return columnIndex(id) >= 0; }
+    std::size_t rows() const { return entities.size(); }
+
+    /**
+     * @brief Swap-remove @p row across all columns and the entity array.
+     * @return the entity slot index relocated into @p row, or Entity::kInvalidIndex
+     *         if @p row was the last row (nothing relocated).
+     *
+     * The caller is responsible for fixing up the relocated entity's record.
+     */
+    std::uint32_t removeRow(std::size_t row) {
+        const std::size_t last = entities.size() - 1;
+        for (auto& column : columns) column.removeSwap(row);
+        std::uint32_t relocated = 0xFFFFFFFFu;
+        if (row != last) {
+            entities[row] = entities[last];
+            relocated = entities[row];
+        }
+        entities.pop_back();
+        return relocated;
+    }
+};
+
+} // namespace ecs
+} // namespace IKore

--- a/src/core/ecs/Component.h
+++ b/src/core/ecs/Component.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+/**
+ * @file Component.h
+ * @brief Type-erased component metadata for the data-oriented ECS.
+ *
+ * Part of Milestone 8 (issue #140). Components in this ECS are plain value types
+ * stored in contiguous, type-erased columns (see Archetype.h). To manage those
+ * columns generically we need, per component type: its size and alignment, and
+ * a way to move-construct and destroy instances. Those are captured once per
+ * type in a ComponentInfo and addressed by a small integer ComponentId.
+ */
+namespace IKore {
+namespace ecs {
+
+/// Dense integer id assigned to each component type the first time it is used.
+using ComponentId = std::uint32_t;
+
+/// Sentinel meaning "no component".
+inline constexpr ComponentId kInvalidComponent = 0xFFFFFFFFu;
+
+/**
+ * @brief Type-erased operations + layout for a single component type.
+ *
+ * Only move-construction and destruction are needed: columns relocate elements
+ * by moving them (never memcpy, so non-trivial components are safe) and destroy
+ * them in place. Components must therefore be move-constructible.
+ */
+struct ComponentInfo {
+    std::size_t size{0};
+    std::size_t align{0};
+    /// Move-construct a new element at @p dst from @p src (src is left moved-from).
+    void (*moveConstruct)(void* dst, void* src){nullptr};
+    /// Run the destructor of the element at @p p.
+    void (*destroy)(void* p){nullptr};
+};
+
+/// The ComponentInfo for type @c T (one shared instance per type).
+template <class T>
+const ComponentInfo& componentInfo() {
+    static const ComponentInfo info{
+        sizeof(T),
+        alignof(T),
+        [](void* dst, void* src) { ::new (dst) T(std::move(*static_cast<T*>(src))); },
+        [](void* p) { static_cast<T*>(p)->~T(); }};
+    return info;
+}
+
+/// Global table mapping ComponentId -> ComponentInfo*, populated on first use.
+inline std::vector<const ComponentInfo*>& componentRegistry() {
+    static std::vector<const ComponentInfo*> registry;
+    return registry;
+}
+
+/// Stable, process-wide id for component type @c T (assigned lazily, once).
+template <class T>
+ComponentId componentId() {
+    static const ComponentId id = [] {
+        const ComponentId newId = static_cast<ComponentId>(componentRegistry().size());
+        componentRegistry().push_back(&componentInfo<T>());
+        return newId;
+    }();
+    return id;
+}
+
+/// Look up the ComponentInfo for a previously-assigned id.
+inline const ComponentInfo* componentInfoById(ComponentId id) {
+    return componentRegistry()[id];
+}
+
+} // namespace ecs
+} // namespace IKore

--- a/src/core/ecs/ECS.h
+++ b/src/core/ecs/ECS.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/**
+ * @file ECS.h
+ * @brief Umbrella header for the data-oriented (archetype/SoA) ECS.
+ *
+ * Milestone 8 — Foundations: Data-Oriented ECS (issue #140).
+ *
+ * This module provides archetype-based, structure-of-arrays component storage
+ * with stable, generational entity handles:
+ *
+ *   - IKore::ecs::Entity   — a stable handle (index + generation).
+ *   - IKore::ecs::Registry — the world: create/destroy entities, add/remove/get
+ *                            components, with data stored contiguously per
+ *                            component type and grouped by component signature.
+ *
+ * Example:
+ * @code
+ * using namespace IKore::ecs;
+ * struct Position { float x, y, z; };
+ * struct Velocity { float dx, dy, dz; };
+ *
+ * Registry world;
+ * Entity e = world.create();
+ * world.add<Position>(e, {0, 0, 0});
+ * world.add<Velocity>(e, {1, 0, 0});   // entity moves to the {Position,Velocity} archetype
+ * world.get<Position>(e).x += world.get<Velocity>(e).dx;
+ * world.remove<Velocity>(e);           // moves back to the {Position} archetype
+ * world.destroy(e);                    // handle `e` is now invalid
+ * @endcode
+ *
+ * Roadmap: a cache-friendly query/iteration API is issue #141; migrating the
+ * engine's existing components onto this storage is issue #142; benchmarking is
+ * issue #143.
+ */
+#include "core/ecs/Archetype.h"
+#include "core/ecs/Component.h"
+#include "core/ecs/Entity.h"
+#include "core/ecs/Registry.h"

--- a/src/core/ecs/ECS.h
+++ b/src/core/ecs/ECS.h
@@ -4,13 +4,13 @@
  * @file ECS.h
  * @brief Umbrella header for the data-oriented (archetype/SoA) ECS.
  *
- * Milestone 8 — Foundations: Data-Oriented ECS (issue #140).
+ * Milestone 8 - Foundations: Data-Oriented ECS (issue #140).
  *
  * This module provides archetype-based, structure-of-arrays component storage
  * with stable, generational entity handles:
  *
- *   - IKore::ecs::Entity   — a stable handle (index + generation).
- *   - IKore::ecs::Registry — the world: create/destroy entities, add/remove/get
+ *   - IKore::ecs::Entity   - a stable handle (index + generation).
+ *   - IKore::ecs::Registry - the world: create/destroy entities, add/remove/get
  *                            components, with data stored contiguously per
  *                            component type and grouped by component signature.
  *

--- a/src/core/ecs/Entity.h
+++ b/src/core/ecs/Entity.h
@@ -7,8 +7,8 @@
  * @file Entity.h
  * @brief Stable, generational entity handle for the data-oriented ECS.
  *
- * Part of Milestone 8 (issue #140). An Entity is a lightweight value type —
- * an index plus a generation counter — that stays valid regardless of where
+ * Part of Milestone 8 (issue #140). An Entity is a lightweight value type -
+ * an index plus a generation counter - that stays valid regardless of where
  * the entity's component data physically lives. When an entity is destroyed
  * its index is recycled with a bumped generation, so stale handles referring
  * to the old occupant compare as invalid.

--- a/src/core/ecs/Entity.h
+++ b/src/core/ecs/Entity.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+/**
+ * @file Entity.h
+ * @brief Stable, generational entity handle for the data-oriented ECS.
+ *
+ * Part of Milestone 8 (issue #140). An Entity is a lightweight value type —
+ * an index plus a generation counter — that stays valid regardless of where
+ * the entity's component data physically lives. When an entity is destroyed
+ * its index is recycled with a bumped generation, so stale handles referring
+ * to the old occupant compare as invalid.
+ */
+namespace IKore {
+namespace ecs {
+
+/**
+ * @brief A handle to an entity. Cheap to copy and store.
+ *
+ * The handle does not point at component storage directly; the Registry maps it
+ * to the current archetype/row. This indirection is what keeps handles stable
+ * while the underlying SoA columns are repacked.
+ */
+struct Entity {
+    std::uint32_t index{0};      ///< Slot index into the Registry's record table.
+    std::uint32_t generation{0}; ///< Bumped each time the slot is recycled.
+
+    static constexpr std::uint32_t kInvalidIndex = 0xFFFFFFFFu;
+
+    /// An explicitly invalid handle.
+    static constexpr Entity invalid() { return Entity{kInvalidIndex, 0}; }
+
+    bool isValid() const { return index != kInvalidIndex; }
+
+    bool operator==(const Entity& o) const {
+        return index == o.index && generation == o.generation;
+    }
+    bool operator!=(const Entity& o) const { return !(*this == o); }
+};
+
+} // namespace ecs
+} // namespace IKore
+
+namespace std {
+template <>
+struct hash<IKore::ecs::Entity> {
+    std::size_t operator()(const IKore::ecs::Entity& e) const noexcept {
+        return (static_cast<std::size_t>(e.generation) << 32) ^ e.index;
+    }
+};
+} // namespace std

--- a/src/core/ecs/Registry.h
+++ b/src/core/ecs/Registry.h
@@ -1,0 +1,208 @@
+#pragma once
+
+#include "core/ecs/Archetype.h"
+#include "core/ecs/Component.h"
+#include "core/ecs/Entity.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <vector>
+
+/**
+ * @file Registry.h
+ * @brief The ECS world: owns entities, archetypes, and the entity->location map.
+ *
+ * Part of Milestone 8 (issue #140). The Registry is the public entry point for
+ * the data-oriented ECS. It hands out stable Entity handles, stores components
+ * in archetype-grouped SoA columns, and moves entities between archetypes as
+ * components are added or removed.
+ *
+ * Scope note: this milestone delivers storage + stable handles + add/remove/get.
+ * A cache-friendly iteration/query API is issue #141; migrating the engine's
+ * existing components onto this storage is issue #142.
+ */
+namespace IKore {
+namespace ecs {
+
+class Registry {
+public:
+    Registry() { m_empty = getOrCreate({}); }
+
+    // Non-copyable: it owns raw-pointer-stable archetypes and aligned buffers.
+    Registry(const Registry&) = delete;
+    Registry& operator=(const Registry&) = delete;
+
+    /// Create a fresh entity (initially with no components).
+    Entity create() {
+        std::uint32_t index;
+        if (!m_freeList.empty()) {
+            index = m_freeList.back();
+            m_freeList.pop_back();
+        } else {
+            index = static_cast<std::uint32_t>(m_records.size());
+            m_records.emplace_back();
+        }
+        Record& record = m_records[index];
+        record.alive = true;
+        record.archetype = m_empty;
+        record.row = static_cast<std::uint32_t>(m_empty->entities.size());
+        m_empty->entities.push_back(index);
+        return Entity{index, record.generation};
+    }
+
+    /// True if @p e refers to a currently-live entity (generation matches).
+    bool isValid(Entity e) const {
+        return e.index < m_records.size() && m_records[e.index].alive &&
+               m_records[e.index].generation == e.generation;
+    }
+
+    /// Destroy @p e and recycle its slot (bumping the generation).
+    void destroy(Entity e) {
+        if (!isValid(e)) return;
+        Record& record = m_records[e.index];
+        const std::uint32_t relocated = record.archetype->removeRow(record.row);
+        if (relocated != Entity::kInvalidIndex) m_records[relocated].row = record.row;
+        record.alive = false;
+        record.archetype = nullptr;
+        ++record.generation;
+        m_freeList.push_back(e.index);
+    }
+
+    template <class T>
+    bool has(Entity e) const {
+        return isValid(e) && m_records[e.index].archetype->has(componentId<T>());
+    }
+
+    /// Add (or overwrite) component @c T on @p e; returns a reference to it.
+    template <class T>
+    T& add(Entity e, T value = {}) {
+        const ComponentId cid = componentId<T>();
+        Record& record = m_records[e.index];
+        Archetype* from = record.archetype;
+
+        const int existing = from->columnIndex(cid);
+        if (existing >= 0) {
+            T& slot = *static_cast<T*>(from->columns[existing].at(record.row));
+            slot = std::move(value);
+            return slot;
+        }
+
+        std::vector<ComponentId> signature = from->signature;
+        signature.push_back(cid);
+        std::sort(signature.begin(), signature.end());
+        Archetype* to = getOrCreate(signature);
+
+        moveRow(e.index, from, to, /*addId=*/cid, /*addSrc=*/&value);
+        return get<T>(e);
+    }
+
+    /// Remove component @c T from @p e (no-op if absent).
+    template <class T>
+    void remove(Entity e) {
+        const ComponentId cid = componentId<T>();
+        Record& record = m_records[e.index];
+        Archetype* from = record.archetype;
+        if (from->columnIndex(cid) < 0) return;
+
+        std::vector<ComponentId> signature;
+        signature.reserve(from->signature.size() - 1);
+        for (ComponentId id : from->signature) {
+            if (id != cid) signature.push_back(id);
+        }
+        Archetype* to = getOrCreate(signature);
+        // The removed component's data lives only in `from`; moveRow copies the
+        // surviving columns and the swap-remove on `from` destroys the rest.
+        moveRow(e.index, from, to, /*addId=*/kInvalidComponent, /*addSrc=*/nullptr);
+    }
+
+    /// Reference to @p e's component @c T. Precondition: has<T>(e).
+    template <class T>
+    T& get(Entity e) {
+        Record& record = m_records[e.index];
+        const int col = record.archetype->columnIndex(componentId<T>());
+        return *static_cast<T*>(record.archetype->columns[col].at(record.row));
+    }
+
+    template <class T>
+    const T& get(Entity e) const {
+        const Record& record = m_records[e.index];
+        const int col = record.archetype->columnIndex(componentId<T>());
+        return *static_cast<const T*>(record.archetype->columns[col].at(record.row));
+    }
+
+    /// Number of currently-live entities.
+    std::size_t aliveCount() const { return m_records.size() - m_freeList.size(); }
+
+    /// Number of distinct archetypes (including the empty one). Mostly for tests.
+    std::size_t archetypeCount() const { return m_archetypes.size(); }
+
+private:
+    struct Record {
+        std::uint32_t generation{0};
+        bool alive{false};
+        Archetype* archetype{nullptr};
+        std::uint32_t row{0};
+    };
+
+    Archetype* getOrCreate(std::vector<ComponentId> signature) {
+        auto it = m_index.find(signature);
+        if (it != m_index.end()) return it->second;
+
+        auto archetype = std::make_unique<Archetype>();
+        archetype->signature = signature;
+        archetype->columns.reserve(signature.size());
+        for (ComponentId id : signature) {
+            archetype->columns.emplace_back(componentInfoById(id));
+        }
+        Archetype* ptr = archetype.get();
+        m_index.emplace(std::move(signature), ptr);
+        m_archetypes.push_back(std::move(archetype));
+        return ptr;
+    }
+
+    /**
+     * @brief Relocate entity @p index from archetype @p from to @p to.
+     *
+     * Surviving components are moved column-by-column; if @p addId is valid the
+     * new component is move-constructed from @p addSrc. The source row is then
+     * swap-removed from @p from, and any entity relocated by that swap has its
+     * record patched.
+     */
+    void moveRow(std::uint32_t index, Archetype* from, Archetype* to, ComponentId addId,
+                 void* addSrc) {
+        Record& record = m_records[index];
+        const std::size_t srcRow = record.row;
+
+        for (std::size_t i = 0; i < to->signature.size(); ++i) {
+            const ComponentId id = to->signature[i];
+            Column& dst = to->columns[i];
+            if (id == addId) {
+                dst.pushMove(addSrc);
+            } else {
+                const int fromCol = from->columnIndex(id);
+                dst.pushMove(from->columns[fromCol].at(srcRow));
+            }
+        }
+        const auto newRow = static_cast<std::uint32_t>(to->entities.size());
+        to->entities.push_back(index);
+
+        const std::uint32_t relocated = from->removeRow(srcRow);
+        if (relocated != Entity::kInvalidIndex) {
+            m_records[relocated].row = static_cast<std::uint32_t>(srcRow);
+        }
+
+        record.archetype = to;
+        record.row = newRow;
+    }
+
+    std::vector<Record> m_records;
+    std::vector<std::uint32_t> m_freeList;
+    std::vector<std::unique_ptr<Archetype>> m_archetypes;
+    std::map<std::vector<ComponentId>, Archetype*> m_index;
+    Archetype* m_empty{nullptr};
+};
+
+} // namespace ecs
+} // namespace IKore

--- a/tests/test_archetype_ecs.cpp
+++ b/tests/test_archetype_ecs.cpp
@@ -1,0 +1,179 @@
+// Unit test for the data-oriented (archetype/SoA) ECS — Milestone 8, issue #140.
+//
+// Verifies the issue's acceptance criteria:
+//   1. Components for a given archetype are laid out contiguously in memory.
+//   2. Adding/removing a component moves the entity between archetypes correctly.
+//   3. No leaks or dangling handles when entities are created/destroyed.
+//
+// Pure standard library + the header-only ECS, so it can be built and run on its
+// own:  g++ -std=c++17 -I src tests/test_archetype_ecs.cpp -o test_archetype_ecs
+
+#include "core/ecs/ECS.h"
+
+#include <cstdint>
+#include <cstdio>
+
+using namespace IKore::ecs;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                       \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);         \
+            ++g_failures;                                                 \
+        }                                                                 \
+    } while (0)
+
+struct Position {
+    float x{0}, y{0}, z{0};
+};
+struct Velocity {
+    float dx{0}, dy{0}, dz{0};
+};
+
+// A component that tracks how many live instances exist, to catch leaks and to
+// prove relocations move-and-destroy rather than duplicate or drop instances.
+struct Tracked {
+    static int alive;
+    int value{0};
+    Tracked() { ++alive; }
+    explicit Tracked(int v) : value(v) { ++alive; }
+    Tracked(const Tracked& o) : value(o.value) { ++alive; }
+    Tracked(Tracked&& o) noexcept : value(o.value) { ++alive; }
+    Tracked& operator=(const Tracked&) = default;
+    Tracked& operator=(Tracked&&) noexcept = default;
+    ~Tracked() { --alive; }
+};
+int Tracked::alive = 0;
+
+static void testBasicAddGet() {
+    Registry world;
+    Entity e = world.create();
+    CHECK(world.isValid(e));
+    CHECK(!world.has<Position>(e));
+
+    world.add<Position>(e, Position{1.0f, 2.0f, 3.0f});
+    CHECK(world.has<Position>(e));
+    CHECK(world.get<Position>(e).x == 1.0f);
+    CHECK(world.get<Position>(e).z == 3.0f);
+
+    // add() with an existing component overwrites in place.
+    world.add<Position>(e, Position{4.0f, 5.0f, 6.0f});
+    CHECK(world.get<Position>(e).y == 5.0f);
+}
+
+static void testContiguousStorage() {
+    // Two entities with the same signature share an archetype; their component
+    // rows must be adjacent in memory (structure-of-arrays).
+    Registry world;
+    Entity a = world.create();
+    Entity b = world.create();
+    world.add<Position>(a, Position{10, 0, 0});
+    world.add<Position>(b, Position{20, 0, 0});
+
+    auto* pa = &world.get<Position>(a);
+    auto* pb = &world.get<Position>(b);
+    const std::ptrdiff_t byteGap =
+        reinterpret_cast<const char*>(pb) - reinterpret_cast<const char*>(pa);
+    CHECK(byteGap == static_cast<std::ptrdiff_t>(sizeof(Position)));
+}
+
+static void testArchetypeTransitions() {
+    Registry world;
+    Entity e = world.create();
+    world.add<Position>(e, Position{1, 1, 1});
+    world.add<Velocity>(e, Velocity{2, 2, 2});
+
+    // After adding a second component the entity has both, with values intact.
+    CHECK(world.has<Position>(e));
+    CHECK(world.has<Velocity>(e));
+    CHECK(world.get<Position>(e).x == 1.0f);
+    CHECK(world.get<Velocity>(e).dy == 2.0f);
+
+    // Removing one moves the entity back to the single-component archetype.
+    world.remove<Velocity>(e);
+    CHECK(world.has<Position>(e));
+    CHECK(!world.has<Velocity>(e));
+    CHECK(world.get<Position>(e).x == 1.0f);
+}
+
+static void testStableHandlesAcrossRelocation() {
+    // Three entities in the {Position} archetype. Promoting the middle one to a
+    // new archetype triggers a swap-remove that relocates the last entity into
+    // the freed row. All three handles must still resolve to the right data.
+    Registry world;
+    Entity a = world.create();
+    Entity b = world.create();
+    Entity c = world.create();
+    world.add<Position>(a, Position{1, 0, 0});
+    world.add<Position>(b, Position{2, 0, 0});
+    world.add<Position>(c, Position{3, 0, 0});
+
+    world.add<Velocity>(b, Velocity{9, 9, 9}); // relocates `c` into b's old row
+
+    CHECK(world.get<Position>(a).x == 1.0f);
+    CHECK(world.get<Position>(b).x == 2.0f);
+    CHECK(world.get<Position>(c).x == 3.0f);
+    CHECK(world.has<Velocity>(b));
+    CHECK(!world.has<Velocity>(a));
+    CHECK(!world.has<Velocity>(c));
+}
+
+static void testGenerationalInvalidation() {
+    Registry world;
+    Entity e = world.create();
+    world.add<Position>(e, Position{7, 7, 7});
+    CHECK(world.isValid(e));
+
+    world.destroy(e);
+    CHECK(!world.isValid(e)); // stale handle no longer valid
+
+    Entity reused = world.create(); // recycles e's slot with a bumped generation
+    CHECK(world.isValid(reused));
+    CHECK(reused.index == e.index);
+    CHECK(reused.generation != e.generation);
+    CHECK(!world.isValid(e)); // old handle still invalid against recycled slot
+}
+
+static void testNoLeaks() {
+    CHECK(Tracked::alive == 0);
+    {
+        Registry world;
+        std::vector<Entity> entities;
+        for (int i = 0; i < 64; ++i) {
+            Entity e = world.create();
+            world.add<Tracked>(e, Tracked{i});
+            if (i % 2 == 0) world.add<Position>(e, Position{}); // force archetype churn
+            entities.push_back(e);
+        }
+        // Add/remove to exercise relocation and overwrite paths.
+        for (std::size_t i = 0; i < entities.size(); ++i) {
+            world.add<Velocity>(entities[i], Velocity{});
+            if (i % 3 == 0) world.remove<Tracked>(entities[i]);
+        }
+        // Destroy half the entities.
+        for (std::size_t i = 0; i < entities.size(); i += 2) {
+            world.destroy(entities[i]);
+        }
+        CHECK(Tracked::alive > 0); // some still live inside the world
+    }
+    // Registry destroyed -> every remaining Tracked must have been destructed.
+    CHECK(Tracked::alive == 0);
+}
+
+int main() {
+    testBasicAddGet();
+    testContiguousStorage();
+    testArchetypeTransitions();
+    testStableHandlesAcrossRelocation();
+    testGenerationalInvalidation();
+    testNoLeaks();
+
+    if (g_failures == 0) {
+        std::printf("All archetype ECS tests passed.\n");
+        return 0;
+    }
+    std::printf("%d archetype ECS test(s) failed.\n", g_failures);
+    return 1;
+}

--- a/tests/test_archetype_ecs.cpp
+++ b/tests/test_archetype_ecs.cpp
@@ -1,4 +1,4 @@
-// Unit test for the data-oriented (archetype/SoA) ECS — Milestone 8, issue #140.
+// Unit test for the data-oriented (archetype/SoA) ECS - Milestone 8, issue #140.
 //
 // Verifies the issue's acceptance criteria:
 //   1. Components for a given archetype are laid out contiguously in memory.


### PR DESCRIPTION
Implements **Milestone 8 / #140** — the data-oriented ECS foundation: a self-contained `src/core/ecs/` module providing archetype, structure-of-arrays component storage with stable, generational entity handles.

## What's included
- **Entity** — index + generation handle, stable across storage relocation; stale handles invalidate when a slot is recycled.
- **Component** — type-erased `ComponentInfo` (size/align/move/destroy) + lazily-assigned dense `ComponentId` per type.
- **Archetype / Column** — contiguous, densely-packed (swap-remove) per-type byte columns; move-only RAII with aligned allocation.
- **Registry** — create/destroy entities; add/remove/get/has components; entities move between archetypes on component change, with the entity->location map patched on every relocation.

## Scope
Storage + handles only. The query/iteration API is #141 and engine migration is #142, kept separate by design — this is **additive** and does not touch the existing `Entity` system.

## Verification
`tests/test_archetype_ecs.cpp` (new `test_archetype_ecs` target) covers every acceptance criterion: contiguous layout, add/remove archetype transitions, no leaks/dangling, plus generational invalidation and stable-handle-after-relocation. Passes locally under `-Wall -Wextra -pedantic` with AddressSanitizer + UBSan. The CodeQL `Analyze (c-cpp)` job builds it in CI (the cross-platform `ci.yml` is currently disabled in repo settings).