### PR TITLE
docs(scripting): sample gameplay script + scripting/hot-reload docs (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ wander) · `Sound` / `Audio` (3D positional, OpenAL) · `Particle` · `Network`.
 ### Audio
 - 3D positional audio with distance attenuation (OpenAL).
 
+### Scripting
+- **Lua scripting** (via sol2) bound to the ECS and event system, with
+  **hot reload** of scripts/shaders/assets. See [`docs/SCRIPTING.md`](docs/SCRIPTING.md).
+
 ---
 
 ## Tech stack

--- a/assets/scripts/hot_reload.lua
+++ b/assets/scripts/hot_reload.lua
@@ -1,0 +1,15 @@
+-- Hot-reload demo script (Milestone 10 / #146-#147).
+-- When the engine watches this file with FileWatcher and re-runs it via
+-- ScriptSystem::runFile on every save, editing and saving applies your change
+-- live - no restart. See docs/SCRIPTING.md ("Hot reload").
+
+-- Tweak this value and save: the new value prints immediately.
+local spawn_count = 5
+
+for _ = 1, spawn_count do
+    local e = world.create()
+    world.add_transform(e)
+end
+
+print("hot_reload.lua ran: spawned " .. spawn_count ..
+      " entities (total with a transform now " .. world.transform_count() .. ")")

--- a/assets/scripts/sample.lua
+++ b/assets/scripts/sample.lua
@@ -1,24 +1,50 @@
--- Sample IKore script (Milestone 10 / #145) showing the Lua API surface.
--- Run via ScriptSystem::runFile("assets/scripts/sample.lua").
+-- Sample gameplay scene driven entirely by Lua (Milestone 10 / #147).
+-- Demonstrates the IKore scripting API: entities, components, and events.
+-- Run with ScriptSystem::runFile("assets/scripts/sample.lua").
+-- Full API reference: docs/SCRIPTING.md.
 
--- Create an entity and give it a transform.
-local player = world.create()
-world.add_transform(player)
+-- Helper: spawn an entity with a Transform at (x, y, z).
+local function spawn_at(x, y, z)
+    local e = world.create()
+    world.add_transform(e)
+    local t = world.get_transform(e)  -- get_transform returns a COPY,
+    t.position = Vec3.new(x, y, z)
+    world.set_transform(e, t)         -- so write it back with set_transform.
+    return e
+end
 
-local t = world.get_transform(player)
-t.position = Vec3.new(0, 1, 0)
-world.set_transform(player, t)
+-- Helper: give an entity a linear velocity.
+local function set_velocity(e, vx, vy, vz)
+    world.add_velocity(e)
+    local v = world.get_velocity(e)
+    v.linear = Vec3.new(vx, vy, vz)
+    world.set_velocity(e, v)
+end
 
--- Give it a velocity.
-world.add_velocity(player, Velocity.new())
-local v = world.get_velocity(player)
-v.linear = Vec3.new(1, 0, 0)
-world.set_velocity(player, v)
+-- --- Build a small scene -------------------------------------------------
+local player = spawn_at(0, 0, 0)
+set_velocity(player, 1, 0, 0)         -- moving along +x
 
--- Subscribe to an event, then emit one.
-events.on("player_spawned", function(id)
-    print("player_spawned received, id = " .. id)
+local coins = {}
+for i = 1, 3 do
+    coins[i] = spawn_at(i * 2, 0, 0)  -- coins lined up ahead of the player
+end
+
+local enemy = spawn_at(10, 0, 0)
+set_velocity(enemy, -1, 0, 0)         -- moving toward the player
+
+-- --- Event-driven scoring -----------------------------------------------
+local score = 0
+events.on("coin_collected", function(value)
+    score = score + value
+    print(string.format("coin collected (+%d), score = %d", value, score))
 end)
-events.emit("player_spawned", 1)
 
-print("entities with a transform: " .. world.transform_count())
+-- Simulate the player collecting each coin.
+for _ = 1, #coins do
+    events.emit("coin_collected", 10)
+end
+
+-- --- Summary ------------------------------------------------------------
+print(string.format("scene ready: %d entities have a transform; final score = %d",
+                    world.transform_count(), score))

--- a/docs/SCRIPTING.md
+++ b/docs/SCRIPTING.md
@@ -1,0 +1,131 @@
+# Scripting (Lua) and Hot Reload
+
+IKore embeds **Lua 5.4** (via [sol2](https://github.com/ThePhd/sol2)) so gameplay
+can be authored in scripts instead of C++. The scripting layer
+(`src/scripting/ScriptSystem.{h,cpp}`, Milestone 10 / #145) exposes the
+data-oriented ECS (`ecs::Registry`) and the engine `EventSystem` to Lua. Live
+editing is provided by the hot-reload file watcher (`src/core/FileWatcher.h`,
+#146).
+
+> The scripting layer is optional and isolated: including `ScriptSystem.h` does
+> not pull in Lua or sol2. Scripts currently operate on a `ScriptSystem`-owned
+> `ecs::Registry` (the live engine is not yet driven by the new ECS).
+
+## Running scripts
+
+```cpp
+#include "scripting/ScriptSystem.h"
+
+IKore::ScriptSystem scripts;
+std::string error;
+if (!scripts.runFile("assets/scripts/sample.lua", &error)) {
+    // error is also logged; runString(code, &error) runs an inline chunk
+}
+```
+
+`runString` / `runFile` return `false` and set the optional error string on a
+Lua error (the script is run protected, so a script error never throws into C++).
+
+## API reference
+
+### Types
+
+| Lua | Constructor | Fields |
+|---|---|---|
+| `Vec3` | `Vec3.new()`, `Vec3.new(x, y, z)` | `x`, `y`, `z` (numbers) |
+| `Transform` | `Transform.new()` | `position`, `rotation`, `scale` (all `Vec3`) |
+| `Velocity` | `Velocity.new()` | `linear`, `angular` (both `Vec3`) |
+| `Entity` | (returned by `world.create()`) | `index`, `generation` (read-only) |
+
+### `world` - entities and components
+
+| Function | Returns | Description |
+|---|---|---|
+| `world.create()` | `Entity` | Create a new entity. |
+| `world.destroy(e)` | - | Destroy an entity (its handle becomes invalid). |
+| `world.valid(e)` | `bool` | Is the entity handle still valid? |
+| `world.add_transform(e [, t])` | - | Add a `Transform` (default if `t` omitted). |
+| `world.has_transform(e)` | `bool` | Does the entity have a `Transform`? |
+| `world.get_transform(e)` | `Transform` | **A copy** of the entity's transform. |
+| `world.set_transform(e, t)` | - | Write a `Transform` back to the entity. |
+| `world.add_velocity(e [, v])` | - | Add a `Velocity` (default if `v` omitted). |
+| `world.has_velocity(e)` | `bool` | Does the entity have a `Velocity`? |
+| `world.get_velocity(e)` | `Velocity` | **A copy** of the entity's velocity. |
+| `world.set_velocity(e, v)` | - | Write a `Velocity` back to the entity. |
+| `world.transform_count()` | `int` | Number of entities that have a `Transform`. |
+
+> **Important:** `get_transform` / `get_velocity` return a **copy**. To change a
+> component, get it, mutate the copy, then write it back with the matching
+> `set_*`:
+> ```lua
+> local t = world.get_transform(e)
+> t.position = Vec3.new(1, 2, 3)
+> world.set_transform(e, t)
+> ```
+
+### `events` - the EventSystem bridge
+
+| Function | Description |
+|---|---|
+| `events.emit(name)` | Publish event `name` with no payload. |
+| `events.emit(name, number)` | Publish event `name` with a numeric payload. |
+| `events.on(name, fn)` | Subscribe; `fn(number)` is called on each emit (payload, or 0). |
+
+```lua
+events.on("coin_collected", function(value)
+    print("score += " .. value)
+end)
+events.emit("coin_collected", 10)
+```
+
+Subscriptions are owned by the `ScriptSystem` and released when it is destroyed.
+
+## Hot reload
+
+`FileWatcher` (`src/core/FileWatcher.h`) re-runs scripts (and reloads shaders or
+textures) when their files change on disk. Register a file with a reload
+callback and call `poll()` once per frame:
+
+```cpp
+#include "core/FileWatcher.h"
+#include "scripting/ScriptSystem.h"
+
+IKore::ScriptSystem scripts;
+IKore::FileWatcher  watcher;
+
+watcher.watch("assets/scripts/hot_reload.lua",
+              [&](const std::string& path) { scripts.runFile(path); });
+
+// each frame:
+watcher.poll();   // edits to the .lua re-run it live, no restart
+```
+
+- The callback fires when the file's modification time advances (or a missing
+  file appears).
+- A reload that fails (a script error, a bad shader) is **caught and reported**
+  through the watcher's error handler; `poll()` keeps going and the engine does
+  not crash.
+- The watcher is portable, dependency-free polling (no inotify / OS-specific
+  APIs), so the same code runs on every platform. Set a custom reporter with
+  `watcher.setErrorHandler(...)`.
+
+## Sample scripts
+
+- [`assets/scripts/sample.lua`](../assets/scripts/sample.lua) - a small scene:
+  spawns a player, coins, and an enemy; sets transforms/velocities; and wires an
+  event-driven score. Demonstrates entity, component, and event usage end to end.
+- [`assets/scripts/hot_reload.lua`](../assets/scripts/hot_reload.lua) - a minimal
+  script to edit while the engine runs, to see hot reload in action.
+
+## Building and testing
+
+The `test_scripting` CMake target builds the bindings and runs the scripted
+scenario against the C++ registry:
+
+```bash
+cmake -S . -B build && cmake --build build --target test_scripting
+./build/test_scripting
+```
+
+Lua and sol2 are fetched automatically by CMake (see the top-level
+`CMakeLists.txt`).


### PR DESCRIPTION
Implements **Milestone 10 / #147** — closes out the Scripting & Hot Reload milestone with documentation and runnable samples for the Lua scripting (#145) and hot-reload (#146) layers.

## What's included
- **`docs/SCRIPTING.md`** — full API reference (`Vec3`/`Transform`/`Velocity`/`Entity` types, the `world.*` entity/component functions, `events.emit`/`events.on`), how to run scripts, the get-copy/set-back caveat, and the `FileWatcher` hot-reload workflow with a wiring example. Cross-checked against the actual `ScriptSystem` bindings.
- **`assets/scripts/sample.lua`** — expanded into a small scene (player + coins + enemy) that sets transforms/velocities and runs event-driven scoring; demonstrates entity, component, and event usage end to end.
- **`assets/scripts/hot_reload.lua`** — a minimal script to edit live and watch reload.
- **README** — a Scripting section linking the docs.

## Acceptance criteria
- *A documented sample script demonstrates entity/component/event usage* — `sample.lua` does all three; `docs/SCRIPTING.md` documents it.
- *Docs cover available bindings and the hot-reload workflow* — full binding reference + a `FileWatcher` + `ScriptSystem` hot-reload example.

## Notes
Docs and Lua samples only — no engine code. The samples use **only bindings that exist** in `ScriptSystem` (verified by grepping the registered functions). Lua isn't available in the authoring environment, so the scripts weren't executed here; they're straightforward and run via the `test_scripting` target / `ScriptSystem::runFile`. (The pre-existing em-dashes elsewhere in the README are unrelated to this diff — they belong to the separate, still-unopened em-dash cleanup branch.)

Closes #147