### PR TITLE
feat(ui): integrate Dear ImGui as the in-engine debug UI foundation (#144)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,25 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(bullet3)
 
+# Dear ImGui (docking branch) for the in-engine editor/debug UI (#144).
+# ImGui ships as source with no CMakeLists, so MakeAvailable only populates it;
+# its sources and the GLFW + OpenGL3 backends are compiled into the IKore target.
+FetchContent_Declare(
+  imgui
+  GIT_REPOSITORY https://github.com/ocornut/imgui.git
+  GIT_TAG        docking
+)
+FetchContent_MakeAvailable(imgui)
+set(IMGUI_SOURCES
+  ${imgui_SOURCE_DIR}/imgui.cpp
+  ${imgui_SOURCE_DIR}/imgui_draw.cpp
+  ${imgui_SOURCE_DIR}/imgui_tables.cpp
+  ${imgui_SOURCE_DIR}/imgui_widgets.cpp
+  ${imgui_SOURCE_DIR}/imgui_demo.cpp
+  ${imgui_SOURCE_DIR}/backends/imgui_impl_glfw.cpp
+  ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
+)
+
 # OpenAL for 3D Audio
 find_package(PkgConfig)
 if(PkgConfig_FOUND)
@@ -194,9 +213,13 @@ set(ENGINE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CameraComponent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/EnhancedCameraEntity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Serialization.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ui/DebugUI.cpp
 )
 
-add_executable(IKore ${ENGINE_SOURCES} ${CORE_SOURCES} ${SCENE_SOURCES} ${AUDIO_SOURCES})
+add_executable(IKore ${ENGINE_SOURCES} ${CORE_SOURCES} ${SCENE_SOURCES} ${AUDIO_SOURCES} ${IMGUI_SOURCES})
+
+# Dear ImGui headers (core + backends) for the IKore target (#144)
+target_include_directories(IKore PRIVATE ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)
 
 # Scene Graph Test executable
 add_executable(test_scene_graph 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include "Serialization.h"
 #include "core/EntityRegistration.h"
 #include "core/EntityDebugSystem.h"
+#include "ui/DebugUI.h"
 
 // Forward declarations for GLFW callbacks
 void framebuffer_size_callback(GLFWwindow* window, int width, int height);
@@ -52,8 +53,11 @@ IKore::CameraController cameraController(camera);
 // Global post-processor pointer for keyboard callbacks
 IKore::PostProcessor* g_postProcessor = nullptr;
 
-// Global skybox pointer for keyboard callbacks  
+// Global skybox pointer for keyboard callbacks
 IKore::Skybox* g_skybox = nullptr;
+
+// Global debug UI pointer for keyboard callbacks (F1 toggles the overlay)
+IKore::DebugUI* g_debugUI = nullptr;
 
 // Global particle system manager for keyboard callbacks
 IKore::ParticleSystemManager* g_particleManager = nullptr;
@@ -130,6 +134,12 @@ int main() {
         return -1;
     }
     LOG_INFO("GLAD initialized successfully");
+
+    // Initialize the in-engine debug UI (Dear ImGui). GL context is 3.3 core,
+    // so the GL3 backend uses GLSL "#version 330". Starts hidden; F1 toggles it.
+    IKore::DebugUI debugUI;
+    debugUI.initialize(window, "#version 330");
+    g_debugUI = &debugUI;
 
     glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
     glEnable(GL_DEPTH_TEST);
@@ -936,6 +946,9 @@ int main() {
         // Render Entity Debug Overlay (after all scene rendering)
         IKore::getEntityDebugSystem().renderDebugOverlay();
 
+        // Render the Dear ImGui debug overlay on top (no-op while hidden)
+        debugUI.render(static_cast<float>(deltaTime));
+
         glfwSwapBuffers(window);
 
         // Frame timing to cap FPS
@@ -959,6 +972,8 @@ int main() {
     entityManager.clear();
 
     LOG_INFO("Shutting down IKore Engine");
+    g_debugUI = nullptr;
+    debugUI.shutdown();
     glfwDestroyWindow(window);
     glfwTerminate();
     return 0;
@@ -1002,6 +1017,11 @@ void framebuffer_size_callback(GLFWwindow* /*window*/, int width, int height) {
 // Keyboard callback for toggling post-processing effects
 void key_callback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int /*mods*/) {
     if (action == GLFW_PRESS) {
+        if (key == GLFW_KEY_F1 && g_debugUI) {
+            // Toggle the in-engine debug UI overlay
+            g_debugUI->toggle();
+            LOG_INFO(std::string("Debug UI ") + (g_debugUI->isVisible() ? "shown" : "hidden"));
+        }
         if (key == GLFW_KEY_1 && g_postProcessor) {
             // Toggle Bloom
             auto* bloom = g_postProcessor->getBloomEffect();

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -1,0 +1,93 @@
+#include "ui/DebugUI.h"
+
+#include "imgui.h"
+#include "imgui_impl_glfw.h"
+#include "imgui_impl_opengl3.h"
+
+#include "core/Logger.h"
+
+namespace IKore {
+
+bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
+    if (m_initialized) return true;
+    if (window == nullptr) return false;
+
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+
+    ImGuiIO& io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable; // allow panels to be docked together
+
+    ImGui::StyleColorsDark();
+
+    if (!ImGui_ImplGlfw_InitForOpenGL(window, /*install_callbacks=*/true)) {
+        LOG_ERROR("DebugUI: ImGui GLFW backend init failed");
+        ImGui::DestroyContext();
+        return false;
+    }
+    if (!ImGui_ImplOpenGL3_Init(glslVersion)) {
+        LOG_ERROR("DebugUI: ImGui OpenGL3 backend init failed");
+        ImGui_ImplGlfw_Shutdown();
+        ImGui::DestroyContext();
+        return false;
+    }
+
+    m_initialized = true;
+    LOG_INFO("DebugUI: Dear ImGui initialized (press F1 to toggle)");
+    return true;
+}
+
+void DebugUI::shutdown() {
+    if (!m_initialized) return;
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext();
+    m_initialized = false;
+}
+
+void DebugUI::render(float deltaTimeSeconds) {
+    // Hidden or uninitialized overlay costs nothing.
+    if (!m_initialized || !m_visible) return;
+
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplGlfw_NewFrame();
+    ImGui::NewFrame();
+
+    buildUI(deltaTimeSeconds);
+
+    ImGui::Render();
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+}
+
+void DebugUI::buildUI(float deltaTimeSeconds) {
+    const ImGuiIO& io = ImGui::GetIO();
+
+    ImGui::Begin("IKore Debug");
+    ImGui::TextUnformatted("IKore Engine - in-engine debug UI");
+    ImGui::Separator();
+
+    ImGui::Text("FPS: %.1f  (%.3f ms/frame)", io.Framerate,
+                io.Framerate > 0.0f ? 1000.0f / io.Framerate : 0.0f);
+    ImGui::Text("Frame delta: %.3f ms", deltaTimeSeconds * 1000.0f);
+
+    ImGui::Separator();
+    ImGui::TextUnformatted("Planned panels (Milestone 9):");
+    ImGui::BulletText("FPS / performance overlay (#53)");
+    ImGui::BulletText("Debug console (#54)");
+    ImGui::BulletText("HUD / menus (#55, #58)");
+    ImGui::BulletText("Entity inspector (#56)");
+    ImGui::BulletText("Scene hierarchy viewer (#59)");
+    ImGui::BulletText("Input remapping (#60)");
+    ImGui::TextDisabled("Docking is enabled: drag a window onto another to dock it.");
+
+    ImGui::Separator();
+    ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
+    ImGui::End();
+
+    if (m_showDemoWindow) {
+        ImGui::ShowDemoWindow(&m_showDemoWindow);
+    }
+}
+
+} // namespace IKore

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -1,0 +1,56 @@
+#pragma once
+
+struct GLFWwindow;
+
+/**
+ * @file DebugUI.h
+ * @brief Dear ImGui integration: the foundation for in-engine editor/debug UI.
+ *
+ * Milestone 9 (issue #144). Wraps ImGui setup, per-frame rendering, and teardown
+ * behind a small interface so the engine's main loop only needs a few lines.
+ * Docking is enabled (ImGuiConfigFlags_DockingEnable) so the panels added by the
+ * follow-on issues (#53-#63: FPS overlay, console, entity inspector, scene
+ * hierarchy, input remapping, HUD) can be docked into a layout.
+ *
+ * The overlay is toggleable and starts hidden; when hidden, render() returns
+ * immediately so there is no per-frame ImGui cost.
+ */
+namespace IKore {
+
+class DebugUI {
+public:
+    /**
+     * @brief Initialize ImGui and its GLFW + OpenGL3 backends.
+     * @param window       The GLFW window owning the current GL context.
+     * @param glslVersion  GLSL #version string for the GL3 backend (e.g. "#version 330").
+     * @return true on success.
+     *
+     * Call after the GL context is current and the loader is initialized.
+     */
+    bool initialize(GLFWwindow* window, const char* glslVersion);
+
+    /// Tear down the ImGui backends and context. Safe to call if not initialized.
+    void shutdown();
+
+    /**
+     * @brief Build and draw the debug UI for this frame.
+     * @param deltaTimeSeconds Frame delta, shown in the stats panel.
+     *
+     * No-op (returns immediately) when the overlay is hidden or uninitialized,
+     * so a hidden overlay costs nothing.
+     */
+    void render(float deltaTimeSeconds);
+
+    void setVisible(bool visible) { m_visible = visible; }
+    bool isVisible() const { return m_visible; }
+    void toggle() { m_visible = !m_visible; }
+
+private:
+    void buildUI(float deltaTimeSeconds);
+
+    bool m_initialized{false};
+    bool m_visible{false};
+    bool m_showDemoWindow{false};
+};
+
+} // namespace IKore


### PR DESCRIPTION
Implements **Milestone 9 / #144** — the Dear ImGui integration that the rest of the M9 panels (#53–#63) build on.

## What's included
- **CMake** — FetchContent the ImGui **docking** branch and compile its core + GLFW/OpenGL3 backends into the `IKore` target, with the ImGui include dirs. (ImGui ships as source with no CMakeLists, so `MakeAvailable` only populates it.)
- **`src/ui/DebugUI.{h,cpp}`** — a small wrapper over ImGui init / per-frame render / teardown. Docking is enabled (`ImGuiConfigFlags_DockingEnable`) so panels can be docked into a layout. The overlay **starts hidden** and `render()` returns immediately while hidden, so a hidden overlay has no per-frame ImGui cost.
- **`main.cpp`** — initialize after GLAD (GL 3.3 core → GLSL `#version 330`), render the overlay each frame just before `glfwSwapBuffers`, shut it down before window destroy, and toggle it with **F1** (global `g_debugUI`, mirroring `g_postProcessor`/`g_skybox`).
- The overlay shows live FPS / frame-time plus a placeholder list of the panels #53–#63 will fill in, and an optional ImGui demo window for verification.

## Acceptance criteria
- *Renders over the scene, toggleable* — drawn after scene rendering, just before buffer swap; F1 toggles visibility.
- *No measurable frame-rate impact when hidden* — `render()` early-returns while hidden, so zero ImGui new-frame/draw work happens.

## Verification note (please read)
The full engine (GLFW/Assimp/Bullet/OpenAL + a live GL context) **cannot be built or run in the authoring environment**, so this change could not be compiled or visually verified locally. It follows the canonical ImGui GLFW+GL3 setup and the `DebugUI` header parses standalone. **CI's CodeQL `Analyze (c-cpp)` job runs the full `cmake && make`, which is the compile check here** (the cross-platform `ci.yml` is disabled in repo settings; CodeQL does not run the binary). The runtime acceptance (renders over the scene, F1 toggles, no FPS impact when hidden) should be confirmed with a local run.