### PR TITLE
feat(scripting): embed Lua (sol2) bound to the ECS + EventSystem (#145)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,37 @@ set(IMGUI_SOURCES
   ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
 )
 
+# Lua + sol2 for the scripting layer (#145).
+# The lua/lua repo ships no CMakeLists, so MakeAvailable only populates it and we
+# build the library ourselves from its .c files (excluding the standalone
+# interpreter lua.c, the compiler luac.c, and the all-in-one amalgam onelua.c).
+FetchContent_Declare(
+  lua
+  GIT_REPOSITORY https://github.com/lua/lua.git
+  GIT_TAG        v5.4.6
+)
+FetchContent_MakeAvailable(lua)
+file(GLOB LUA_LIB_SOURCES "${lua_SOURCE_DIR}/*.c")
+list(REMOVE_ITEM LUA_LIB_SOURCES
+  "${lua_SOURCE_DIR}/lua.c"
+  "${lua_SOURCE_DIR}/luac.c"
+  "${lua_SOURCE_DIR}/onelua.c")
+add_library(lua_static STATIC ${LUA_LIB_SOURCES})
+target_include_directories(lua_static PUBLIC ${lua_SOURCE_DIR})
+set_target_properties(lua_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# sol2 is header-only; populate it and use its include dir directly (avoid running
+# sol2's own CMake, which would try to locate a Lua install for its targets).
+FetchContent_Declare(
+  sol2
+  GIT_REPOSITORY https://github.com/ThePhd/sol2.git
+  GIT_TAG        v3.3.0
+)
+FetchContent_GetProperties(sol2)
+if(NOT sol2_POPULATED)
+  FetchContent_Populate(sol2)
+endif()
+
 # OpenAL for 3D Audio
 find_package(PkgConfig)
 if(PkgConfig_FOUND)
@@ -421,6 +452,19 @@ add_executable(test_ecs_query
 add_executable(test_ecs_systems
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ecs_systems.cpp
 )
+
+# Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
+# static lib and uses sol2 (header-only) + the header-only ECS.
+add_executable(test_scripting
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_scripting.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/scripting/ScriptSystem.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/core/EventSystem.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/core/Logger.cpp
+)
+target_include_directories(test_scripting PRIVATE
+    ${sol2_SOURCE_DIR}/include
+    ${lua_SOURCE_DIR})
+target_link_libraries(test_scripting PRIVATE lua_static)
 
 if(MSVC)
     target_compile_options(IKore PRIVATE /W4)

--- a/assets/scripts/sample.lua
+++ b/assets/scripts/sample.lua
@@ -1,0 +1,24 @@
+-- Sample IKore script (Milestone 10 / #145) showing the Lua API surface.
+-- Run via ScriptSystem::runFile("assets/scripts/sample.lua").
+
+-- Create an entity and give it a transform.
+local player = world.create()
+world.add_transform(player)
+
+local t = world.get_transform(player)
+t.position = Vec3.new(0, 1, 0)
+world.set_transform(player, t)
+
+-- Give it a velocity.
+world.add_velocity(player, Velocity.new())
+local v = world.get_velocity(player)
+v.linear = Vec3.new(1, 0, 0)
+world.set_velocity(player, v)
+
+-- Subscribe to an event, then emit one.
+events.on("player_spawned", function(id)
+    print("player_spawned received, id = " .. id)
+end)
+events.emit("player_spawned", 1)
+
+print("entities with a transform: " .. world.transform_count())

--- a/src/scripting/ScriptSystem.cpp
+++ b/src/scripting/ScriptSystem.cpp
@@ -1,0 +1,127 @@
+#include "scripting/ScriptSystem.h"
+
+#define SOL_ALL_SAFETIES_ON 1
+#include <sol/sol.hpp>
+
+#include "core/Logger.h"
+#include "core/ecs/View.h"
+
+namespace IKore {
+
+using namespace IKore::ecs;
+
+ScriptSystem::ScriptSystem() : m_lua(std::make_unique<sol::state>()) {
+    m_lua->open_libraries(sol::lib::base, sol::lib::math, sol::lib::string, sol::lib::table);
+    registerBindings();
+}
+
+ScriptSystem::~ScriptSystem() {
+    // Release event hooks BEFORE the Lua state is destroyed: the subscription
+    // callbacks hold Lua functions, and the global EventSystem outlives us.
+    EventSystem& events = EventSystem::getInstance();
+    for (const EventSubscription& sub : m_subscriptions) {
+        events.unsubscribe(sub);
+    }
+    m_subscriptions.clear();
+}
+
+bool ScriptSystem::runString(const std::string& code, std::string* errorOut) {
+    sol::protected_function_result result = m_lua->safe_script(code, sol::script_pass_on_error);
+    if (!result.valid()) {
+        sol::error err = result;
+        if (errorOut) *errorOut = err.what();
+        LOG_ERROR(std::string("ScriptSystem: ") + err.what());
+        return false;
+    }
+    return true;
+}
+
+bool ScriptSystem::runFile(const std::string& path, std::string* errorOut) {
+    sol::protected_function_result result = m_lua->safe_script_file(path, sol::script_pass_on_error);
+    if (!result.valid()) {
+        sol::error err = result;
+        if (errorOut) *errorOut = err.what();
+        LOG_ERROR(std::string("ScriptSystem: ") + err.what());
+        return false;
+    }
+    return true;
+}
+
+void ScriptSystem::registerBindings() {
+    sol::state& lua = *m_lua;
+
+    // --- Component value types --------------------------------------------
+    lua.new_usertype<Vec3>("Vec3",
+        sol::factories(
+            []() { return Vec3{}; },
+            [](float x, float y, float z) { return Vec3{x, y, z}; }),
+        "x", &Vec3::x, "y", &Vec3::y, "z", &Vec3::z);
+
+    lua.new_usertype<Transform>("Transform",
+        sol::factories([]() { return Transform{}; }),
+        "position", &Transform::position,
+        "rotation", &Transform::rotation,
+        "scale", &Transform::scale);
+
+    lua.new_usertype<Velocity>("Velocity",
+        sol::factories([]() { return Velocity{}; }),
+        "linear", &Velocity::linear,
+        "angular", &Velocity::angular);
+
+    // Entity is an opaque handle (index + generation), read-only from Lua.
+    lua.new_usertype<Entity>("Entity",
+        "index", sol::readonly(&Entity::index),
+        "generation", sol::readonly(&Entity::generation));
+
+    // --- world: entity + component API ------------------------------------
+    sol::table world = lua["world"].get_or_create<sol::table>();
+    world.set_function("create", [this]() { return m_registry.create(); });
+    world.set_function("destroy", [this](Entity e) { m_registry.destroy(e); });
+    world.set_function("valid", [this](Entity e) { return m_registry.isValid(e); });
+
+    world.set_function("add_transform", [this](Entity e, sol::optional<Transform> t) {
+        m_registry.add<Transform>(e, t.value_or(Transform{}));
+    });
+    world.set_function("has_transform", [this](Entity e) { return m_registry.has<Transform>(e); });
+    world.set_function("get_transform", [this](Entity e) { return m_registry.get<Transform>(e); });
+    world.set_function("set_transform", [this](Entity e, Transform t) {
+        if (m_registry.has<Transform>(e)) m_registry.get<Transform>(e) = t;
+    });
+
+    world.set_function("add_velocity", [this](Entity e, sol::optional<Velocity> v) {
+        m_registry.add<Velocity>(e, v.value_or(Velocity{}));
+    });
+    world.set_function("has_velocity", [this](Entity e) { return m_registry.has<Velocity>(e); });
+    world.set_function("get_velocity", [this](Entity e) { return m_registry.get<Velocity>(e); });
+    world.set_function("set_velocity", [this](Entity e, Velocity v) {
+        if (m_registry.has<Velocity>(e)) m_registry.get<Velocity>(e) = v;
+    });
+
+    world.set_function("transform_count",
+                       [this]() { return static_cast<int>(m_registry.view<Transform>().count()); });
+
+    // --- events: bridge to the engine EventSystem -------------------------
+    sol::table events = lua["events"].get_or_create<sol::table>();
+    events.set_function("emit", sol::overload(
+        [](const std::string& name) { EventSystem::getInstance().publish<double>(name, 0.0); },
+        [](const std::string& name, double value) {
+            EventSystem::getInstance().publish<double>(name, value);
+        }));
+    events.set_function("on", [this](const std::string& name, sol::protected_function callback) {
+        EventSubscription sub = EventSystem::getInstance().subscribe(
+            name, [callback](const std::shared_ptr<EventData>& data) {
+                double value = 0.0;
+                if (auto typed = std::dynamic_pointer_cast<TypedEventData<double>>(data)) {
+                    value = typed->data;
+                }
+                sol::protected_function_result r = callback(value);
+                if (!r.valid()) {
+                    sol::error err = r;
+                    LOG_ERROR(std::string("ScriptSystem event handler: ") + err.what());
+                }
+            });
+        m_subscriptions.push_back(sub);
+    });
+}
+
+} // namespace IKore

--- a/src/scripting/ScriptSystem.h
+++ b/src/scripting/ScriptSystem.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "core/EventSystem.h"
+#include "core/ecs/Registry.h"
+#include "core/ecs/components/Components.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+/**
+ * @file ScriptSystem.h
+ * @brief Lua scripting layer (sol2) bound to the data-oriented ECS + EventSystem.
+ *
+ * Milestone 10 (issue #145). Embeds a Lua VM and exposes a small, clean API so
+ * scripts can create entities, read/write components, and emit/subscribe to
+ * events. The implementation detail (sol2/Lua) is hidden behind this header
+ * (sol::state is held via a forward-declared pimpl), so including this file does
+ * not pull in Lua or sol2 - the scripting layer stays optional and isolated.
+ *
+ * Scripts operate on a ScriptSystem-owned ecs::Registry. (The live engine is not
+ * yet driven by the new ECS - that is the deferred #142 follow-on - so for now
+ * scripting drives its own world.)
+ *
+ * Lua API exposed (see ScriptSystem.cpp for the bindings):
+ *   world.create() -> Entity
+ *   world.destroy(e) / world.valid(e)
+ *   world.add_transform(e[, Transform]) / has_transform(e) / get_transform(e) / set_transform(e, t)
+ *   world.add_velocity(e[, Velocity]) / has_velocity(e) / get_velocity(e) / set_velocity(e, v)
+ *   world.transform_count()
+ *   Vec3.new(x,y,z) / Transform.new() / Velocity.new()
+ *   events.emit(name[, number]) / events.on(name, function(number))
+ */
+namespace sol { class state; }
+
+namespace IKore {
+
+class ScriptSystem {
+public:
+    ScriptSystem();
+    ~ScriptSystem();
+
+    ScriptSystem(const ScriptSystem&) = delete;
+    ScriptSystem& operator=(const ScriptSystem&) = delete;
+
+    /// Run a chunk of Lua source. Returns false and sets @p errorOut on error.
+    bool runString(const std::string& code, std::string* errorOut = nullptr);
+
+    /// Run a Lua file. Returns false and sets @p errorOut on error.
+    bool runFile(const std::string& path, std::string* errorOut = nullptr);
+
+    /// The world that scripts manipulate.
+    ecs::Registry& registry() { return m_registry; }
+
+    /// Access the underlying Lua state (for host-side inspection/tests).
+    sol::state& lua() { return *m_lua; }
+
+private:
+    void registerBindings();
+
+    ecs::Registry m_registry;
+    std::unique_ptr<sol::state> m_lua;
+    std::vector<EventSubscription> m_subscriptions; // event hooks to release on destroy
+};
+
+} // namespace IKore

--- a/tests/test_scripting.cpp
+++ b/tests/test_scripting.cpp
@@ -1,0 +1,83 @@
+// Test for the Lua scripting layer (sol2 + ecs) - Milestone 10, issue #145.
+//
+// Runs a Lua script through ScriptSystem and verifies, from the C++ side, that
+// it created an entity, wrote/read components, and that an emitted event reached
+// a Lua subscriber. Demonstrates the issue's acceptance criteria.
+//
+// NOTE: requires Lua + sol2 (fetched by CMake). It cannot be built or run in the
+// authoring sandbox (no Lua, the proxy blocks fetching it); CI's CodeQL build
+// compiles it. Run it locally to exercise the runtime behavior:
+//   cmake --build build --target test_scripting && ./build/test_scripting
+
+#include "scripting/ScriptSystem.h"
+
+#include <sol/sol.hpp>
+
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+int main() {
+    ScriptSystem script;
+
+    const char* code = R"LUA(
+        e = world.create()
+
+        world.add_transform(e)
+        local t = world.get_transform(e)
+        t.position = Vec3.new(5, 6, 7)
+        world.set_transform(e, t)
+
+        world.add_velocity(e, Velocity.new())
+        local v = world.get_velocity(e)
+        v.linear = Vec3.new(1, 0, 0)
+        world.set_velocity(e, v)
+
+        count = world.transform_count()
+
+        received = -1
+        events.on("ping", function(n) received = n end)
+        events.emit("ping", 42)
+    )LUA";
+
+    std::string err;
+    const bool ok = script.runString(code, &err);
+    CHECK(ok);
+    if (!ok) std::printf("script error: %s\n", err.c_str());
+
+    // Verify the script's effects through the C++ ECS registry.
+    ecs::Entity e = script.lua()["e"].get<ecs::Entity>();
+    CHECK(script.registry().isValid(e));
+    CHECK(script.registry().has<ecs::Transform>(e));
+    CHECK(script.registry().has<ecs::Velocity>(e));
+
+    const ecs::Transform& t = script.registry().get<ecs::Transform>(e);
+    CHECK(t.position.x == 5.0f);
+    CHECK(t.position.y == 6.0f);
+    CHECK(t.position.z == 7.0f);
+
+    const ecs::Velocity& v = script.registry().get<ecs::Velocity>(e);
+    CHECK(v.linear.x == 1.0f);
+
+    // Verify values observed on the Lua side.
+    CHECK(script.lua()["count"].get<int>() == 1);
+    CHECK(script.lua()["received"].get<double>() == 42.0);
+
+    if (g_failures == 0) {
+        std::printf("All scripting tests passed.\n");
+        return 0;
+    }
+    std::printf("%d scripting test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Implements **Milestone 10 / #145** — an optional, isolated Lua scripting layer so scripts can create entities, read/write components, and emit/subscribe to events.

## What's included
- **CMake** — FetchContent **Lua** (built into `lua_static` from `lua/lua`, which ships no CMakeLists: glob its `.c` minus `lua.c`/`luac.c`/`onelua.c`) and **sol2** (header-only, populated and used via its include dir; sol2's own CMake is intentionally not run).
- **`src/scripting/ScriptSystem.{h,cpp}`** — a Lua VM (sol2) bound to the new `ecs::Registry` (entities + `Transform`/`Velocity`/`Vec3`) and the engine `EventSystem` (`events.emit` / `events.on`). sol2/Lua are hidden behind the header via a forward-declared `sol::state` pimpl, so including the header pulls in neither — the layer stays optional and isolated. Event hooks are released in the destructor before the Lua state dies (the global `EventSystem` outlives the `ScriptSystem`).
- Scripts drive a `ScriptSystem`-owned `Registry` (the live engine isn't on the new ECS yet — the deferred #142 follow-on).
- **`tests/test_scripting.cpp`** (new `test_scripting` target) runs a Lua script and verifies entity/component writes via the C++ registry plus an event delivered to a Lua handler; **`assets/scripts/sample.lua`** shows the API.

## Verification note (please read)
There is no Lua in the authoring environment and the proxy blocks fetching it, so this **could not be compiled or run locally**. The `ScriptSystem` header was verified to be self-contained (no sol2/lua leak). **CI's CodeQL `Analyze (c-cpp)` job runs the full build**, which is the compile check for the Lua static lib + sol2 bindings (the cross-platform `ci.yml` is disabled in repo settings; CodeQL does not execute the test). The runtime behavior should be confirmed with a local run of `test_scripting`.

Closes #145