### PR TITLE
feat(ecs): cache-friendly query/View API over archetypes (#141)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,11 @@ add_executable(test_archetype_ecs
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_archetype_ecs.cpp
 )
 
+# ECS query/View test (Milestone 8 / #141) - header-only module, no extra deps
+add_executable(test_ecs_query
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ecs_query.cpp
+)
+
 if(MSVC)
     target_compile_options(IKore PRIVATE /W4)
 else()

--- a/src/core/ecs/ECS.h
+++ b/src/core/ecs/ECS.h
@@ -13,6 +13,8 @@
  *   - IKore::ecs::Registry - the world: create/destroy entities, add/remove/get
  *                            components, with data stored contiguously per
  *                            component type and grouped by component signature.
+ *   - IKore::ecs::View     - cache-friendly queries: iterate every entity with a
+ *                            given component set (with optional excludes).
  *
  * Example:
  * @code
@@ -25,15 +27,22 @@
  * world.add<Position>(e, {0, 0, 0});
  * world.add<Velocity>(e, {1, 0, 0});   // entity moves to the {Position,Velocity} archetype
  * world.get<Position>(e).x += world.get<Velocity>(e).dx;
+ *
+ * // Iterate all entities that have both components, cache-coherently:
+ * world.view<Position, Velocity>().each([](Entity, Position& p, Velocity& v) {
+ *     p.x += v.dx;
+ * });
+ *
  * world.remove<Velocity>(e);           // moves back to the {Position} archetype
  * world.destroy(e);                    // handle `e` is now invalid
  * @endcode
  *
- * Roadmap: a cache-friendly query/iteration API is issue #141; migrating the
- * engine's existing components onto this storage is issue #142; benchmarking is
- * issue #143.
+ * Roadmap: the cache-friendly query/iteration API (View) is issue #141; migrating
+ * the engine's existing components onto this storage is issue #142; benchmarking
+ * is issue #143.
  */
 #include "core/ecs/Archetype.h"
 #include "core/ecs/Component.h"
 #include "core/ecs/Entity.h"
 #include "core/ecs/Registry.h"
+#include "core/ecs/View.h"

--- a/src/core/ecs/Registry.h
+++ b/src/core/ecs/Registry.h
@@ -20,11 +20,15 @@
  * components are added or removed.
  *
  * Scope note: this milestone delivers storage + stable handles + add/remove/get.
- * A cache-friendly iteration/query API is issue #141; migrating the engine's
- * existing components onto this storage is issue #142.
+ * The cache-friendly iteration/query API lives in View.h (issue #141); migrating
+ * the engine's existing components onto this storage is issue #142.
  */
 namespace IKore {
 namespace ecs {
+
+// Defined in View.h: the query/iteration API (issue #141).
+template <class... Include>
+class View;
 
 class Registry {
 public:
@@ -138,7 +142,14 @@ public:
     /// Number of distinct archetypes (including the empty one). Mostly for tests.
     std::size_t archetypeCount() const { return m_archetypes.size(); }
 
+    /// Begin a query over all entities that have every one of @c Include.
+    /// Compose with `.exclude<...>()` and iterate with `.each(fn)`; see View.h.
+    template <class... Include>
+    View<Include...> view();
+
 private:
+    template <class...> friend class View;
+
     struct Record {
         std::uint32_t generation{0};
         bool alive{false};

--- a/src/core/ecs/View.h
+++ b/src/core/ecs/View.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "core/ecs/Archetype.h"
+#include "core/ecs/Component.h"
+#include "core/ecs/Entity.h"
+#include "core/ecs/Registry.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+/**
+ * @file View.h
+ * @brief Cache-friendly query/iteration API over archetype storage.
+ *
+ * Milestone 8 (issue #141). A View selects every entity whose archetype contains
+ * all of the requested @c Include components (and, optionally, none of the
+ * excluded ones) and iterates them archetype-by-archetype, row-by-row, over the
+ * contiguous SoA columns. Component pointers are resolved once per archetype, so
+ * the inner loop is a straight walk of packed arrays with no per-entity hashing
+ * and no virtual dispatch.
+ *
+ * Usage:
+ * @code
+ * world.view<Position, Velocity>().each([](Entity e, Position& p, Velocity& v) {
+ *     p.x += v.dx;
+ * });
+ *
+ * // Composed include/exclude:
+ * world.view<Position>().exclude<Frozen>().each([](Entity, Position& p) { ... });
+ * @endcode
+ *
+ * Iteration order is deterministic: archetypes in creation order, rows in row
+ * order.
+ */
+namespace IKore {
+namespace ecs {
+
+template <class... Include>
+class View {
+    static_assert(sizeof...(Include) >= 1, "A view needs at least one component type");
+
+public:
+    explicit View(Registry& registry) : m_registry(registry) {}
+
+    /// Narrow the query to entities that have NONE of @c Exclude. Chainable.
+    template <class... Exclude>
+    View& exclude() {
+        (m_excludes.push_back(componentId<Exclude>()), ...);
+        return *this;
+    }
+
+    /**
+     * @brief Invoke @p fn(Entity, Include&...) for every matching entity.
+     *
+     * Components are passed by reference, so @p fn may mutate them in place.
+     */
+    template <class Fn>
+    void each(Fn&& fn) {
+        const ComponentId includeIds[] = {componentId<Include>()...};
+
+        for (const auto& archetypePtr : m_registry.m_archetypes) {
+            Archetype& archetype = *archetypePtr;
+
+            // Resolve the column for each required component once per archetype;
+            // skip the whole archetype if any is missing.
+            Column* columns[sizeof...(Include)];
+            bool matches = true;
+            for (std::size_t i = 0; i < sizeof...(Include); ++i) {
+                const int columnIndex = archetype.columnIndex(includeIds[i]);
+                if (columnIndex < 0) {
+                    matches = false;
+                    break;
+                }
+                columns[i] = &archetype.columns[columnIndex];
+            }
+            if (!matches) continue;
+
+            bool excluded = false;
+            for (ComponentId id : m_excludes) {
+                if (archetype.has(id)) {
+                    excluded = true;
+                    break;
+                }
+            }
+            if (excluded) continue;
+
+            for (std::size_t row = 0; row < archetype.entities.size(); ++row) {
+                const std::uint32_t index = archetype.entities[row];
+                const Entity entity{index, m_registry.m_records[index].generation};
+                invokeRow(fn, entity, columns, row, std::index_sequence_for<Include...>{});
+            }
+        }
+    }
+
+    /// Number of entities the query matches.
+    std::size_t count() {
+        std::size_t total = 0;
+        each([&total](Entity, Include&...) { ++total; });
+        return total;
+    }
+
+private:
+    template <class Fn, std::size_t... I>
+    static void invokeRow(Fn& fn, Entity entity, Column** columns, std::size_t row,
+                          std::index_sequence<I...>) {
+        fn(entity, *static_cast<Include*>(columns[I]->at(row))...);
+    }
+
+    Registry& m_registry;
+    std::vector<ComponentId> m_excludes;
+};
+
+// Defined here, now that View is complete (declared in Registry.h).
+template <class... Include>
+View<Include...> Registry::view() {
+    return View<Include...>(*this);
+}
+
+} // namespace ecs
+} // namespace IKore

--- a/tests/test_ecs_query.cpp
+++ b/tests/test_ecs_query.cpp
@@ -1,0 +1,155 @@
+// Unit test for the ECS query/iteration API (View) - Milestone 8, issue #141.
+//
+// Verifies the issue's acceptance criteria:
+//   1. A system can iterate (Position, Velocity) entities and mutate them.
+//   2. Query iteration order is deterministic.
+//   3. Queries compose with include/exclude.
+// Also checks that a query spans multiple archetypes (any superset matches) and
+// that mutations through the view are visible via get().
+//
+// Pure standard library + the header-only ECS:
+//   g++ -std=c++17 -I src tests/test_ecs_query.cpp -o test_ecs_query
+
+#include "core/ecs/ECS.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::ecs;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+struct Position {
+    float x{0}, y{0}, z{0};
+};
+struct Velocity {
+    float dx{0}, dy{0}, dz{0};
+};
+struct Frozen {
+    bool dummy{true};
+};
+struct Tag {
+    int id{0};
+};
+
+static void testIterateAndMutate() {
+    Registry world;
+    Entity a = world.create();
+    Entity b = world.create();
+    Entity c = world.create();
+    world.add<Position>(a, Position{0, 0, 0});
+    world.add<Velocity>(a, Velocity{1, 2, 3});
+    world.add<Position>(b, Position{10, 10, 10});
+    world.add<Velocity>(b, Velocity{1, 1, 1});
+    world.add<Position>(c, Position{100, 0, 0}); // Position only -> must NOT match
+
+    int visited = 0;
+    world.view<Position, Velocity>().each([&](Entity, Position& p, Velocity& v) {
+        p.x += v.dx;
+        p.y += v.dy;
+        p.z += v.dz;
+        ++visited;
+    });
+
+    CHECK(visited == 2); // only a and b have both
+    CHECK(world.get<Position>(a).x == 1.0f);  // 0 + 1
+    CHECK(world.get<Position>(a).z == 3.0f);  // 0 + 3
+    CHECK(world.get<Position>(b).x == 11.0f); // 10 + 1
+    CHECK(world.get<Position>(c).x == 100.0f); // untouched (not matched)
+}
+
+static void testSpansMultipleArchetypes() {
+    // Entities with {Position,Velocity} and with {Position,Velocity,Tag} live in
+    // different archetypes; a view<Position,Velocity> must visit both.
+    Registry world;
+    Entity a = world.create();
+    Entity b = world.create();
+    world.add<Position>(a, Position{});
+    world.add<Velocity>(a, Velocity{});
+    world.add<Position>(b, Position{});
+    world.add<Velocity>(b, Velocity{});
+    world.add<Tag>(b, Tag{7}); // moves b to a different archetype
+
+    // Extra parens: the commas are template-argument separators, not macro args.
+    CHECK((world.view<Position, Velocity>().count() == 2));
+    CHECK((world.view<Position, Velocity, Tag>().count() == 1));
+}
+
+static void testExclude() {
+    Registry world;
+    Entity a = world.create();
+    Entity b = world.create();
+    world.add<Position>(a, Position{1, 0, 0});
+    world.add<Position>(b, Position{2, 0, 0});
+    world.add<Frozen>(b, Frozen{}); // b is frozen
+
+    int visited = 0;
+    float sumX = 0;
+    world.view<Position>().exclude<Frozen>().each([&](Entity, Position& p) {
+        ++visited;
+        sumX += p.x;
+    });
+    CHECK(visited == 1);     // only a
+    CHECK(sumX == 1.0f);     // a.x
+
+    CHECK(world.view<Position>().count() == 2);                  // both
+    CHECK(world.view<Position>().exclude<Frozen>().count() == 1); // only a
+}
+
+static void testDeterministicOrder() {
+    Registry world;
+    std::vector<Entity> made;
+    for (int i = 0; i < 32; ++i) {
+        Entity e = world.create();
+        world.add<Position>(e, Position{static_cast<float>(i), 0, 0});
+        if (i % 2 == 0) world.add<Velocity>(e, Velocity{}); // mix archetypes
+        made.push_back(e);
+    }
+
+    auto collect = [&] {
+        std::vector<float> order;
+        world.view<Position>().each([&](Entity, Position& p) { order.push_back(p.x); });
+        return order;
+    };
+
+    const std::vector<float> first = collect();
+    const std::vector<float> second = collect();
+    CHECK(first.size() == 32);
+    CHECK(first == second); // identical order across runs -> deterministic
+}
+
+static void testEmptyAndNoMatch() {
+    Registry world;
+    // No entities at all.
+    CHECK(world.view<Position>().count() == 0);
+
+    Entity e = world.create();
+    world.add<Velocity>(e, Velocity{});
+    // Entities exist, but none match the requested component.
+    CHECK(world.view<Position>().count() == 0);
+    CHECK(world.view<Velocity>().count() == 1);
+}
+
+int main() {
+    testIterateAndMutate();
+    testSpansMultipleArchetypes();
+    testExclude();
+    testDeterministicOrder();
+    testEmptyAndNoMatch();
+
+    if (g_failures == 0) {
+        std::printf("All ECS query tests passed.\n");
+        return 0;
+    }
+    std::printf("%d ECS query test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Implements **Milestone 8 / #141** — the iteration/query layer on top of the #140 archetype storage.

> **Stacked PR.** Base is `claude/archetype-ecs-140` (PR for #140), so this diff shows only the query API. Merge #140 first; GitHub will retarget this to `main`.

## What's included
`IKore::ecs::View`, reached via `Registry::view<...>()`:

```cpp
world.view<Position, Velocity>().each([](Entity e, Position& p, Velocity& v) { p.x += v.dx; });
world.view<Position>().exclude<Frozen>().each([](Entity, Position& p) { ... });
```

- **Cache-coherent, no virtual dispatch** — resolves each component's column once per archetype, then walks the contiguous SoA rows directly.
- **Multi-component, spans archetypes** — any archetype that is a superset of the requested set matches.
- **Include + `.exclude<...>()` composition.**
- **Deterministic order** — archetypes in creation order, rows in row order.

## Verification
`tests/test_ecs_query.cpp` (new `test_ecs_query` target) covers iterate+mutate, multi-archetype coverage, include/exclude, deterministic order, and empty/no-match. Passes locally under `-Wall -Wextra -pedantic` with ASan/UBSan.