### PR TITLE
feat(sim): time control and rewind/replay timeline (#154)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,6 +488,11 @@ add_executable(test_crowd
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_crowd.cpp
 )
 
+# Time control + rewind/replay test (Milestone 12 / #154) - header-only
+add_executable(test_timeline
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_timeline.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/sim/Simulation.h
+++ b/src/core/sim/Simulation.h
@@ -31,6 +31,11 @@ public:
 
     void seed(std::uint64_t seedValue) { m_state = seedValue; }
 
+    /// Full internal state - capture/restore it to snapshot the exact stream
+    /// position (e.g. for rewind/replay), not just the original seed.
+    std::uint64_t state() const { return m_state; }
+    void setState(std::uint64_t stateValue) { m_state = stateValue; }
+
     std::uint64_t nextU64() {
         std::uint64_t z = (m_state += 0x9E3779B97F4A7C15ULL);
         z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;

--- a/src/core/sim/Timeline.h
+++ b/src/core/sim/Timeline.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include "core/sim/Simulation.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <utility>
+
+/**
+ * @file Timeline.h
+ * @brief Time control (pause / step / speed) and rewind / replay (issue #154).
+ *
+ * Milestone 12. Wraps the deterministic fixed-step loop (#152) with interactive
+ * time controls and a bounded history so a running simulation can be paused,
+ * single-stepped, sped up or slowed down, and rewound to an earlier tick.
+ *
+ * Rewind/replay is snapshot based. The Timeline keeps a ring buffer of per-tick
+ * snapshots, each capturing the full deterministic state at a tick boundary: the
+ * tick number, the RNG's internal state, and a copy of the user @p State. Because
+ * the step function is deterministic given (state, tick, rng), restoring a
+ * snapshot and stepping forward again reproduces exactly the original trajectory
+ * - the issue's reproducibility guarantee. Snapshotting the RNG's internal state
+ * (not just the seed) is what makes replay bit-identical.
+ *
+ * @tparam State the simulation world, a value type that is copyable and cheap
+ *         enough to snapshot each tick (e.g. a serializable POD or a small SoA
+ *         container). The Registry itself is non-copyable, so callers snapshot a
+ *         serializable view of their world here ("building on serialization").
+ *
+ * Header-only and dependency-free (std + the #152 sim primitives), so it is
+ * unit-tested in isolation.
+ */
+namespace IKore {
+namespace sim {
+
+template <class State>
+class Timeline {
+public:
+    /**
+     * @param initial         the starting world state (snapshotted as tick 0).
+     * @param seed            RNG seed for the deterministic stream.
+     * @param fixedDelta      seconds per simulation step.
+     * @param historyCapacity max snapshots retained (the rewind window); >= 1.
+     * @param maxStepsPerFrame spiral-of-death cap on real-time-driven steps.
+     */
+    explicit Timeline(State initial, std::uint64_t seed = 0, double fixedDelta = 1.0 / 60.0,
+                      std::size_t historyCapacity = 256, int maxStepsPerFrame = 8)
+        : m_state(std::move(initial)),
+          m_rng(seed),
+          m_capacity(historyCapacity == 0 ? 1 : historyCapacity) {
+        m_timestep.fixedDelta = fixedDelta;
+        m_timestep.maxSteps = maxStepsPerFrame;
+        m_history.push_back(Snapshot{m_tick, m_rng.state(), m_state}); // S(0)
+    }
+
+    // --- Time controls -----------------------------------------------------
+
+    void pause() { m_paused = true; }
+    void resume() { m_paused = false; }
+    bool paused() const { return m_paused; }
+
+    /// Playback rate: 1.0 normal, 2.0 double speed, 0.5 half. Clamped to >= 0.
+    void setTimeScale(double scale) { m_timeScale = scale < 0.0 ? 0.0 : scale; }
+    double timeScale() const { return m_timeScale; }
+
+    /// Queue @p n fixed steps to run on the next advance regardless of pause or
+    /// elapsed time - the "single-step" control (typically used while paused).
+    void requestStep(int n = 1) {
+        if (n > 0) m_pendingSteps += n;
+    }
+
+    /**
+     * @brief Advance by a render frame of @p realDt seconds.
+     *
+     * Runs any queued single-steps first, then - unless paused - consumes
+     * @p realDt scaled by the time scale into fixed steps. @p step is called per
+     * fixed step as step(State&, tick, DeterministicRng&). Returns steps run.
+     */
+    template <class StepFn>
+    int advance(double realDt, StepFn&& step) {
+        int ran = 0;
+        while (m_pendingSteps > 0) { // explicit single steps always run
+            runStep(step);
+            --m_pendingSteps;
+            ++ran;
+        }
+        if (!m_paused) {
+            const int steps = m_timestep.stepsFor(realDt * m_timeScale);
+            for (int i = 0; i < steps; ++i) {
+                runStep(step);
+                ++ran;
+            }
+        }
+        return ran;
+    }
+
+    // --- Rewind / replay ---------------------------------------------------
+
+    /// Current simulation tick (number of steps run since construction).
+    std::uint64_t tick() const { return m_tick; }
+    /// Earliest tick still recoverable from the history window.
+    std::uint64_t oldestTick() const { return m_history.front().tick; }
+    /// History snapshots currently retained.
+    std::size_t historySize() const { return m_history.size(); }
+
+    /// True if @p t is within the retained window (oldestTick .. current tick).
+    bool canRewindTo(std::uint64_t t) const {
+        return t <= m_tick && t >= m_history.front().tick;
+    }
+
+    /**
+     * @brief Rewind to tick @p t: restore the state and RNG as they were at that
+     *        tick and drop the now-invalid future snapshots. Replaying forward
+     *        from here reproduces the original trajectory.
+     * @return false (no change) if @p t is outside the retained window.
+     */
+    bool rewindTo(std::uint64_t t) {
+        if (!canRewindTo(t)) return false;
+        while (m_history.back().tick > t) m_history.pop_back(); // drop the future
+        const Snapshot& snap = m_history.back();
+        m_state = snap.state;
+        m_rng.setState(snap.rngState);
+        m_tick = snap.tick;
+        m_timestep.accumulator = 0.0; // start the replay cleanly on a tick boundary
+        return true;
+    }
+
+    // --- Accessors ---------------------------------------------------------
+
+    const State& state() const { return m_state; }
+    DeterministicRng& rng() { return m_rng; }
+    double fixedDelta() const { return m_timestep.fixedDelta; }
+    double alpha() const { return m_timestep.alpha(); }
+
+private:
+    struct Snapshot {
+        std::uint64_t tick;
+        std::uint64_t rngState;
+        State state;
+    };
+
+    template <class StepFn>
+    void runStep(StepFn&& step) {
+        step(m_state, m_tick, m_rng);
+        ++m_tick;
+        m_history.push_back(Snapshot{m_tick, m_rng.state(), m_state}); // S(m_tick)
+        while (m_history.size() > m_capacity) m_history.pop_front();    // ring eviction
+    }
+
+    State m_state;
+    DeterministicRng m_rng;
+    FixedTimestep m_timestep;
+    std::deque<Snapshot> m_history; // bounded ring of per-tick snapshots
+    std::size_t m_capacity;
+    std::uint64_t m_tick{0};
+    int m_pendingSteps{0};
+    double m_timeScale{1.0};
+    bool m_paused{false};
+};
+
+} // namespace sim
+} // namespace IKore

--- a/tests/test_timeline.cpp
+++ b/tests/test_timeline.cpp
@@ -1,0 +1,168 @@
+// Test for time control + rewind/replay - Milestone 12, #154.
+//
+// Verifies the issue's acceptance criteria:
+//   - The simulation can be paused, single-stepped, and sped up / slowed down.
+//   - Rewinding to an earlier tick and replaying forward reproduces the same
+//     state (exercising RNG-state snapshot/restore, so replay is bit-identical).
+// Plus the bounded history window (ring buffer eviction) behaviour.
+//
+// Pure std + header-only sim primitives:
+//   g++ -std=c++17 -I src tests/test_timeline.cpp -o test_timeline
+
+#include "core/sim/Timeline.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::sim;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(double a, double b, double eps = 1e-9) {
+    return std::fabs(a - b) <= eps;
+}
+
+// Step that just counts ticks (ignores the RNG) - for the control tests.
+static void countStep(int& s, std::uint64_t, DeterministicRng&) { ++s; }
+
+static void testPauseAndSingleStep() {
+    Timeline<int> tl(0, /*seed=*/1, /*fixedDelta=*/1.0, /*historyCapacity=*/1000,
+                     /*maxStepsPerFrame=*/1000);
+
+    // Running: 2.5s at fixedDelta 1.0 -> 2 steps, 0.5 left over.
+    CHECK(tl.advance(2.5, countStep) == 2);
+    CHECK(tl.tick() == 2);
+    CHECK(tl.state() == 2);
+    CHECK(approx(tl.alpha(), 0.5));
+
+    // Paused: real time no longer advances the sim.
+    tl.pause();
+    CHECK(tl.paused());
+    CHECK(tl.advance(100.0, countStep) == 0);
+    CHECK(tl.tick() == 2);
+
+    // Single-step works while paused, even with a zero frame delta.
+    tl.requestStep(1);
+    CHECK(tl.advance(0.0, countStep) == 1);
+    CHECK(tl.tick() == 3);
+    CHECK(tl.state() == 3);
+
+    // Multiple queued steps run together.
+    tl.requestStep(2);
+    CHECK(tl.advance(0.0, countStep) == 2);
+    CHECK(tl.tick() == 5);
+    CHECK(tl.state() == 5);
+}
+
+static void testVariableSpeed() {
+    // Double speed: 1s of real time yields 2 steps at fixedDelta 1.0.
+    Timeline<int> fast(0, 1, 1.0, 1000, 1000);
+    fast.setTimeScale(2.0);
+    CHECK(approx(fast.timeScale(), 2.0));
+    CHECK(fast.advance(1.0, countStep) == 2);
+    CHECK(fast.tick() == 2);
+
+    // Half speed: 1s yields 0 steps (0.5 accumulated), the next 1s completes one.
+    Timeline<int> slow(0, 1, 1.0, 1000, 1000);
+    slow.setTimeScale(0.5);
+    CHECK(slow.advance(1.0, countStep) == 0);
+    CHECK(approx(slow.alpha(), 0.5));
+    CHECK(slow.advance(1.0, countStep) == 1);
+    CHECK(slow.tick() == 1);
+
+    // Negative scale is clamped to a freeze.
+    Timeline<int> frozen(0, 1, 1.0, 1000, 1000);
+    frozen.setTimeScale(-3.0);
+    CHECK(approx(frozen.timeScale(), 0.0));
+    CHECK(frozen.advance(10.0, countStep) == 0);
+}
+
+// A small world perturbed by the RNG each step, so reproducing it across a
+// rewind/replay proves the RNG stream is snapshotted and restored correctly.
+struct World {
+    double a{0.0};
+    double b{0.0};
+    bool operator==(const World& o) const { return a == o.a && b == o.b; }
+};
+
+static void perturb(World& w, std::uint64_t, DeterministicRng& rng) {
+    w.a += rng.nextDouble();
+    w.b += rng.nextDouble() * 2.0 - 1.0;
+}
+
+static void testRewindReplayReproducesState() {
+    Timeline<World> tl(World{}, /*seed=*/12345, /*fixedDelta=*/1.0, /*historyCapacity=*/64,
+                       /*maxStepsPerFrame=*/1000);
+
+    // Record the full trajectory: state at tick 0, 1, ... 50.
+    std::vector<World> traj;
+    traj.push_back(tl.state());
+    for (int t = 1; t <= 50; ++t) {
+        tl.advance(1.0, perturb);
+        traj.push_back(tl.state());
+    }
+    CHECK(tl.tick() == 50);
+
+    // Rewind to tick 20: state is exactly what it was then.
+    CHECK(tl.rewindTo(20));
+    CHECK(tl.tick() == 20);
+    CHECK(tl.state() == traj[20]);
+
+    // Replay forward: every tick reproduces the original trajectory.
+    bool replayMatches = true;
+    for (int t = 21; t <= 50; ++t) {
+        tl.advance(1.0, perturb);
+        if (!(tl.state() == traj[static_cast<std::size_t>(t)])) replayMatches = false;
+    }
+    CHECK(replayMatches);
+    CHECK(tl.tick() == 50);
+
+    // Rewinding to the current tick is a no-op success; the future is rejected.
+    CHECK(tl.rewindTo(50));
+    CHECK(!tl.rewindTo(51));
+}
+
+static void testHistoryWindow() {
+    // Capacity 16: after 50 steps only the most recent 16 ticks are recoverable.
+    Timeline<int> tl(0, 1, 1.0, /*historyCapacity=*/16, 1000);
+    for (int i = 0; i < 50; ++i) tl.advance(1.0, countStep);
+
+    CHECK(tl.tick() == 50);
+    CHECK(tl.historySize() == 16);
+    CHECK(tl.oldestTick() == 35); // ticks 35..50 retained
+    CHECK(tl.canRewindTo(35));
+    CHECK(!tl.canRewindTo(34)); // evicted
+    CHECK(tl.canRewindTo(50));
+    CHECK(!tl.canRewindTo(51)); // future
+
+    CHECK(!tl.rewindTo(34));     // outside the window: no change
+    CHECK(tl.tick() == 50);
+
+    CHECK(tl.rewindTo(40));      // inside the window
+    CHECK(tl.tick() == 40);
+    CHECK(tl.state() == 40);
+}
+
+int main() {
+    testPauseAndSingleStep();
+    testVariableSpeed();
+    testRewindReplayReproducesState();
+    testHistoryWindow();
+
+    if (g_failures == 0) {
+        std::printf("All timeline (time control + rewind) tests passed.\n");
+        return 0;
+    }
+    std::printf("%d timeline test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements Milestone 12 / #154: interactive time controls (pause / single-step / variable speed) and rewind/replay via ring-buffered state snapshots, layered on the #152 fixed-step loop. Closes #154.

New header `src/core/sim/Timeline.h` (namespace `IKore::sim`), header-only and dependency-free.

`Timeline<State>` wraps the fixed-step accumulator and the deterministic RNG with:

### Time controls
- `pause()` / `resume()` - while paused, real time no longer advances the sim.
- `requestStep(n)` - single-step: runs `n` queued fixed steps on the next `advance`, even while paused and with a zero frame delta.
- `setTimeScale(s)` - variable speed (`2.0` = double speed, `0.5` = half); negatives are clamped to a freeze.

### Rewind / replay
- A bounded ring of per-tick snapshots. Each snapshot captures the full deterministic state at a tick boundary: the tick number, the RNG's internal state, and a copy of the user `State`.
- `rewindTo(tick)` restores that snapshot and drops the now-invalid future; replaying forward then reproduces the original trajectory bit-for-bit. Snapshotting the RNG's *internal state* (not just the seed) is what makes replay exact.
- `canRewindTo`, `oldestTick`, `historySize` expose the retained window; the ring evicts the oldest snapshot once capacity is exceeded.

`State` is a copyable value type. The `Registry` is non-copyable, so callers snapshot a serializable view of their world here, as the issue intends ("building on serialization").

Supporting change: `DeterministicRng` gains `state()` / `setState()` accessors for its internal SplitMix64 state (additive), so the stream position can be snapshotted mid-run.

## Acceptance criteria

- [x] The simulation can be paused, stepped, and sped up / slowed down
- [x] Rewinding to an earlier tick and replaying forward reproduces the same state

## Testing

`tests/test_timeline.cpp` (wired as the `test_timeline` CMake target):

- Pause + single-step: paused frames run zero steps; queued single-steps run even with a zero frame delta.
- Variable speed: double speed yields two steps per second at a 1s fixed delta, half speed accumulates across frames, negative scale is clamped to a freeze.
- Rewind/replay: record the full trajectory of an RNG-driven world over 50 ticks, rewind to tick 20 (state matches exactly), replay forward, and confirm every tick reproduces the recorded trajectory; rewind-to-current is a no-op success and a future tick is rejected.
- History window: with capacity 16, only the most recent 16 ticks are recoverable; in-window rewinds succeed, out-of-window rewinds are rejected with no change.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_timeline.cpp -o test_timeline && ./test_timeline
```

All tests pass clean under the address and undefined-behavior sanitizers. The existing `test_simulation` and `test_crowd` were rebuilt against the updated `Simulation.h` and still pass.

## Notes

Builds on #152 (fixed-step loop + RNG). Last in M12: data export (#155).