### PR TITLE
feat(core): deterministic fixed-step simulation loop (#152)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,6 +478,11 @@ add_executable(test_navmesh
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_navmesh.cpp
 )
 
+# Deterministic fixed-step simulation test (Milestone 12 / #152) - header-only
+add_executable(test_simulation
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_simulation.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/sim/Simulation.h
+++ b/src/core/sim/Simulation.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+/**
+ * @file Simulation.h
+ * @brief Deterministic fixed-step simulation loop (issue #152).
+ *
+ * Milestone 12 foundation. Provides:
+ *   - FixedTimestep: the "fix your timestep" accumulator. A variable-length
+ *     render frame is consumed into a whole number of fixed-size simulation
+ *     steps, with a leftover used as an interpolation `alpha` - so rendering is
+ *     decoupled from the simulation rate and the sim advances in reproducible
+ *     fixed increments.
+ *   - DeterministicRng: a fully-specified SplitMix64 PRNG (portable integer math)
+ *     so the same seed yields the same sequence on every platform.
+ *   - Simulation: ties them together with a tick counter and an owned RNG, so the
+ *     same seed + the same frame-delta inputs produce identical state across runs.
+ *
+ * Header-only and dependency-free, so it is unit-tested in isolation; this is the
+ * substrate the agent simulation (#153-#155) builds on.
+ */
+namespace IKore {
+namespace sim {
+
+/// SplitMix64 - small, fast, fully-specified, portable deterministic PRNG.
+class DeterministicRng {
+public:
+    explicit DeterministicRng(std::uint64_t seedValue = 0) : m_state(seedValue) {}
+
+    void seed(std::uint64_t seedValue) { m_state = seedValue; }
+
+    std::uint64_t nextU64() {
+        std::uint64_t z = (m_state += 0x9E3779B97F4A7C15ULL);
+        z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+        z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+        return z ^ (z >> 31);
+    }
+
+    /// Uniform double in [0, 1).
+    double nextDouble() { return static_cast<double>(nextU64() >> 11) * (1.0 / 9007199254740992.0); }
+    float nextFloat() { return static_cast<float>(nextDouble()); }
+
+    /// Uniform integer in [lo, hi].
+    int nextInt(int lo, int hi) {
+        if (hi <= lo) return lo;
+        const std::uint64_t range = static_cast<std::uint64_t>(hi - lo) + 1;
+        return lo + static_cast<int>(nextU64() % range);
+    }
+
+private:
+    std::uint64_t m_state;
+};
+
+/// Accumulator that turns a variable frame delta into fixed simulation steps.
+struct FixedTimestep {
+    double fixedDelta{1.0 / 60.0}; ///< seconds per simulation step
+    double accumulator{0.0};
+    int maxSteps{8}; ///< cap per frame to avoid the "spiral of death"
+
+    /// Accumulate @p frameDelta and return how many fixed steps to run now.
+    int stepsFor(double frameDelta) {
+        if (fixedDelta <= 0.0) return 0;
+        accumulator += frameDelta;
+        int n = 0;
+        while (accumulator >= fixedDelta && n < maxSteps) {
+            accumulator -= fixedDelta;
+            ++n;
+        }
+        if (accumulator >= fixedDelta) {
+            // Hit the cap: drop the excess whole steps (keep only the remainder)
+            // so a long stall doesn't snowball into unbounded catch-up.
+            accumulator = std::fmod(accumulator, fixedDelta);
+        }
+        return n;
+    }
+
+    /// Interpolation factor in [0, 1) for rendering between fixed steps.
+    double alpha() const { return fixedDelta > 0.0 ? accumulator / fixedDelta : 0.0; }
+};
+
+class Simulation {
+public:
+    explicit Simulation(std::uint64_t seed = 0, double fixedDelta = 1.0 / 60.0, int maxSteps = 8)
+        : m_rng(seed) {
+        m_timestep.fixedDelta = fixedDelta;
+        m_timestep.maxSteps = maxSteps;
+    }
+
+    /// Re-seed the RNG and clear tick/accumulator (for repeatable runs).
+    void reset(std::uint64_t seed) {
+        m_rng.seed(seed);
+        m_tick = 0;
+        m_timestep.accumulator = 0.0;
+    }
+
+    /**
+     * @brief Advance the simulation by a render frame of @p frameDelta seconds.
+     *        Runs zero or more fixed steps; @p step is called once per fixed step
+     *        as step(tick, rng). Returns the number of steps run.
+     */
+    template <class StepFn>
+    int advance(double frameDelta, StepFn&& step) {
+        const int steps = m_timestep.stepsFor(frameDelta);
+        for (int i = 0; i < steps; ++i) {
+            step(m_tick, m_rng);
+            ++m_tick;
+        }
+        return steps;
+    }
+
+    std::uint64_t tick() const { return m_tick; }
+    double fixedDelta() const { return m_timestep.fixedDelta; }
+    double alpha() const { return m_timestep.alpha(); }
+    DeterministicRng& rng() { return m_rng; }
+
+private:
+    FixedTimestep m_timestep;
+    DeterministicRng m_rng;
+    std::uint64_t m_tick{0};
+};
+
+} // namespace sim
+} // namespace IKore

--- a/tests/test_simulation.cpp
+++ b/tests/test_simulation.cpp
@@ -1,0 +1,123 @@
+// Test for the deterministic fixed-step simulation loop - Milestone 12, #152.
+//
+// Verifies the issue's acceptance criteria:
+//   - Same seed + same inputs yields identical state across runs (and a different
+//     seed yields different state).
+//   - Rendering is decoupled from the fixed step: the number of fixed steps and
+//     the resulting state depend only on elapsed time, not how it is chunked per
+//     frame; a leftover alpha is exposed for interpolation.
+// Pure std, header-only:
+//   g++ -std=c++17 -I src tests/test_simulation.cpp -o test_simulation
+
+#include "core/sim/Simulation.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::sim;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(double a, double b, double eps = 1e-9) {
+    return std::fabs(a - b) <= eps;
+}
+
+// Run a small world (5 agents) for the given per-frame deltas; each fixed step
+// nudges every agent by a deterministic random amount. Returns final positions.
+static std::vector<float> runWorld(std::uint64_t seed, double fixedDelta, int maxSteps,
+                                   const std::vector<double>& frameDeltas) {
+    Simulation sim(seed, fixedDelta, maxSteps);
+    std::vector<float> world(5, 0.0f);
+    for (double dt : frameDeltas) {
+        sim.advance(dt, [&world](std::uint64_t, DeterministicRng& rng) {
+            for (float& v : world) v += rng.nextFloat();
+        });
+    }
+    return world;
+}
+
+static void testRngDeterminism() {
+    DeterministicRng a(123), b(123), c(124);
+    bool sameAB = true, diffAC = false;
+    for (int i = 0; i < 16; ++i) {
+        const std::uint64_t va = a.nextU64();
+        if (va != b.nextU64()) sameAB = false;
+        if (va != c.nextU64()) diffAC = true;
+    }
+    CHECK(sameAB);  // same seed -> identical sequence
+    CHECK(diffAC);  // different seed -> diverges
+}
+
+static void testFixedStepDecoupling() {
+    FixedTimestep ts;
+    ts.fixedDelta = 1.0; // whole seconds: exact, no FP boundary fuzz
+    ts.maxSteps = 1000;
+
+    CHECK(ts.stepsFor(0.0) == 0);
+    CHECK(approx(ts.alpha(), 0.0));
+
+    CHECK(ts.stepsFor(2.5) == 2);      // 2 whole steps...
+    CHECK(approx(ts.alpha(), 0.5));    // ...with 0.5 left over for interpolation
+
+    CHECK(ts.stepsFor(0.6) == 1);      // 0.5 + 0.6 = 1.1 -> 1 step
+    CHECK(approx(ts.alpha(), 0.1));
+
+    // Spiral-of-death guard: a huge stall is capped.
+    FixedTimestep capped;
+    capped.fixedDelta = 1.0;
+    capped.maxSteps = 8;
+    CHECK(capped.stepsFor(100.0) == 8);
+}
+
+static void testReproducibleAcrossRunsAndChunking() {
+    // Same seed + same inputs -> identical state.
+    const std::vector<double> deltas(20, 1.0);
+    const std::vector<float> run1 = runWorld(7, 1.0, 1000, deltas);
+    const std::vector<float> run2 = runWorld(7, 1.0, 1000, deltas);
+    CHECK(run1 == run2);
+
+    // Different seed -> different state.
+    const std::vector<float> run3 = runWorld(8, 1.0, 1000, deltas);
+    CHECK(run1 != run3);
+
+    // Decoupled from frame chunking: 20s as one frame vs twenty 1s frames vs
+    // forty 0.5s frames all produce the same state (same total fixed steps).
+    const std::vector<float> oneBigFrame = runWorld(7, 1.0, 1000, {20.0});
+    std::vector<double> manySmall(40, 0.5);
+    const std::vector<float> manyFrames = runWorld(7, 1.0, 1000, manySmall);
+    CHECK(run1 == oneBigFrame);
+    CHECK(run1 == manyFrames);
+}
+
+static void testSimulationTickCount() {
+    Simulation sim(1, 1.0, 1000);
+    int ran = sim.advance(10.0, [](std::uint64_t, DeterministicRng&) {});
+    CHECK(ran == 10);
+    CHECK(sim.tick() == 10);
+    ran = sim.advance(0.4, [](std::uint64_t, DeterministicRng&) {});
+    CHECK(ran == 0);                 // not a full step yet
+    CHECK(approx(sim.alpha(), 0.4)); // leftover available to the renderer
+}
+
+int main() {
+    testRngDeterminism();
+    testFixedStepDecoupling();
+    testReproducibleAcrossRunsAndChunking();
+    testSimulationTickCount();
+
+    if (g_failures == 0) {
+        std::printf("All simulation tests passed.\n");
+        return 0;
+    }
+    std::printf("%d simulation test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements the Milestone 12 foundation: a deterministic, fixed-step simulation loop with rendering decoupled from the simulation rate. Closes #152.

New header `src/core/sim/Simulation.h` (namespace `IKore::sim`), header-only and dependency-free:

- **FixedTimestep** - the "fix your timestep" accumulator. It consumes a variable render-frame delta into a whole number of fixed-size simulation steps and exposes the leftover as an interpolation `alpha`, so rendering is decoupled from the fixed simulation rate. A `maxSteps` cap guards against the spiral of death on a long stall.
- **DeterministicRng** - a fully specified SplitMix64 PRNG (portable integer math) so the same seed yields the same sequence on every platform.
- **Simulation** - ties them together with a tick counter and an owned RNG. The same seed plus the same frame-delta inputs produce identical state across runs, independent of how the elapsed time is chunked per frame. `advance(frameDelta, step)` runs `step(tick, rng)` once per fixed step and returns the step count; `reset(seed)`, `tick()`, `alpha()`, and `fixedDelta()` round out the surface.

## Acceptance criteria

- [x] Same seed + inputs yields identical state across runs
- [x] Rendering is decoupled from the fixed simulation step (leftover `alpha` exposed for interpolation)

## Testing

`tests/test_simulation.cpp` (wired as the `test_simulation` CMake target) covers:

- RNG determinism: same seed yields an identical sequence, a different seed diverges.
- Fixed-step decoupling: step counts and leftover `alpha` for a sequence of frame deltas, plus the spiral-of-death cap.
- Reproducibility: byte-for-byte identical final state across repeat runs, a different result for a different seed, and the same result whether 20 seconds of elapsed time arrives as one big frame, twenty 1s frames, or forty 0.5s frames.
- Tick / alpha accounting on `Simulation::advance`.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_simulation.cpp -o test_simulation && ./test_simulation
```

All simulation tests pass clean under the address and undefined-behavior sanitizers.

## Notes

This is the substrate the agent simulation (#153-#155) builds on.
