### PR TITLE
feat(ecs): migrate hot-path components + systems to archetype storage (#142)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,11 @@ add_executable(test_ecs_query
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ecs_query.cpp
 )
 
+# ECS hot-path components + systems test (Milestone 8 / #142) - header-only
+add_executable(test_ecs_systems
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ecs_systems.cpp
+)
+
 if(MSVC)
     target_compile_options(IKore PRIVATE /W4)
 else()

--- a/src/core/ecs/ECS.h
+++ b/src/core/ecs/ECS.h
@@ -46,3 +46,7 @@
 #include "core/ecs/Entity.h"
 #include "core/ecs/Registry.h"
 #include "core/ecs/View.h"
+// Concrete hot-path components and systems (issue #142) are an opt-in layer on
+// top of this generic core - include them directly when needed:
+//   #include "core/ecs/components/Components.h"
+//   #include "core/ecs/systems/Systems.h"

--- a/src/core/ecs/components/Components.h
+++ b/src/core/ecs/components/Components.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <cmath>
+#include <memory>
+
+/**
+ * @file Components.h
+ * @brief Hot-path components expressed as value types for archetype storage.
+ *
+ * Milestone 8 (issue #142). These are the frequently-updated components the
+ * engine touches every frame - transform, velocity, physics, AI - re-expressed
+ * as plain value types so they live in the contiguous, cache-friendly SoA
+ * columns provided by the archetype ECS (issues #140/#141) and are driven by the
+ * systems in systems/Systems.h.
+ *
+ * They are intentionally dependency-free (a small built-in Vec3 instead of glm)
+ * so the data layer and its systems are unit-testable in isolation. The
+ * class-based components under src/core/components/ remain for the parts of the
+ * engine not yet migrated; the @ref Legacy bridge below lets an archetype entity
+ * carry a link to its legacy counterpart during the transition.
+ */
+namespace IKore {
+namespace ecs {
+
+/// Minimal 3-component vector (kept local to avoid a glm dependency here).
+struct Vec3 {
+    float x{0.0f}, y{0.0f}, z{0.0f};
+
+    Vec3 operator+(const Vec3& o) const { return {x + o.x, y + o.y, z + o.z}; }
+    Vec3 operator-(const Vec3& o) const { return {x - o.x, y - o.y, z - o.z}; }
+    Vec3 operator*(float s) const { return {x * s, y * s, z * s}; }
+    Vec3& operator+=(const Vec3& o) {
+        x += o.x; y += o.y; z += o.z;
+        return *this;
+    }
+    Vec3& operator*=(float s) {
+        x *= s; y *= s; z *= s;
+        return *this;
+    }
+
+    float lengthSquared() const { return x * x + y * y + z * z; }
+    float length() const { return std::sqrt(lengthSquared()); }
+    Vec3 normalized() const {
+        const float len = length();
+        return len > 0.0f ? Vec3{x / len, y / len, z / len} : Vec3{};
+    }
+};
+
+/// Spatial transform (position, Euler rotation in radians, scale).
+struct Transform {
+    Vec3 position{};
+    Vec3 rotation{};
+    Vec3 scale{1.0f, 1.0f, 1.0f};
+};
+
+/// Linear + angular velocity, integrated into Transform by the movement system.
+struct Velocity {
+    Vec3 linear{};
+    Vec3 angular{};
+};
+
+/// Hot physics data integrated into Velocity by the physics system.
+struct RigidBody {
+    Vec3 acceleration{};   ///< Constant acceleration (e.g. gravity) this step.
+    float mass{1.0f};
+    float damping{0.0f};   ///< Per-second velocity damping factor in [0, 1].
+    bool kinematic{false}; ///< Kinematic bodies are not integrated by physics.
+};
+
+/// Hot AI steering data: the agent moves toward @c target at @c speed.
+struct AIAgent {
+    Vec3 target{};
+    float speed{1.0f};
+    float arriveRadius{0.05f}; ///< Stop when within this distance of target.
+    bool active{true};
+};
+
+/**
+ * @brief Compatibility bridge to a legacy (class-based) component or entity.
+ *
+ * During the migration, less-frequently-updated components stay in the existing
+ * src/core/components/ classes. Attaching a Legacy to an archetype entity lets
+ * it carry a type-erased owning handle to that legacy object (e.g. a
+ * std::shared_ptr<Entity> or a specific legacy component), so systems can bridge
+ * between the two worlds without the ECS data layer depending on engine types.
+ * Ownership rides correctly through archetype moves and is released on destroy.
+ */
+struct Legacy {
+    std::shared_ptr<void> handle;
+};
+
+} // namespace ecs
+} // namespace IKore

--- a/src/core/ecs/systems/Systems.h
+++ b/src/core/ecs/systems/Systems.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "core/ecs/Registry.h"
+#include "core/ecs/View.h"
+#include "core/ecs/components/Components.h"
+
+/**
+ * @file Systems.h
+ * @brief Hot-path systems that run over archetype storage via the query API.
+ *
+ * Milestone 8 (issue #142). These are the per-frame updates for the migrated
+ * components. Each is a plain free function that iterates the relevant
+ * components with Registry::view<...>().each(...), so it walks the contiguous
+ * SoA columns directly - the cache-friendly hot path.
+ *
+ * Pipeline order (see @ref stepSimulation): AI steering sets desired velocities,
+ * physics integrates accelerations into velocities, then movement integrates
+ * velocities into transforms. Entities typically carry either AIAgent or
+ * RigidBody, so the two velocity writers rarely overlap; the order is fixed for
+ * determinism regardless.
+ */
+namespace IKore {
+namespace ecs {
+
+/// Integrate RigidBody acceleration (and damping) into Velocity.
+inline void physicsSystem(Registry& registry, float dt) {
+    registry.view<Velocity, RigidBody>().each([dt](Entity, Velocity& v, RigidBody& rb) {
+        if (rb.kinematic) return;
+        v.linear += rb.acceleration * dt;
+        if (rb.damping > 0.0f) {
+            float factor = 1.0f - rb.damping * dt;
+            if (factor < 0.0f) factor = 0.0f;
+            v.linear *= factor;
+            v.angular *= factor;
+        }
+    });
+}
+
+/// Steer each AIAgent toward its target by writing its Velocity.
+inline void aiSteeringSystem(Registry& registry) {
+    registry.view<Transform, Velocity, AIAgent>().each(
+        [](Entity, Transform& t, Velocity& v, AIAgent& a) {
+            if (!a.active) {
+                v.linear = Vec3{};
+                return;
+            }
+            const Vec3 toTarget = a.target - t.position;
+            if (toTarget.length() > a.arriveRadius) {
+                v.linear = toTarget.normalized() * a.speed;
+            } else {
+                v.linear = Vec3{}; // arrived: hold position
+            }
+        });
+}
+
+/// Integrate Velocity into Transform (position and Euler rotation).
+inline void movementSystem(Registry& registry, float dt) {
+    registry.view<Transform, Velocity>().each([dt](Entity, Transform& t, Velocity& v) {
+        t.position += v.linear * dt;
+        t.rotation += v.angular * dt;
+    });
+}
+
+/// Run the full hot-path pipeline for one fixed step of @p dt seconds.
+inline void stepSimulation(Registry& registry, float dt) {
+    physicsSystem(registry, dt);
+    aiSteeringSystem(registry);
+    movementSystem(registry, dt);
+}
+
+} // namespace ecs
+} // namespace IKore

--- a/tests/test_ecs_systems.cpp
+++ b/tests/test_ecs_systems.cpp
@@ -1,0 +1,141 @@
+// Unit test for the migrated hot-path components + systems - Milestone 8, #142.
+//
+// Verifies the issue's acceptance criteria:
+//   - The migrated components (Transform/Velocity/Physics/AI) run against the new
+//     archetype storage via the systems.
+//   - No behavioral regressions: movement, physics integration, and AI steering
+//     produce the expected results, deterministically.
+//   - The compatibility bridge (Legacy) carries less-frequent/legacy components
+//     through archetype moves without leaking or dangling.
+//
+// Pure standard library + the header-only ECS:
+//   g++ -std=c++17 -I src tests/test_ecs_systems.cpp -o test_ecs_systems
+
+#include "core/ecs/components/Components.h"
+#include "core/ecs/systems/Systems.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::ecs;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-4f) {
+    return std::fabs(a - b) <= eps;
+}
+
+static void testMovement() {
+    Registry world;
+    Entity e = world.create();
+    world.add<Transform>(e, Transform{});
+    world.add<Velocity>(e, Velocity{Vec3{2.0f, 0.0f, 0.0f}, Vec3{}});
+
+    movementSystem(world, 0.5f);
+    CHECK(approx(world.get<Transform>(e).position.x, 1.0f)); // 0 + 2*0.5
+    movementSystem(world, 0.5f);
+    CHECK(approx(world.get<Transform>(e).position.x, 2.0f)); // + 2*0.5
+}
+
+static void testPhysicsIntegration() {
+    Registry world;
+    Entity body = world.create();
+    world.add<Velocity>(body, Velocity{});
+    world.add<RigidBody>(body, RigidBody{Vec3{0.0f, -10.0f, 0.0f}, 1.0f, 0.0f, false});
+
+    physicsSystem(world, 0.1f);
+    CHECK(approx(world.get<Velocity>(body).linear.y, -1.0f)); // 0 + (-10)*0.1
+
+    // Kinematic bodies are not integrated.
+    Entity kin = world.create();
+    world.add<Velocity>(kin, Velocity{});
+    world.add<RigidBody>(kin, RigidBody{Vec3{0.0f, -10.0f, 0.0f}, 1.0f, 0.0f, true});
+    physicsSystem(world, 0.1f);
+    CHECK(approx(world.get<Velocity>(kin).linear.y, 0.0f));
+
+    // Damping reduces velocity.
+    Entity damped = world.create();
+    world.add<Velocity>(damped, Velocity{Vec3{10.0f, 0.0f, 0.0f}, Vec3{}});
+    world.add<RigidBody>(damped, RigidBody{Vec3{}, 1.0f, 1.0f, false});
+    physicsSystem(world, 0.1f); // factor = 1 - 1*0.1 = 0.9
+    CHECK(approx(world.get<Velocity>(damped).linear.x, 9.0f));
+}
+
+static void testAISteeringConverges() {
+    Registry world;
+    Entity agent = world.create();
+    world.add<Transform>(agent, Transform{});
+    world.add<Velocity>(agent, Velocity{});
+    // arriveRadius (0.6) > speed*dt (5 * 0.1 = 0.5) so it settles without oscillating.
+    world.add<AIAgent>(agent, AIAgent{Vec3{10.0f, 0.0f, 0.0f}, 5.0f, 0.6f, true});
+
+    for (int i = 0; i < 60; ++i) stepSimulation(world, 0.1f);
+
+    const Transform& t = world.get<Transform>(agent);
+    const Vec3 toTarget = Vec3{10.0f, 0.0f, 0.0f} - t.position;
+    CHECK(toTarget.length() <= 0.6f);                          // arrived
+    CHECK(approx(world.get<Velocity>(agent).linear.length(), 0.0f)); // and stopped
+    CHECK(t.position.x <= 10.0f + 1e-3f);                      // no wild overshoot
+}
+
+static void testDeterministic() {
+    auto run = [] {
+        Registry world;
+        std::vector<Entity> es;
+        for (int i = 0; i < 16; ++i) {
+            Entity e = world.create();
+            world.add<Transform>(e, Transform{});
+            world.add<Velocity>(e, Velocity{Vec3{static_cast<float>(i), 1.0f, 0.0f}, Vec3{}});
+            es.push_back(e);
+        }
+        for (int s = 0; s < 10; ++s) movementSystem(world, 0.1f);
+        std::vector<float> out;
+        for (Entity e : es) out.push_back(world.get<Transform>(e).position.x);
+        return out;
+    };
+    CHECK(run() == run());
+}
+
+static void testLegacyBridgeSurvivesArchetypeMoves() {
+    Registry world;
+    auto legacyObject = std::make_shared<int>(42); // stand-in for a legacy component
+    CHECK(legacyObject.use_count() == 1);
+
+    Entity e = world.create();
+    world.add<Transform>(e, Transform{});
+    world.add<Legacy>(e, Legacy{legacyObject});
+    CHECK(legacyObject.use_count() == 2); // held by the Legacy component too
+
+    // Adding another component relocates the entity to a new archetype.
+    world.add<Velocity>(e, Velocity{});
+    CHECK(world.get<Legacy>(e).handle.get() == legacyObject.get());
+    CHECK(*std::static_pointer_cast<int>(world.get<Legacy>(e).handle) == 42);
+    CHECK(legacyObject.use_count() == 2); // moved, not copied, through the relocation
+
+    world.destroy(e);
+    CHECK(legacyObject.use_count() == 1); // released on destroy - no leak/dangling
+}
+
+int main() {
+    testMovement();
+    testPhysicsIntegration();
+    testAISteeringConverges();
+    testDeterministic();
+    testLegacyBridgeSurvivesArchetypeMoves();
+
+    if (g_failures == 0) {
+        std::printf("All ECS systems/migration tests passed.\n");
+        return 0;
+    }
+    std::printf("%d ECS systems/migration test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Implements **Milestone 8 / #142** — moves the frequently-updated components onto the data-oriented ECS (#140/#141) as value types and adds the per-frame systems that drive them.

## What's included
- **`components/Components.h`** — `Transform`, `Velocity`, `RigidBody` (physics), `AIAgent` (AI) as dependency-free value components (with a small built-in `Vec3`), so they live in the contiguous SoA columns and stay unit-testable in isolation.
- **`systems/Systems.h`** — `physicsSystem` (accel/damping → velocity), `aiSteeringSystem` (steer toward target → velocity), `movementSystem` (velocity → transform), and `stepSimulation()` running the fixed-order pipeline via `Registry::view<...>().each(...)` — the cache-friendly hot path.
- **Compatibility bridge** — `Legacy { std::shared_ptr<void> }` lets an archetype entity carry an owning, type-erased link to a legacy class-based component during the transition. Ownership rides through archetype moves and releases on destroy.
- **Layering** — the concrete components/systems are kept **out** of the `ECS.h` umbrella (opt-in includes) so generic core users can `using namespace ecs` without clashing with their own `Transform`/`Velocity` types. This also keeps the existing #140/#141 tests compiling.

## Scope
This migrates the hot-path **data layer + systems** and verifies them in isolation. Adopting the new storage at engine call sites (`main.cpp` / renderer loop) is the follow-on, deferred because the full engine (GLFW/Assimp/Bullet/OpenAL) can't be built or validated in the authoring environment.

## Verification
`tests/test_ecs_systems.cpp` (new `test_ecs_systems` target) covers movement, physics integration (including kinematic skip + damping), AI steering convergence, determinism, and the `Legacy` bridge surviving archetype moves with no leak. All three ECS tests (`test_archetype_ecs`, `test_ecs_query`, `test_ecs_systems`) pass locally under `-Wall -Wextra -pedantic` with AddressSanitizer + UBSan. CI's CodeQL `Analyze (c-cpp)` job builds them (the cross-platform `ci.yml` is currently disabled in repo settings).

Closes #142