### PR TITLE
feat(core): hot-reload file watcher for scripts/shaders/assets (#146)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,11 @@ add_executable(test_ecs_systems
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ecs_systems.cpp
 )
 
+# Hot-reload file watcher test (Milestone 10 / #146) - header-only, std::filesystem
+add_executable(test_file_watcher
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_file_watcher.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/FileWatcher.h
+++ b/src/core/FileWatcher.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <system_error>
+#include <vector>
+
+/**
+ * @file FileWatcher.h
+ * @brief Polling file watcher: the mechanism behind hot reload (issue #146).
+ *
+ * Milestone 10. Register files with a reload callback and call poll() each frame
+ * (or every few frames). When a watched file's modification time advances - or a
+ * missing file appears - its callback fires. Callbacks are where the engine
+ * actually reloads the resource:
+ *
+ *   watcher.watch("assets/scripts/ai.lua",  [&](auto& p){ scripts.runFile(p); });
+ *   watcher.watch("src/shaders/phong.frag", [&](auto& p){ shader.reload(); });
+ *   watcher.watch("assets/textures/wall.png",[&](auto& p){ texture.reload(); });
+ *
+ * Reload failures must not take down the engine: a callback that throws is
+ * caught and reported through the error handler, and poll() keeps going. This is
+ * a portable, dependency-free polling watcher (std::filesystem) - chosen over
+ * inotify/ReadDirectoryChangesW so the same code runs on every platform.
+ */
+namespace IKore {
+
+class FileWatcher {
+public:
+    using Callback = std::function<void(const std::string& path)>;
+    using ErrorHandler = std::function<void(const std::string& path, const std::string& message)>;
+
+    FileWatcher() : m_onError(defaultErrorHandler()) {}
+
+    /// Replace the error reporter (defaults to printing to stderr).
+    void setErrorHandler(ErrorHandler handler) {
+        m_onError = handler ? std::move(handler) : defaultErrorHandler();
+    }
+
+    /**
+     * @brief Watch @p path; @p onChange fires when its mtime advances (or it
+     *        appears after being missing). Returns an id for unwatch().
+     *
+     * The current mtime is recorded now, so an unmodified file does not fire on
+     * the first poll().
+     */
+    std::size_t watch(const std::string& path, Callback onChange) {
+        Entry entry;
+        entry.id = m_nextId++;
+        entry.path = std::filesystem::path(path);
+        entry.onChange = std::move(onChange);
+
+        std::error_code ec;
+        const auto time = std::filesystem::last_write_time(entry.path, ec);
+        if (!ec) {
+            entry.exists = true;
+            entry.lastWrite = time;
+        } else {
+            entry.exists = false; // watch a not-yet-created file; fires when it appears
+        }
+        m_entries.push_back(std::move(entry));
+        return m_entries.back().id;
+    }
+
+    /// Stop watching the file registered under @p id. Returns true if removed.
+    bool unwatch(std::size_t id) {
+        for (auto it = m_entries.begin(); it != m_entries.end(); ++it) {
+            if (it->id == id) {
+                m_entries.erase(it);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Check every watched file and fire callbacks for those that changed.
+    void poll() {
+        for (Entry& entry : m_entries) {
+            std::error_code ec;
+            const bool exists = std::filesystem::exists(entry.path, ec);
+            if (ec) {
+                report(entry.path, "could not stat file");
+                continue;
+            }
+            if (!exists) {
+                entry.exists = false; // mark gone; a later reappearance will fire
+                continue;
+            }
+            const auto time = std::filesystem::last_write_time(entry.path, ec);
+            if (ec) {
+                report(entry.path, "could not read modification time");
+                continue;
+            }
+            if (!entry.exists || time > entry.lastWrite) {
+                entry.exists = true;
+                entry.lastWrite = time;
+                fire(entry);
+            }
+        }
+    }
+
+    std::size_t count() const { return m_entries.size(); }
+
+private:
+    struct Entry {
+        std::size_t id{0};
+        std::filesystem::path path;
+        Callback onChange;
+        std::filesystem::file_time_type lastWrite{};
+        bool exists{false};
+    };
+
+    void fire(const Entry& entry) {
+        try {
+            if (entry.onChange) entry.onChange(entry.path.string());
+        } catch (const std::exception& ex) {
+            report(entry.path, std::string("reload failed: ") + ex.what());
+        } catch (...) {
+            report(entry.path, "reload failed: unknown error");
+        }
+    }
+
+    void report(const std::filesystem::path& path, const std::string& message) {
+        if (m_onError) m_onError(path.string(), message);
+    }
+
+    static ErrorHandler defaultErrorHandler() {
+        return [](const std::string& path, const std::string& message) {
+            std::fprintf(stderr, "[FileWatcher] %s: %s\n", path.c_str(), message.c_str());
+        };
+    }
+
+    std::vector<Entry> m_entries;
+    std::size_t m_nextId{1};
+    ErrorHandler m_onError;
+};
+
+} // namespace IKore

--- a/tests/test_file_watcher.cpp
+++ b/tests/test_file_watcher.cpp
@@ -1,0 +1,128 @@
+// Test for the hot-reload file watcher - Milestone 10, issue #146.
+//
+// Verifies the issue's acceptance criteria at the mechanism level:
+//   - Editing a watched file triggers its reload callback at runtime.
+//   - A reload callback that fails is reported and does NOT crash; polling
+//     continues for the other watched files.
+// Plus: no spurious fire on an unchanged file, missing-then-created files, and
+// unwatch. Pure std::filesystem, so it builds and runs standalone:
+//   g++ -std=c++17 -I src tests/test_file_watcher.cpp -o test_file_watcher
+
+#include "core/FileWatcher.h"
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace IKore;
+namespace fs = std::filesystem;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static void writeFile(const fs::path& p, const std::string& contents) {
+    std::ofstream out(p, std::ios::trunc);
+    out << contents;
+}
+
+// Make a file look freshly edited, deterministically (avoids mtime-granularity
+// flakiness from a real write).
+static void bumpMtime(const fs::path& p) {
+    std::error_code ec;
+    fs::last_write_time(p, fs::file_time_type::clock::now() + std::chrono::seconds(2), ec);
+}
+
+int main() {
+    std::error_code ec;
+    const fs::path dir = fs::temp_directory_path(ec) / "ikore_filewatcher_test";
+    fs::remove_all(dir, ec);
+    fs::create_directories(dir, ec);
+
+    const fs::path scriptFile = dir / "script.lua";
+    const fs::path badFile = dir / "bad.txt";
+    const fs::path lateFile = dir / "late.txt";
+
+    writeFile(scriptFile, "v1");
+    writeFile(badFile, "x");
+
+    FileWatcher watcher;
+    int errorCount = 0;
+    watcher.setErrorHandler([&errorCount](const std::string&, const std::string&) { ++errorCount; });
+
+    int scriptReloads = 0;
+    std::string lastContents;
+    const std::size_t scriptId = watcher.watch(scriptFile.string(), [&](const std::string& path) {
+        ++scriptReloads;
+        std::ifstream in(path);
+        std::getline(in, lastContents);
+    });
+
+    int badReloads = 0;
+    watcher.watch(badFile.string(), [&badReloads](const std::string&) {
+        ++badReloads;
+        throw std::runtime_error("simulated reload failure");
+    });
+
+    int lateReloads = 0;
+    watcher.watch(lateFile.string(), [&lateReloads](const std::string&) { ++lateReloads; });
+
+    CHECK(watcher.count() == 3);
+
+    // 1) No change since watch() -> nothing fires.
+    watcher.poll();
+    CHECK(scriptReloads == 0);
+    CHECK(errorCount == 0);
+
+    // 2) Edit the script -> its callback fires once with the new contents.
+    writeFile(scriptFile, "v2");
+    bumpMtime(scriptFile);
+    watcher.poll();
+    CHECK(scriptReloads == 1);
+    CHECK(lastContents == "v2");
+
+    // 3) Polling again with no change -> no extra fire.
+    watcher.poll();
+    CHECK(scriptReloads == 1);
+
+    // 4) A failing reload is reported and does not crash; other files still poll.
+    bumpMtime(badFile);
+    writeFile(scriptFile, "v3");
+    bumpMtime(scriptFile);
+    watcher.poll();
+    CHECK(badReloads == 1);       // the bad callback ran
+    CHECK(errorCount == 1);       // and its failure was reported
+    CHECK(scriptReloads == 2);    // poll still serviced the good file
+    CHECK(lastContents == "v3");
+
+    // 5) A file that did not exist at watch() time fires once it appears.
+    watcher.poll();
+    CHECK(lateReloads == 0);      // still missing
+    writeFile(lateFile, "hello");
+    watcher.poll();
+    CHECK(lateReloads == 1);
+
+    // 6) After unwatch, edits no longer fire.
+    CHECK(watcher.unwatch(scriptId));
+    writeFile(scriptFile, "v4");
+    bumpMtime(scriptFile);
+    watcher.poll();
+    CHECK(scriptReloads == 2);    // unchanged from before
+
+    fs::remove_all(dir, ec);
+
+    if (g_failures == 0) {
+        std::printf("All file watcher (hot reload) tests passed.\n");
+        return 0;
+    }
+    std::printf("%d file watcher test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Implements **Milestone 10 / #146** — the mechanism behind hot reload.

## What's included
- **`src/core/FileWatcher.h`** — a portable, polling watcher (`std::filesystem`, header-only): `watch(path, callback)` / `unwatch(id)` / `poll()` / `count()`, with a settable error handler (defaults to stderr). The engine plugs in callbacks that do the actual reload and calls `poll()` each frame:
  ```cpp
  watcher.watch("assets/scripts/ai.lua",   [&](auto& p){ scripts.runFile(p); });
  watcher.watch("src/shaders/phong.frag",  [&](auto& p){ shader.reload();  });
  watcher.watch("assets/textures/wall.png",[&](auto& p){ texture.reload(); });
  ```
- **Reload failures don't crash the engine** — a callback that throws is caught and reported via the error handler, and `poll()` continues with the other files (the issue's "failures are reported and do not crash" criterion).
- Dependency-free polling (no inotify/ReadDirectoryChangesW) so the same code runs on every platform.

## Verification
`tests/test_file_watcher.cpp` (new `test_file_watcher` target) covers: edit detection + new contents, no spurious fire on unchanged files, a throwing callback reported without crashing while other files still poll, missing→created files, and unwatch. **Compiled and run locally — passes under `-Wall -Wextra -pedantic` with AddressSanitizer + UBSan.** (This one was fully verifiable here, since the watcher is pure `std::filesystem`.)

## Scope
This lands the tested, reusable mechanism. Wiring it into the engine's main loop with concrete script/shader/texture reloads needs the live GL context, so that's the follow-on.

Closes #146