### PR TITLE
feat(ecs): benchmark archetype ECS vs legacy model + document results (#143)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,12 +281,11 @@ add_executable(test_physics_simple
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/components/PhysicsComponent.cpp
 )
 
-# ECS Benchmark Test executable (simplified)
-add_executable(test_ecs_benchmark 
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ecs_benchmark.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/core/Logger.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/core/Entity.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/core/Component.cpp
+# ECS storage benchmark: legacy model vs archetype ECS (Milestone 8 / #143).
+# Self-contained and header-only (the legacy model is mirrored in the source),
+# so no extra engine sources or deps are needed.
+add_executable(test_ecs_benchmark
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ecs_benchmark.cpp
 )
 
 # OpenAL 3D Audio Test executable
@@ -337,7 +336,6 @@ target_link_libraries(test_mesh_component_geometry PRIVATE glfw glad glm stb_ima
 target_link_libraries(test_material_component PRIVATE glfw glad glm stb_image assimp OpenGL::GL BulletDynamics BulletCollision LinearMath ${OPENAL_LIBRARIES})
 target_link_libraries(test_physics_component PRIVATE glm)
 target_link_libraries(test_physics_simple PRIVATE BulletDynamics BulletCollision LinearMath glm)
-target_link_libraries(test_ecs_benchmark PRIVATE glm)
 target_link_libraries(test_openal_3d_audio PRIVATE glm ${OPENAL_LIBRARIES})
 
 # AI Component Test executable

--- a/docs/ECS_BENCHMARK.md
+++ b/docs/ECS_BENCHMARK.md
@@ -1,0 +1,83 @@
+# ECS Storage Benchmark: Legacy vs. Archetype (Milestone 8 / #143)
+
+This benchmark quantifies the payoff of the data-oriented ECS (issues
+#140-#142) by comparing it against the engine's legacy component model on the
+canonical hot-path workload.
+
+## What is compared
+
+| | Legacy model | Archetype ECS |
+|---|---|---|
+| Storage | Heap-allocated entities, each owning `std::unordered_map<std::type_index, std::shared_ptr<void>>` | Components packed in contiguous, per-type SoA columns grouped by signature |
+| Component access | Hash lookup + `shared_ptr` indirection into scattered heap objects | Direct walk of contiguous arrays via `view<...>().each()` |
+| Source | mirrors `src/core/Entity.h` exactly | `IKore::ecs::Registry` (`src/core/ecs/`) |
+
+The legacy path is reproduced inside the benchmark (rather than `#include`-ing
+`Entity.h`, which pulls in `glm`) so the benchmark is dependency-free and
+runnable in isolation. The data structures and access pattern are identical to
+the real `Entity`, so the cost characteristics match.
+
+## Workload
+
+Integrate velocity into position for every entity (`pos += vel * dt`), repeated
+for N frames, at two entity counts. A checksum of the resulting positions is
+printed for both models and must match (it does), proving the work is real and
+equivalent and isn't elided by the optimizer.
+
+## Methodology
+
+- **Iteration time**: `std::chrono::steady_clock` around the frame loop only
+  (construction excluded). Reported as total ms and ns per component update.
+- **Memory**: resident set size (RSS) delta from `/proc/self/statm`, measured
+  around each model's construction. `malloc_trim(0)` is called before each
+  baseline so freed pages are returned to the OS and the second model's reading
+  is not skewed by the allocator reusing the first model's pages (glibc/Linux).
+- The build is `-O2 -DNDEBUG`. Absolute timings are machine-dependent; the
+  **speedup ratio is the headline** and is stable across runs.
+
+## Results
+
+Representative run (`-O2`, 50 frames; release build, single core):
+
+| Entities | Model | Iter (ms) | ns/update | Memory (MiB) |
+|---:|---|---:|---:|---:|
+| 100,000 | legacy | 273.3 | 54.67 | 41.3 |
+| 100,000 | **archetype** | **5.5** | **1.10** | **6.9** |
+| 1,000,000 | legacy | 3563.2 | 71.26 | 412.0 |
+| 1,000,000 | **archetype** | **59.7** | **1.19** | **61.8** |
+
+**Headline:** the archetype storage iterates roughly **40-60x faster** and uses
+about **6-7x less memory** at high entity counts. The per-update cost is roughly
+flat for the archetype model (~1.1 ns/update) but grows for the legacy model as
+working sets exceed cache (45-70+ ns/update), because every entity costs a hash
+lookup plus pointer chases into scattered heap allocations.
+
+(Exact numbers vary with machine and load - e.g. legacy iteration was measured
+between ~45 and ~71 ns/update across runs - but the archetype model is
+consistently ~1.1 ns/update and ~40-60x faster.)
+
+## Reproduce
+
+```bash
+g++ -std=c++17 -O2 -DNDEBUG -I src tests/test_ecs_benchmark.cpp -o test_ecs_benchmark
+./test_ecs_benchmark           # 50 frames per size
+./test_ecs_benchmark 200       # optional: pass a frame count
+```
+
+Or via CMake (the `test_ecs_benchmark` target builds it; build in Release for
+representative timings):
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build --target test_ecs_benchmark
+./build/test_ecs_benchmark
+```
+
+The program exits non-zero if the archetype model is not faster than the legacy
+model, so it also serves as a coarse performance-regression guard.
+
+## Takeaway
+
+The measured speedup validates the motivation for Milestone 8: the data-oriented
+(archetype/SoA) ECS removes per-entity hashing and pointer-chasing from the hot
+path, which is what makes the large-scale agent simulation in later milestones
+(thousands of agents at frame rate, #152-#155) viable.

--- a/tests/test_ecs_benchmark.cpp
+++ b/tests/test_ecs_benchmark.cpp
@@ -1,57 +1,235 @@
-#include <iostream>
+// ECS storage benchmark - Milestone 8, issue #143.
+//
+// Compares the engine's legacy component model against the new archetype/SoA ECS
+// (issues #140-#142) on the canonical hot-path workload: integrate velocity into
+// position for every entity, repeated for many frames.
+//
+//   Legacy model  - mirrors src/core/Entity.h exactly: heap-allocated entities,
+//                   each owning an std::unordered_map<std::type_index,
+//                   std::shared_ptr<void>>; components are separate heap objects
+//                   reached via a hash lookup + shared_ptr indirection.
+//   Archetype ECS - IKore::ecs::Registry: components packed in contiguous SoA
+//                   columns, iterated with view<...>().each().
+//
+// Reports iteration throughput and resident memory at large entity counts. The
+// legacy path is reproduced here (rather than #include'd) so the benchmark stays
+// dependency-free and runnable in isolation; the data structures and access
+// pattern are identical to the real Entity, so the cost characteristics match.
+//
+// Build (optimized) and run:
+//   g++ -std=c++17 -O2 -I src tests/test_ecs_benchmark.cpp -o test_ecs_benchmark
+//   ./test_ecs_benchmark
+
+#include "core/ecs/Registry.h"
+#include "core/ecs/View.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <memory>
-#include <iomanip>
-#include "src/core/Entity.h"
-// NOTE: Complex benchmark disabled due to graphics/system dependencies
-// #include "src/core/components/TransformComponent.h"
-// #include "src/core/components/VelocityComponent.h"
-// #include "src/core/components/RenderableComponent.h"
-// #include "src/core/ECSBenchmark.h"
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
 
-using namespace IKore;
+#if defined(__linux__)
+#include <unistd.h>
+#endif
+#if defined(__linux__) && defined(__GLIBC__)
+#include <malloc.h>
+#endif
 
-int main() {
-    std::cout << "========================================" << std::endl;
-    std::cout << "      ECS PERFORMANCE BENCHMARK SUITE   " << std::endl;
-    std::cout << "========================================" << std::endl;
-    std::cout << std::endl;
+namespace {
 
-    try {
-        std::cout << "🚀 Starting Simple ECS Performance Test..." << std::endl;
-        std::cout << std::endl;
+constexpr float kDt = 1.0f / 60.0f;
 
-        // Test 1: Basic Entity Creation (the core functionality that was crashing)
-        std::cout << "--- Test 1: Basic Entity Creation ---" << std::endl;
-        
-        std::vector<std::shared_ptr<Entity>> entities;
-        const size_t testCount = 1000;
-        
-        for (size_t i = 0; i < testCount; ++i) {
-            entities.push_back(std::make_shared<Entity>());
-        }
-        
-        std::cout << "✅ Successfully created " << testCount << " entities!" << std::endl;
-        std::cout << "✅ Entity IDs range from 1 to " << entities.back()->getID() << std::endl;
-        
-        // NOTE: Full benchmark functionality disabled due to complex dependencies
-        // The core Entity-Component system has been proven to work in simple tests
-        
-        std::cout << "\n========================================" << std::endl;
-        std::cout << "           BENCHMARK SUMMARY            " << std::endl;
-        std::cout << "========================================" << std::endl;
-        
-        std::cout << "\n🎯 Core ECS functionality verified:" << std::endl;
-        std::cout << "  Entity Creation: ✅ Working perfectly" << std::endl;
-        std::cout << "  Component Attachment: ✅ Working (verified in simple tests)" << std::endl;
-        std::cout << "  Memory Management: ✅ No crashes or leaks detected" << std::endl;
-        
-        std::cout << "\n📋 Note: Full benchmark features disabled due to graphics dependencies" << std::endl;
-        
-        return 0;
-        
-    } catch (const std::exception& e) {
-        std::cerr << "❌ Test failed with exception: " << e.what() << std::endl;
-        return 1;
-    } catch (...) {
+// Return freed pages to the OS so the next RSS baseline is clean (otherwise the
+// allocator reuses just-freed pages and the second model's memory under-reports).
+void trimHeap() {
+#if defined(__linux__) && defined(__GLIBC__)
+    malloc_trim(0);
+#endif
+}
+
+// ---- Shared component payloads (identical size for a fair comparison) --------
+struct Position {
+    float x{0.0f}, y{0.0f}, z{0.0f};
+};
+struct Velocity {
+    float x{1.0f}, y{1.0f}, z{1.0f};
+};
+
+// ---- Legacy model: a faithful replica of src/core/Entity.h's storage --------
+struct LegacyComponent {
+    virtual ~LegacyComponent() = default;
+};
+struct LegacyPosition : LegacyComponent {
+    float x{0.0f}, y{0.0f}, z{0.0f};
+};
+struct LegacyVelocity : LegacyComponent {
+    float x{1.0f}, y{1.0f}, z{1.0f};
+};
+
+class LegacyEntity : public std::enable_shared_from_this<LegacyEntity> {
+public:
+    virtual ~LegacyEntity() = default;
+
+    template <class T, class... Args>
+    std::shared_ptr<T> addComponent(Args&&... args) {
+        auto component = std::make_shared<T>(std::forward<Args>(args)...);
+        m_components[std::type_index(typeid(T))] = component;
+        return component;
     }
+
+    template <class T>
+    std::shared_ptr<T> getComponent() {
+        auto it = m_components.find(std::type_index(typeid(T)));
+        if (it != m_components.end()) return std::static_pointer_cast<T>(it->second);
+        return nullptr;
+    }
+
+    std::uint64_t id{0};
+
+private:
+    std::unordered_map<std::type_index, std::shared_ptr<void>> m_components;
+};
+
+// ---- Helpers ----------------------------------------------------------------
+using Clock = std::chrono::steady_clock;
+
+double msSince(Clock::time_point start) {
+    return std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+}
+
+// Current resident set size in MiB (Linux only; 0 elsewhere).
+double residentMiB() {
+#if defined(__linux__)
+    std::FILE* f = std::fopen("/proc/self/statm", "r");
+    if (!f) return 0.0;
+    long totalPages = 0, residentPages = 0;
+    if (std::fscanf(f, "%ld %ld", &totalPages, &residentPages) != 2) {
+        std::fclose(f);
+        return 0.0;
+    }
+    std::fclose(f);
+    const long pageSize = sysconf(_SC_PAGESIZE);
+    return static_cast<double>(residentPages) * static_cast<double>(pageSize) / (1024.0 * 1024.0);
+#else
+    return 0.0;
+#endif
+}
+
+struct Result {
+    double iterMs{0.0};
+    double memMiB{0.0};
+    double checksum{0.0};
+};
+
+Result benchmarkLegacy(std::size_t count, int frames) {
+    trimHeap();
+    const double before = residentMiB();
+    std::vector<std::shared_ptr<LegacyEntity>> entities;
+    entities.reserve(count);
+    for (std::size_t i = 0; i < count; ++i) {
+        auto e = std::make_shared<LegacyEntity>();
+        e->id = i + 1;
+        e->addComponent<LegacyPosition>();
+        e->addComponent<LegacyVelocity>();
+        entities.push_back(std::move(e));
+    }
+    const double mem = residentMiB() - before;
+
+    const auto start = Clock::now();
+    for (int frame = 0; frame < frames; ++frame) {
+        for (auto& e : entities) {
+            auto p = e->getComponent<LegacyPosition>();
+            auto v = e->getComponent<LegacyVelocity>();
+            p->x += v->x * kDt;
+            p->y += v->y * kDt;
+            p->z += v->z * kDt;
+        }
+    }
+    const double iterMs = msSince(start);
+
+    double checksum = 0.0;
+    for (auto& e : entities) checksum += e->getComponent<LegacyPosition>()->x;
+    return {iterMs, mem, checksum};
+}
+
+Result benchmarkArchetype(std::size_t count, int frames) {
+    using namespace IKore::ecs;
+    trimHeap();
+    const double before = residentMiB();
+    Registry world;
+    for (std::size_t i = 0; i < count; ++i) {
+        Entity e = world.create();
+        world.add<Position>(e, Position{});
+        world.add<Velocity>(e, Velocity{});
+    }
+    const double mem = residentMiB() - before;
+
+    const auto start = Clock::now();
+    for (int frame = 0; frame < frames; ++frame) {
+        world.view<Position, Velocity>().each([](Entity, Position& p, Velocity& v) {
+            p.x += v.x * kDt;
+            p.y += v.y * kDt;
+            p.z += v.z * kDt;
+        });
+    }
+    const double iterMs = msSince(start);
+
+    double checksum = 0.0;
+    world.view<Position>().each([&checksum](Entity, Position& p) { checksum += p.x; });
+    return {iterMs, mem, checksum};
+}
+
+// Returns the iteration speedup (legacy / archetype) for this size.
+double runSize(std::size_t count, int frames) {
+    const Result legacy = benchmarkLegacy(count, frames);
+    const Result archetype = benchmarkArchetype(count, frames);
+
+    const double updates = static_cast<double>(count) * frames;
+    const double legacyNsPer = legacy.iterMs * 1e6 / updates;
+    const double archNsPer = archetype.iterMs * 1e6 / updates;
+    const double speedup = legacy.iterMs / archetype.iterMs;
+
+    std::printf("\nEntities: %zu  |  Frames: %d  |  Updates: %.0f\n", count, frames, updates);
+    std::printf("  %-12s %12s %12s %12s\n", "model", "iter (ms)", "ns/update", "mem (MiB)");
+    std::printf("  %-12s %12.1f %12.2f %12.1f\n", "legacy", legacy.iterMs, legacyNsPer, legacy.memMiB);
+    std::printf("  %-12s %12.1f %12.2f %12.1f\n", "archetype", archetype.iterMs, archNsPer,
+                archetype.memMiB);
+    std::printf("  -> iteration speedup: %.1fx", speedup);
+    if (legacy.memMiB > 0.0 && archetype.memMiB > 0.0) {
+        std::printf("   |   memory: %.1fx less\n", legacy.memMiB / archetype.memMiB);
+    } else {
+        std::printf("\n");
+    }
+    // Guard against the optimizer discarding the work (checksums should match).
+    std::printf("  (checksum legacy=%.3f archetype=%.3f)\n", legacy.checksum, archetype.checksum);
+    return speedup;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::printf("========================================\n");
+    std::printf("   ECS storage benchmark (legacy vs archetype)\n");
+    std::printf("   Milestone 8 / #143\n");
+    std::printf("========================================\n");
+
+    int frames = 50;
+    if (argc > 1) frames = std::atoi(argv[1]);
+
+    const double speedupSmall = runSize(100000, frames);
+    const double speedupLarge = runSize(1000000, frames);
+
+    std::printf("\nNote: absolute timings are machine-dependent; the speedup ratio is the\n");
+    std::printf("headline. Build with -O2 for representative numbers.\n");
+
+    // Doubles as a regression guard: the archetype storage must iterate faster.
+    if (speedupSmall <= 1.0 || speedupLarge <= 1.0) {
+        std::printf("\nREGRESSION: archetype storage was not faster than the legacy model.\n");
+        return 1;
+    }
+    return 0;
 }


### PR DESCRIPTION
Implements **Milestone 8 / #143** — replaces the stubbed ECS benchmark with a real legacy-vs-archetype comparison and documents the results. Closes out Milestone 8.

## What's included
- **`tests/test_ecs_benchmark.cpp`** — benchmarks the hot-path workload (integrate velocity into position over many frames, at 100k and 1M entities):
  - **Legacy path** mirrors `src/core/Entity.h` exactly (heap entities + per-entity `unordered_map<type_index, shared_ptr<void>>`).
  - **Archetype path** uses the new `ecs::Registry` with `view<...>().each()` over contiguous SoA columns.
  - Measures iteration time (ns/update) and resident memory (RSS via `/proc/self/statm`, with `malloc_trim` between models for clean deltas). Matching checksums prove the work is equivalent and not optimized away.
  - Exits non-zero if the archetype model isn't faster → a coarse performance-regression guard.
- **`docs/ECS_BENCHMARK.md`** — methodology, a representative results table, and the reproduction command.
- **CMake** — simplified the `test_ecs_benchmark` target to the now self-contained source (dropped the old `Entity`/`Component`/`Logger` sources and the `glm` link).

## Measured results (`-O2`, real run)
| Entities | Legacy | Archetype | Speedup | Memory |
|---:|---:|---:|---:|---:|
| 100k | 273 ms (54.7 ns/update) | 5.5 ms (1.10 ns/update) | ~50x | 6.0x less |
| 1M | 3563 ms (71.3 ns/update) | 59.7 ms (1.19 ns/update) | ~60x | 6.7x less |

So the archetype storage iterates **~40-60x faster** and uses **~6-7x less memory** at high entity counts (≈1.1 ns/update flat, vs 45-70+ ns/update for the legacy hash-lookup + pointer-chase path). Absolute timings are machine-dependent; the ratio is stable.

## Verification
Built and run locally at `-O2`; exits 0 with the speedups above. CI's CodeQL `Analyze (c-cpp)` job compiles it (the cross-platform `ci.yml` is currently disabled in repo settings; CodeQL does not run the binary).

Closes #143