### PR TITLE
feat(ai): IBrain interface with LLM and behavior-tree NPC brains (#156)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,13 @@ add_executable(test_data_export
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_data_export.cpp
 )
 
+# IBrain + LLM/behavior-tree NPC test (Milestone 13 / #156). Header-only AI layer
+# plus the engine EventSystem for the emit/consume integration.
+add_executable(test_ai_brain
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ai_brain.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/core/EventSystem.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/ai/BehaviorTree.h
+++ b/src/ai/BehaviorTree.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include "ai/Brain.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * @file BehaviorTree.h
+ * @brief A minimal behavior tree and the offline fallback brain (issue #156).
+ *
+ * Milestone 13. A small, dependency-free behavior tree (Sequence / Selector /
+ * Condition / Action / Inverter) plus BehaviorTreeBrain, an IBrain that runs a
+ * tree to decide. Because it needs nothing external, it is the offline fallback
+ * when no AI provider is available, so the engine has no hard dependency on any
+ * single provider.
+ *
+ * makeDefaultNpcBrain() builds a tree that reacts to perceived threats (flee),
+ * otherwise pursues the goal (move toward it), otherwise idles - enough for an
+ * NPC to "pursue goals and react to world events" with zero dependencies.
+ */
+namespace IKore {
+namespace ai {
+
+enum class Status { Success, Failure, Running };
+
+/// Working state a tree node sees: the read-only context and the Decision it fills.
+struct BtState {
+    const BrainContext& ctx;
+    Decision& out;
+};
+
+/// A behavior-tree node: inspects state, may write @c out, returns a status.
+using BtNode = std::function<Status(BtState&)>;
+
+/// Run children in order; fail at the first failure, else succeed (AND).
+inline BtNode sequence(std::vector<BtNode> children) {
+    return [children = std::move(children)](BtState& s) {
+        for (const BtNode& child : children) {
+            const Status st = child(s);
+            if (st != Status::Success) return st;
+        }
+        return Status::Success;
+    };
+}
+
+/// Run children in order; succeed at the first success, else fail (OR).
+inline BtNode selector(std::vector<BtNode> children) {
+    return [children = std::move(children)](BtState& s) {
+        for (const BtNode& child : children) {
+            const Status st = child(s);
+            if (st != Status::Failure) return st;
+        }
+        return Status::Failure;
+    };
+}
+
+/// Succeed iff the predicate holds (a guard that writes nothing).
+inline BtNode condition(std::function<bool(const BrainContext&)> pred) {
+    return [pred = std::move(pred)](BtState& s) {
+        return pred(s.ctx) ? Status::Success : Status::Failure;
+    };
+}
+
+/// Leaf that fills @c out via @p effect and succeeds.
+inline BtNode action(std::function<void(const BrainContext&, Decision&)> effect) {
+    return [effect = std::move(effect)](BtState& s) {
+        effect(s.ctx, s.out);
+        return Status::Success;
+    };
+}
+
+/// Invert Success<->Failure (Running passes through).
+inline BtNode inverter(BtNode child) {
+    return [child = std::move(child)](BtState& s) {
+        const Status st = child(s);
+        if (st == Status::Success) return Status::Failure;
+        if (st == Status::Failure) return Status::Success;
+        return st;
+    };
+}
+
+/// An IBrain that decides by running a behavior tree. Needs no AI provider.
+class BehaviorTreeBrain : public IBrain {
+public:
+    explicit BehaviorTreeBrain(BtNode root, Decision fallback = makeIdle())
+        : m_root(std::move(root)), m_fallback(std::move(fallback)) {}
+
+    Decision think(const BrainContext& ctx) override {
+        Decision out = m_fallback;
+        BtState state{ctx, out};
+        m_root(state);
+        out.valid = true; // a tree always yields a usable decision (idle at worst)
+        return out;
+    }
+
+    const char* name() const override { return "BehaviorTreeBrain"; }
+
+    static Decision makeIdle() {
+        Decision d;
+        d.action = "idle";
+        d.rationale = "nothing to do";
+        return d;
+    }
+
+private:
+    BtNode m_root;
+    Decision m_fallback;
+};
+
+/**
+ * @brief A sensible default NPC: flee perceived threats, else pursue the goal,
+ *        else idle. Demonstrates pursuing goals and reacting to events offline.
+ */
+inline std::unique_ptr<IBrain> makeDefaultNpcBrain() {
+    BtNode reactToThreat = sequence({
+        condition([](const BrainContext& c) { return c.perceived("threat") != nullptr; }),
+        action([](const BrainContext& c, Decision& d) {
+            const Percept* threat = c.perceived("threat");
+            d.action = "flee";
+            d.target = threat->subject;
+            // Head directly away from the threat.
+            const ecs::Vec3 away = (c.selfPosition - threat->position).normalized();
+            d.position = c.selfPosition + away * 5.0f;
+            d.rationale = "fleeing " + threat->subject;
+        }),
+    });
+
+    BtNode pursueGoal = sequence({
+        condition([](const BrainContext& c) { return !c.goal.empty() && !c.atGoal(); }),
+        action([](const BrainContext& c, Decision& d) {
+            d.action = "move_to";
+            d.target = c.goal;
+            d.position = c.goalPosition;
+            d.rationale = "pursuing goal " + c.goal;
+        }),
+    });
+
+    BtNode idle = action([](const BrainContext&, Decision& d) {
+        d.action = "idle";
+        d.rationale = "at goal / nothing to react to";
+    });
+
+    return std::unique_ptr<IBrain>(
+        new BehaviorTreeBrain(selector({std::move(reactToThreat), std::move(pursueGoal), std::move(idle)})));
+}
+
+} // namespace ai
+} // namespace IKore

--- a/src/ai/Brain.h
+++ b/src/ai/Brain.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "core/ecs/components/Components.h"
+
+#include <cstddef>
+#include <deque>
+#include <string>
+#include <vector>
+
+/**
+ * @file Brain.h
+ * @brief Swappable NPC decision-making interface (issue #156).
+ *
+ * Milestone 13 (AI-Native Authoring & NPCs) foundation. Defines a provider-
+ * agnostic brain abstraction: an NPC hands a brain its situation (a BrainContext
+ * - goal, position, what it just perceived, and its memory) and the brain returns
+ * a Decision (an action to take). Concrete brains are swappable behind IBrain:
+ *   - LlmBrain (LlmBrain.h) drives decisions through an injected text-completion
+ *     function, so the engine links no specific AI provider, and
+ *   - BehaviorTreeBrain (BehaviorTree.h) decides with a plain behavior tree and
+ *     no external dependency - the offline fallback.
+ * FallbackBrain composes the two so the engine has no hard dependency on any
+ * single AI provider.
+ *
+ * This header is pure (std + the header-only Vec3), so brains are unit-tested in
+ * isolation; EventSystem wiring lives in Npc.h.
+ */
+namespace IKore {
+namespace ai {
+
+/// One thing an NPC perceives this tick (built from a world/EventSystem event).
+struct Percept {
+    std::string type;       ///< e.g. "threat", "item", "sound", "ally".
+    std::string subject;    ///< who/what (an entity name or tag).
+    float intensity{1.0f};  ///< strength/priority of the stimulus.
+    ecs::Vec3 position{};    ///< where it happened, in world space.
+};
+
+/// A small bounded memory of recent observations (newest last).
+class Memory {
+public:
+    explicit Memory(std::size_t capacity = 16) : m_capacity(capacity == 0 ? 1 : capacity) {}
+
+    /// Record a human-readable note (also fed to an LLM prompt). Evicts oldest.
+    void remember(const std::string& note) {
+        m_notes.push_back(note);
+        while (m_notes.size() > m_capacity) m_notes.pop_front();
+    }
+
+    /// True if any remembered note contains @p substr.
+    bool recalls(const std::string& substr) const {
+        for (const std::string& n : m_notes) {
+            if (n.find(substr) != std::string::npos) return true;
+        }
+        return false;
+    }
+
+    std::size_t size() const { return m_notes.size(); }
+    std::size_t capacity() const { return m_capacity; }
+    void clear() { m_notes.clear(); }
+
+    const std::deque<std::string>& notes() const { return m_notes; }
+
+private:
+    std::deque<std::string> m_notes;
+    std::size_t m_capacity;
+};
+
+/// The NPC's situation, handed to a brain to decide on.
+struct BrainContext {
+    std::string npcName;
+    std::string goal;               ///< current goal tag, e.g. "reach_exit".
+    ecs::Vec3 selfPosition{};
+    ecs::Vec3 goalPosition{};
+    float arriveRadius{0.5f};       ///< treated as "at the goal" within this.
+    std::vector<Percept> percepts;  ///< perceived since the last decision.
+    const Memory* memory{nullptr};  ///< the NPC's memory (may be null).
+
+    /// First percept of @p type this tick, or nullptr if none.
+    const Percept* perceived(const std::string& type) const {
+        for (const Percept& p : percepts) {
+            if (p.type == type) return &p;
+        }
+        return nullptr;
+    }
+
+    /// True when the NPC is within arriveRadius of the goal position.
+    bool atGoal() const { return (goalPosition - selfPosition).length() <= arriveRadius; }
+};
+
+/// A decision: an action plus optional target/destination and a rationale.
+struct Decision {
+    std::string action;     ///< e.g. "move_to", "flee", "interact", "idle".
+    std::string target;     ///< optional subject of the action.
+    ecs::Vec3 position{};    ///< optional destination in world space.
+    std::string rationale;  ///< why - useful for LLM output and debugging.
+    bool valid{true};       ///< false if the brain could not decide (see FallbackBrain).
+};
+
+/// Swappable NPC decision-maker.
+class IBrain {
+public:
+    virtual ~IBrain() = default;
+
+    /// Decide what to do given @p ctx.
+    virtual Decision think(const BrainContext& ctx) = 0;
+
+    /// Stable identifier for logging/debugging (e.g. "LlmBrain").
+    virtual const char* name() const = 0;
+};
+
+} // namespace ai
+} // namespace IKore

--- a/src/ai/LlmBrain.h
+++ b/src/ai/LlmBrain.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include "ai/Brain.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+/**
+ * @file LlmBrain.h
+ * @brief Provider-agnostic LLM brain + offline fallback composer (issue #156).
+ *
+ * Milestone 13. LlmBrain drives NPC decisions through an injected text-completion
+ * function (CompletionFn). The engine therefore links no specific AI provider:
+ * the caller supplies any backend (a hosted API, a local model, or a mock in
+ * tests). LlmBrain formats the BrainContext + memory into a prompt, calls the
+ * completion function, and parses the reply into a Decision.
+ *
+ * If no completion function is set (offline) or the reply cannot be parsed,
+ * LlmBrain returns a Decision with valid=false. FallbackBrain uses that to defer
+ * to a second brain (typically a BehaviorTreeBrain), so the engine has no hard
+ * dependency on any single AI provider and keeps working offline.
+ */
+namespace IKore {
+namespace ai {
+
+/// Provider-agnostic text completion: prompt in, model reply out.
+using CompletionFn = std::function<std::string(const std::string& prompt)>;
+
+class LlmBrain : public IBrain {
+public:
+    explicit LlmBrain(CompletionFn complete, std::string systemPrompt = defaultSystemPrompt())
+        : m_complete(std::move(complete)), m_system(std::move(systemPrompt)) {}
+
+    /// True if a completion backend is attached (an LLM provider is available).
+    bool usable() const { return static_cast<bool>(m_complete); }
+
+    Decision think(const BrainContext& ctx) override {
+        Decision decision;
+        if (!m_complete) { // offline: no provider attached
+            decision.valid = false;
+            decision.rationale = "no LLM provider available";
+            return decision;
+        }
+        const std::string reply = m_complete(buildPrompt(ctx));
+        if (!parseDecision(reply, decision)) {
+            decision = Decision{};
+            decision.valid = false; // unparseable reply: let the caller fall back
+            decision.rationale = "unparseable LLM reply";
+        }
+        return decision;
+    }
+
+    const char* name() const override { return "LlmBrain"; }
+
+    /// Build the prompt from the NPC's goal, position, percepts, and memory.
+    std::string buildPrompt(const BrainContext& ctx) const {
+        std::string p = m_system;
+        p += "\nNPC: " + ctx.npcName;
+        p += "\nGoal: " + (ctx.goal.empty() ? std::string("(none)") : ctx.goal);
+        p += "\nAt goal: " + std::string(ctx.atGoal() ? "yes" : "no");
+        p += "\nPerceived now:";
+        if (ctx.percepts.empty()) {
+            p += " (nothing)";
+        } else {
+            for (const Percept& pc : ctx.percepts) p += " [" + pc.type + ":" + pc.subject + "]";
+        }
+        p += "\nMemory:";
+        if (ctx.memory == nullptr || ctx.memory->size() == 0) {
+            p += " (empty)";
+        } else {
+            for (const std::string& n : ctx.memory->notes()) p += " - " + n;
+        }
+        p += "\nReply with one JSON object: {\"action\": \"...\", \"target\": \"...\", "
+             "\"rationale\": \"...\"}.";
+        return p;
+    }
+
+    /**
+     * @brief Parse a model reply into a Decision. Tolerant of prose around the
+     *        JSON (reads the first quoted value after each key). "action" is
+     *        required; "target"/"rationale" are optional.
+     * @return false if no "action" field is found.
+     */
+    static bool parseDecision(const std::string& reply, Decision& out) {
+        std::string action;
+        if (!extractField(reply, "action", action) || action.empty()) return false;
+        out.action = action;
+        extractField(reply, "target", out.target);
+        extractField(reply, "rationale", out.rationale);
+        out.valid = true;
+        return true;
+    }
+
+    static std::string defaultSystemPrompt() {
+        return "You are an NPC decision-maker. Choose one action that pursues the goal "
+               "and reacts to what is perceived.";
+    }
+
+private:
+    /// Find `"key"`, then the next `"..."` value after the following colon.
+    static bool extractField(const std::string& s, const std::string& key, std::string& out) {
+        const std::string needle = "\"" + key + "\"";
+        std::size_t k = s.find(needle);
+        if (k == std::string::npos) return false;
+        std::size_t colon = s.find(':', k + needle.size());
+        if (colon == std::string::npos) return false;
+        std::size_t q1 = s.find('"', colon + 1);
+        if (q1 == std::string::npos) return false;
+        std::string value;
+        for (std::size_t i = q1 + 1; i < s.size(); ++i) {
+            const char c = s[i];
+            if (c == '\\' && i + 1 < s.size()) { // unescape
+                const char e = s[++i];
+                switch (e) {
+                    case 'n': value += '\n'; break;
+                    case 't': value += '\t'; break;
+                    default: value += e; break;
+                }
+                continue;
+            }
+            if (c == '"') {
+                out = value;
+                return true;
+            }
+            value += c;
+        }
+        return false; // unterminated string
+    }
+
+    CompletionFn m_complete;
+    std::string m_system;
+};
+
+/**
+ * @brief Try a primary brain (e.g. LlmBrain); if it cannot decide (offline or an
+ *        unparseable reply -> Decision.valid == false), defer to a fallback brain
+ *        (e.g. BehaviorTreeBrain). This is what removes any hard dependency on a
+ *        single AI provider.
+ */
+class FallbackBrain : public IBrain {
+public:
+    FallbackBrain(std::unique_ptr<IBrain> primary, std::unique_ptr<IBrain> fallback)
+        : m_primary(std::move(primary)), m_fallback(std::move(fallback)) {}
+
+    Decision think(const BrainContext& ctx) override {
+        if (m_primary) {
+            Decision d = m_primary->think(ctx);
+            if (d.valid) {
+                m_lastUsedPrimary = true;
+                return d;
+            }
+        }
+        m_lastUsedPrimary = false;
+        return m_fallback->think(ctx);
+    }
+
+    const char* name() const override { return "FallbackBrain"; }
+
+    /// True if the most recent think() was answered by the primary brain.
+    bool lastUsedPrimary() const { return m_lastUsedPrimary; }
+
+private:
+    std::unique_ptr<IBrain> m_primary;
+    std::unique_ptr<IBrain> m_fallback;
+    bool m_lastUsedPrimary{false};
+};
+
+} // namespace ai
+} // namespace IKore

--- a/src/ai/Npc.h
+++ b/src/ai/Npc.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "ai/Brain.h"
+#include "core/EventSystem.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * @file Npc.h
+ * @brief An NPC (memory + swappable brain) wired to the EventSystem (issue #156).
+ *
+ * Milestone 13. Npc owns a goal, a Memory, and an IBrain that can be swapped at
+ * runtime. It consumes perceived events (recording them to memory) and, on
+ * decide(), runs its brain over the current situation to choose an action.
+ *
+ * NpcEventBridge connects an Npc to the engine's EventSystem: it subscribes the
+ * NPC to event types (consume - each event becomes a Percept) and publishes the
+ * chosen Decision back as an event (emit), so NPCs "emit/consume EventSystem
+ * events" without the brain layer depending on the event system.
+ */
+namespace IKore {
+namespace ai {
+
+class Npc {
+public:
+    Npc(std::string name, std::unique_ptr<IBrain> brain, std::size_t memoryCapacity = 16)
+        : m_name(std::move(name)), m_brain(std::move(brain)), m_memory(memoryCapacity) {}
+
+    void setGoal(std::string goal, const ecs::Vec3& goalPosition) {
+        m_goal = std::move(goal);
+        m_goalPosition = goalPosition;
+    }
+    void setPosition(const ecs::Vec3& position) { m_selfPosition = position; }
+    void setArriveRadius(float r) { m_arriveRadius = r; }
+
+    /// Swap the decision-making brain at runtime (LLM <-> behavior tree, etc.).
+    void setBrain(std::unique_ptr<IBrain> brain) { m_brain = std::move(brain); }
+    IBrain* brain() { return m_brain.get(); }
+
+    /// Consume a perceived event: buffer it for the next decision and remember it.
+    void perceive(const Percept& p) {
+        m_percepts.push_back(p);
+        m_memory.remember(p.type + ":" + p.subject);
+    }
+
+    /// Run the brain over the current context, then clear this tick's percepts.
+    Decision decide() {
+        BrainContext ctx;
+        ctx.npcName = m_name;
+        ctx.goal = m_goal;
+        ctx.selfPosition = m_selfPosition;
+        ctx.goalPosition = m_goalPosition;
+        ctx.arriveRadius = m_arriveRadius;
+        ctx.percepts = m_percepts;
+        ctx.memory = &m_memory;
+
+        Decision d = m_brain ? m_brain->think(ctx) : Decision{};
+        m_percepts.clear();
+        return d;
+    }
+
+    const std::string& name() const { return m_name; }
+    Memory& memory() { return m_memory; }
+    const Memory& memory() const { return m_memory; }
+    const ecs::Vec3& position() const { return m_selfPosition; }
+    std::size_t pendingPercepts() const { return m_percepts.size(); }
+
+private:
+    std::string m_name;
+    std::unique_ptr<IBrain> m_brain;
+    Memory m_memory;
+    std::string m_goal;
+    ecs::Vec3 m_selfPosition{};
+    ecs::Vec3 m_goalPosition{};
+    float m_arriveRadius{0.5f};
+    std::vector<Percept> m_percepts;
+};
+
+/// Connects an Npc to the EventSystem for consuming and emitting events.
+class NpcEventBridge {
+public:
+    explicit NpcEventBridge(Npc& npc, EventSystem& events = EventSystem::getInstance(),
+                            std::string actionEventType = "npc.action")
+        : m_npc(npc), m_events(events), m_actionEventType(std::move(actionEventType)) {}
+
+    ~NpcEventBridge() {
+        for (const EventSubscription& sub : m_subs) m_events.unsubscribe(sub);
+    }
+
+    NpcEventBridge(const NpcEventBridge&) = delete;
+    NpcEventBridge& operator=(const NpcEventBridge&) = delete;
+
+    /**
+     * @brief Subscribe to @p eventType; each event is consumed as a Percept.
+     *
+     * A TypedEventData<Percept> payload is used directly (its type filled in from
+     * @p eventType if empty); any other payload becomes a minimal Percept tagged
+     * with the event type, so generic world events are still perceived.
+     */
+    void listen(const std::string& eventType) {
+        EventSubscription sub = m_events.subscribe(
+            eventType, [this, eventType](const std::shared_ptr<EventData>& data) {
+                Percept p;
+                if (auto* typed = dynamic_cast<TypedEventData<Percept>*>(data.get())) {
+                    p = typed->data;
+                    if (p.type.empty()) p.type = eventType;
+                } else {
+                    p.type = eventType;
+                }
+                m_npc.perceive(p);
+            });
+        m_subs.push_back(sub);
+    }
+
+    /// Decide and publish the resulting action as an EventSystem event.
+    Decision step() {
+        Decision d = m_npc.decide();
+        m_events.publish<Decision>(m_actionEventType, d);
+        return d;
+    }
+
+private:
+    Npc& m_npc;
+    EventSystem& m_events;
+    std::string m_actionEventType;
+    std::vector<EventSubscription> m_subs;
+};
+
+} // namespace ai
+} // namespace IKore

--- a/tests/test_ai_brain.cpp
+++ b/tests/test_ai_brain.cpp
@@ -1,0 +1,222 @@
+// Test for the IBrain interface + LLM/behavior-tree NPCs - Milestone 13, #156.
+//
+// Verifies the issue's acceptance criteria:
+//   - NPCs pursue goals and react to world events: the behavior-tree brain moves
+//     toward the goal, idles at it, and flees a perceived threat; an NPC wired to
+//     the EventSystem consumes a published threat and emits its action back.
+//   - No hard dependency on any single AI provider: the LLM brain runs through an
+//     injected completion function (a mock here, no provider linked), and when no
+//     provider is available the FallbackBrain transparently uses the offline
+//     behavior tree.
+//
+// Links the engine EventSystem (header-only AI + EventSystem.cpp):
+//   g++ -std=c++17 -I src tests/test_ai_brain.cpp src/core/EventSystem.cpp -o test_ai_brain
+
+#include "ai/BehaviorTree.h"
+#include "ai/LlmBrain.h"
+#include "ai/Npc.h"
+#include "core/EventSystem.h"
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+#include <string>
+
+using namespace IKore;
+using namespace IKore::ai;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static BrainContext makeCtx(const ecs::Vec3& self, const ecs::Vec3& goal,
+                            const std::string& goalTag = "exit") {
+    BrainContext ctx;
+    ctx.npcName = "guard";
+    ctx.goal = goalTag;
+    ctx.selfPosition = self;
+    ctx.goalPosition = goal;
+    return ctx;
+}
+
+static void testBehaviorTreePursuesAndReacts() {
+    std::unique_ptr<IBrain> brain = makeDefaultNpcBrain();
+
+    // Far from the goal, nothing perceived: pursue the goal.
+    {
+        BrainContext ctx = makeCtx({0, 0, 0}, {10, 0, 0});
+        const Decision d = brain->think(ctx);
+        CHECK(d.action == "move_to");
+        CHECK(d.target == "exit");
+        CHECK(std::fabs(d.position.x - 10.0f) < 1e-3f);
+        CHECK(d.valid);
+    }
+
+    // Standing on the goal: idle.
+    {
+        BrainContext ctx = makeCtx({10, 0, 0}, {10, 0, 0});
+        const Decision d = brain->think(ctx);
+        CHECK(d.action == "idle");
+    }
+
+    // A perceived threat overrides goal-seeking: flee away from it.
+    {
+        BrainContext ctx = makeCtx({0, 0, 0}, {10, 0, 0});
+        ctx.percepts.push_back(Percept{"threat", "wolf", 1.0f, {1, 0, 0}});
+        const Decision d = brain->think(ctx);
+        CHECK(d.action == "flee");
+        CHECK(d.target == "wolf");
+        CHECK(d.position.x < 0.0f); // moved away from the threat at +x
+    }
+}
+
+static void testMemoryIsBounded() {
+    Memory m(3);
+    m.remember("saw:a");
+    m.remember("saw:b");
+    m.remember("saw:c");
+    m.remember("saw:d"); // evicts the oldest
+    CHECK(m.size() == 3);
+    CHECK(!m.recalls("saw:a"));
+    CHECK(m.recalls("saw:b"));
+    CHECK(m.recalls("saw:d"));
+}
+
+static void testLlmBrainParsesReply() {
+    // A mock provider: no real AI dependency, deterministic reply.
+    LlmBrain brain([](const std::string&) {
+        return std::string("{\"action\":\"flee\",\"target\":\"wolf\",\"rationale\":\"scared\"}");
+    });
+    CHECK(brain.usable());
+
+    BrainContext ctx = makeCtx({0, 0, 0}, {10, 0, 0});
+    ctx.percepts.push_back(Percept{"threat", "wolf", 1.0f, {1, 0, 0}});
+    Memory mem;
+    mem.remember("heard:howl");
+    ctx.memory = &mem;
+
+    const Decision d = brain.think(ctx);
+    CHECK(d.valid);
+    CHECK(d.action == "flee");
+    CHECK(d.target == "wolf");
+    CHECK(d.rationale == "scared");
+
+    // The prompt should carry the goal, the percept, and the memory.
+    const std::string prompt = brain.buildPrompt(ctx);
+    CHECK(prompt.find("exit") != std::string::npos);
+    CHECK(prompt.find("wolf") != std::string::npos);
+    CHECK(prompt.find("heard:howl") != std::string::npos);
+}
+
+static void testParseDecisionTolerance() {
+    // Prose around the JSON is fine.
+    Decision d;
+    CHECK(LlmBrain::parseDecision(
+        "Sure! My decision: {\"action\": \"move_to\", \"target\": \"exit\"} - good luck", d));
+    CHECK(d.action == "move_to");
+    CHECK(d.target == "exit");
+
+    // No action field -> cannot parse.
+    Decision bad;
+    CHECK(!LlmBrain::parseDecision("{\"target\":\"exit\"}", bad));
+}
+
+static void testFallbackWorksOffline() {
+    // Primary LLM brain with NO provider attached (offline) + behavior-tree
+    // fallback: the NPC must still pursue goals and react to events.
+    FallbackBrain fb(std::unique_ptr<IBrain>(new LlmBrain(CompletionFn{})), makeDefaultNpcBrain());
+
+    BrainContext pursue = makeCtx({0, 0, 0}, {10, 0, 0});
+    Decision d = fb.think(pursue);
+    CHECK(d.action == "move_to");
+    CHECK(!fb.lastUsedPrimary()); // fell back to the offline tree
+
+    BrainContext react = makeCtx({0, 0, 0}, {10, 0, 0});
+    react.percepts.push_back(Percept{"threat", "wolf", 1.0f, {1, 0, 0}});
+    d = fb.think(react);
+    CHECK(d.action == "flee");
+    CHECK(!fb.lastUsedPrimary());
+}
+
+static void testFallbackPrefersLlmWhenAvailable() {
+    // A working provider: the LLM decision is used.
+    auto good = std::unique_ptr<IBrain>(new LlmBrain(
+        [](const std::string&) { return std::string("{\"action\":\"interact\",\"target\":\"lever\"}"); }));
+    FallbackBrain fb(std::move(good), makeDefaultNpcBrain());
+    BrainContext ctx = makeCtx({0, 0, 0}, {10, 0, 0});
+    Decision d = fb.think(ctx);
+    CHECK(d.action == "interact");
+    CHECK(d.target == "lever");
+    CHECK(fb.lastUsedPrimary());
+
+    // A provider that returns garbage -> unparseable -> fall back to the tree.
+    auto bad = std::unique_ptr<IBrain>(
+        new LlmBrain([](const std::string&) { return std::string("I am not sure what to do."); }));
+    FallbackBrain fb2(std::move(bad), makeDefaultNpcBrain());
+    d = fb2.think(ctx);
+    CHECK(d.action == "move_to"); // tree pursued the goal
+    CHECK(!fb2.lastUsedPrimary());
+}
+
+static void testNpcConsumesAndEmitsEvents() {
+    EventSystem& es = EventSystem::getInstance();
+    es.clear();
+
+    Npc npc("guard", makeDefaultNpcBrain());
+    npc.setGoal("exit", {10, 0, 0});
+    npc.setPosition({0, 0, 0});
+
+    NpcEventBridge bridge(npc, es);
+    bridge.listen("threat"); // consume threats from the EventSystem
+
+    // Capture the NPC's emitted actions.
+    std::string emittedAction;
+    EventSubscription actionSub = es.subscribe("npc.action", [&](const std::shared_ptr<EventData>& d) {
+        if (auto* td = dynamic_cast<TypedEventData<Decision>*>(d.get())) {
+            emittedAction = td->data.action;
+        }
+    });
+
+    // Publish a world event: the NPC consumes it as a percept and remembers it.
+    es.publish<Percept>("threat", Percept{"threat", "wolf", 1.0f, {1, 0, 0}});
+    CHECK(npc.pendingPercepts() == 1);
+    CHECK(npc.memory().recalls("wolf"));
+
+    // Decide + emit: it reacts to the consumed threat and publishes the action.
+    Decision d = bridge.step();
+    CHECK(d.action == "flee");
+    CHECK(emittedAction == "flee"); // the action was emitted as an event
+    CHECK(npc.pendingPercepts() == 0);
+
+    // With nothing perceived, it pursues the goal and emits that.
+    emittedAction.clear();
+    d = bridge.step();
+    CHECK(d.action == "move_to");
+    CHECK(emittedAction == "move_to");
+
+    es.unsubscribe(actionSub);
+    es.clear();
+}
+
+int main() {
+    testBehaviorTreePursuesAndReacts();
+    testMemoryIsBounded();
+    testLlmBrainParsesReply();
+    testParseDecisionTolerance();
+    testFallbackWorksOffline();
+    testFallbackPrefersLlmWhenAvailable();
+    testNpcConsumesAndEmitsEvents();
+
+    if (g_failures == 0) {
+        std::printf("All AI brain (IBrain + LLM/BT NPC) tests passed.\n");
+        return 0;
+    }
+    std::printf("%d AI brain test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Starts Milestone 13 (AI-Native Authoring & NPCs) with a swappable, provider-agnostic NPC decision-making layer under `src/ai/` (namespace `IKore::ai`). Closes #156.

### Architecture

- **`Brain.h`** - the core abstraction. An NPC hands a brain a `BrainContext` (goal, position, what it perceived this tick, and its `Memory`) and the brain returns a `Decision` (action + optional target/destination + rationale). `IBrain` makes the decision-maker swappable; `Memory` is a small bounded store of recent observations. Pure (std + the header-only `Vec3`).

- **`BehaviorTree.h`** - a minimal, dependency-free behavior tree (`Sequence` / `Selector` / `Condition` / `Action` / `Inverter`) and `BehaviorTreeBrain`. `makeDefaultNpcBrain()` builds a tree that flees a perceived threat, otherwise pursues the goal, otherwise idles - so an NPC pursues goals and reacts to events with zero external dependencies. **This is the offline fallback.**

- **`LlmBrain.h`** - `LlmBrain` drives decisions through an injected `CompletionFn` (prompt in, reply out), so **the engine links no specific AI provider**: the caller supplies any backend (hosted, local, or a mock in tests). It formats the context plus memory into a prompt, calls the function, and parses the reply tolerantly (reads the first quoted value after each key; `action` required). If no provider is attached or the reply is unparseable it returns `Decision.valid = false`, and **`FallbackBrain`** uses that to defer to a second brain - removing any hard dependency on a single provider.

- **`Npc.h`** - `Npc` owns a goal, `Memory`, and a runtime-swappable brain; it consumes percepts (recording them to memory) and decides via its brain. **`NpcEventBridge`** wires an `Npc` to the engine `EventSystem`: it subscribes to event types (consume - each event becomes a `Percept`) and publishes the chosen `Decision` back as an event (emit), so NPCs emit/consume EventSystem events without the brain layer depending on the event system.

## Acceptance criteria

- [x] NPCs pursue goals and react to world events (the behavior tree moves toward the goal, idles at it, and flees a perceived threat; an NPC wired to the EventSystem consumes a published threat and emits its reaction)
- [x] No hard dependency on any single AI provider, offline fallback works (the LLM brain runs through an injected completion function with nothing linked; when no provider is available `FallbackBrain` transparently uses the offline behavior tree)

## Testing

`tests/test_ai_brain.cpp` (wired as the `test_ai_brain` CMake target; links `EventSystem.cpp` for the real emit/consume path):

- Behavior tree pursues the goal, idles on it, and flees a perceived threat.
- Bounded memory (eviction + recall).
- `LlmBrain` prompt building (carries goal, percept, and memory) and tolerant reply parsing, including prose wrapped around the JSON and a missing-`action` reply that fails to parse.
- `FallbackBrain` uses the offline tree when no provider is attached and prefers the LLM when one is (and falls back when the LLM returns garbage).
- An NPC consumes a threat published through the `EventSystem` (memory updated, percept buffered), then emits its reaction (`flee`) back as an `npc.action` event a subscriber receives; with nothing perceived it pursues the goal instead.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_ai_brain.cpp src/core/EventSystem.cpp -o test_ai_brain && ./test_ai_brain
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

New layer is decoupled from the legacy `AIComponent`/`AISystem` (kept as-is) and uses the existing `EventSystem`. Follow-ons in M13 build on this `IBrain` foundation.