### PR TITLE
feat(sim): deterministic fixed-point core and state hash for netcode (#159)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,6 +516,11 @@ add_executable(test_quest_gen
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_quest_gen.cpp
 )
 
+# Deterministic simulation core for netcode (Milestone 14 / #159) - header-only.
+add_executable(test_determinism
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_determinism.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/sim/Fixed.h
+++ b/src/core/sim/Fixed.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <cstdint>
+
+/**
+ * @file Fixed.h
+ * @brief Deterministic fixed-point real number for lockstep netcode (issue #159).
+ *
+ * Milestone 14. Floating point is the main cross-platform non-determinism hazard:
+ * x87 vs SSE, fused multiply-add contraction, compiler fast-math, and libm
+ * transcendentals all produce subtly different results on different machines and
+ * builds, which desyncs a lockstep simulation. Fixed replaces float in the
+ * simulation core with a Q16.16 fixed-point value stored in an int32_t: every
+ * operation is pure integer arithmetic with 64-bit intermediates, so the result
+ * is bit-identical on every platform and compiler.
+ *
+ * 16 fractional bits give a resolution of 1/65536 (~1.5e-5) over a range of about
+ * +/-32768 - suitable for bounded simulation coordinates. Construct canonical
+ * inputs without float via fromInt / fromFraction / fromRaw so that all machines
+ * quantize identical inputs identically; fromFloat exists for convenience but
+ * should only be used for build-time constants. Arithmetic saturates rather than
+ * overflowing, and division truncates toward zero - both deterministic.
+ *
+ * Header-only and dependency-free.
+ */
+namespace IKore {
+namespace sim {
+
+class Fixed {
+public:
+    static constexpr int kFracBits = 16;
+    static constexpr int32_t kOneRaw = 1 << kFracBits;
+
+    constexpr Fixed() = default;
+
+    /// The underlying Q16.16 integer (this is the canonical, hashable state).
+    int32_t raw{0};
+
+    static constexpr Fixed fromRaw(int32_t r) {
+        Fixed f;
+        f.raw = r;
+        return f;
+    }
+    static Fixed fromInt(int n) { return fromRaw(narrow(static_cast<int64_t>(n) * kOneRaw)); }
+    /// Exact rational num/den without float (deterministic quantization of inputs).
+    static Fixed fromFraction(int num, int den) {
+        if (den == 0) return fromRaw(num < 0 ? INT32_MIN : INT32_MAX);
+        return fromRaw(narrow((static_cast<int64_t>(num) * kOneRaw) / den));
+    }
+    /// Convenience for build-time constants only; avoid on the simulation hot path.
+    static Fixed fromFloat(double d) {
+        return fromRaw(narrow(static_cast<int64_t>(d * static_cast<double>(kOneRaw))));
+    }
+
+    static constexpr Fixed zero() { return fromRaw(0); }
+    static constexpr Fixed one() { return fromRaw(kOneRaw); }
+
+    int toInt() const { return static_cast<int>(raw >> kFracBits); } // floor
+    double toDouble() const { return static_cast<double>(raw) / static_cast<double>(kOneRaw); }
+
+    Fixed operator+(Fixed o) const { return fromRaw(narrow(static_cast<int64_t>(raw) + o.raw)); }
+    Fixed operator-(Fixed o) const { return fromRaw(narrow(static_cast<int64_t>(raw) - o.raw)); }
+    Fixed operator-() const { return fromRaw(narrow(-static_cast<int64_t>(raw))); }
+
+    Fixed operator*(Fixed o) const {
+        const int64_t product = static_cast<int64_t>(raw) * o.raw;
+        return fromRaw(narrow(product >> kFracBits)); // arithmetic shift = /2^16
+    }
+    Fixed operator/(Fixed o) const {
+        if (o.raw == 0) return fromRaw(raw < 0 ? INT32_MIN : INT32_MAX); // saturate
+        const int64_t numerator = static_cast<int64_t>(raw) * kOneRaw;
+        return fromRaw(narrow(numerator / o.raw)); // truncates toward zero
+    }
+
+    Fixed& operator+=(Fixed o) { return *this = *this + o; }
+    Fixed& operator-=(Fixed o) { return *this = *this - o; }
+    Fixed& operator*=(Fixed o) { return *this = *this * o; }
+    Fixed& operator/=(Fixed o) { return *this = *this / o; }
+
+    bool operator==(Fixed o) const { return raw == o.raw; }
+    bool operator!=(Fixed o) const { return raw != o.raw; }
+    bool operator<(Fixed o) const { return raw < o.raw; }
+    bool operator<=(Fixed o) const { return raw <= o.raw; }
+    bool operator>(Fixed o) const { return raw > o.raw; }
+    bool operator>=(Fixed o) const { return raw >= o.raw; }
+
+    Fixed abs() const { return fromRaw(raw < 0 ? narrow(-static_cast<int64_t>(raw)) : raw); }
+
+    /// Deterministic square root (integer Newton-free bit method; no float).
+    static Fixed sqrt(Fixed x) {
+        if (x.raw <= 0) return zero();
+        // sqrt(x) in Q16.16: result_raw = isqrt(raw << 16).
+        const uint64_t r = isqrt(static_cast<uint64_t>(x.raw) << kFracBits);
+        return fromRaw(narrow(static_cast<int64_t>(r)));
+    }
+
+    /// Integer square root of a 64-bit value (floor), pure integer math.
+    static uint64_t isqrt(uint64_t n) {
+        uint64_t result = 0;
+        uint64_t bit = static_cast<uint64_t>(1) << 62;
+        while (bit > n) bit >>= 2;
+        while (bit != 0) {
+            if (n >= result + bit) {
+                n -= result + bit;
+                result = (result >> 1) + bit;
+            } else {
+                result >>= 1;
+            }
+            bit >>= 2;
+        }
+        return result;
+    }
+
+private:
+    /// Saturating narrow from the 64-bit intermediate to the Q16.16 int32 (deterministic).
+    static constexpr int32_t narrow(int64_t v) {
+        return v > INT32_MAX ? INT32_MAX : (v < INT32_MIN ? INT32_MIN : static_cast<int32_t>(v));
+    }
+};
+
+} // namespace sim
+} // namespace IKore

--- a/src/core/sim/StateHash.h
+++ b/src/core/sim/StateHash.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "core/sim/Fixed.h"
+
+#include <cstdint>
+
+/**
+ * @file StateHash.h
+ * @brief Deterministic checksum of simulation state for lockstep (issue #159).
+ *
+ * Milestone 14. In lockstep / rollback netcode each peer advances the same
+ * deterministic simulation from the same inputs and periodically exchanges a
+ * checksum of its state; a mismatch flags a desync. StateHash is a 64-bit FNV-1a
+ * accumulator fed the canonical integer representation of state (Fixed::raw, RNG
+ * state, tick counts, entity fields), never floats - so the digest is bit-
+ * identical across platforms whenever the state is.
+ *
+ * The hash is order-dependent by design: peers must feed values in the same order
+ * (e.g. iterate entities in the ECS's deterministic archetype/row order, and any
+ * std::map in key order - never an unordered_map). Header-only.
+ */
+namespace IKore {
+namespace sim {
+
+class StateHash {
+public:
+    /// Feed a raw 64-bit value (one FNV-1a step).
+    void add(uint64_t value) {
+        m_hash ^= value;
+        m_hash *= kPrime;
+    }
+    void addI64(int64_t value) { add(static_cast<uint64_t>(value)); }
+    void addU32(uint32_t value) { add(static_cast<uint64_t>(value)); }
+    void addI32(int32_t value) { add(static_cast<uint64_t>(static_cast<uint32_t>(value))); }
+
+    /// Feed a Fixed by its exact integer representation (never its float value).
+    void addFixed(Fixed value) { addI32(value.raw); }
+
+    uint64_t digest() const { return m_hash; }
+    void reset() { m_hash = kOffsetBasis; }
+
+private:
+    static constexpr uint64_t kOffsetBasis = 14695981039346656037ULL;
+    static constexpr uint64_t kPrime = 1099511628211ULL;
+    uint64_t m_hash{kOffsetBasis};
+};
+
+} // namespace sim
+} // namespace IKore

--- a/tests/test_determinism.cpp
+++ b/tests/test_determinism.cpp
@@ -1,0 +1,149 @@
+// Test for the deterministic simulation core - Milestone 14, #159.
+//
+// Verifies the issue's acceptance criteria:
+//   - Identical inputs produce identical state: a lockstep simulation built on
+//     Fixed (fixed-point) + DeterministicRng yields the same state hash across
+//     repeat runs and across different step chunking, and matches a pinned golden
+//     digest (so a different machine/build that diverged would fail this test).
+//   - Sources of non-determinism are controlled: the state is integer Fixed (no
+//     float), the only randomness is the integer DeterministicRng, and iteration
+//     order is a fixed vector order fed into an order-defined hash.
+//
+// Pure std + header-only sim core:
+//   g++ -std=c++17 -I src tests/test_determinism.cpp -o test_determinism
+
+#include "core/sim/Fixed.h"
+#include "core/sim/Simulation.h" // DeterministicRng
+#include "core/sim/StateHash.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::sim;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static void testFixedExactArithmetic() {
+    // Exact rationals, no float involved.
+    CHECK((Fixed::fromInt(2) + Fixed::fromInt(3)).raw == Fixed::fromInt(5).raw);
+    CHECK((Fixed::fromInt(7) - Fixed::fromInt(10)).raw == Fixed::fromInt(-3).raw);
+
+    const Fixed half = Fixed::fromFraction(1, 2);
+    const Fixed quarter = Fixed::fromFraction(1, 4);
+    CHECK(half.raw == 32768);             // 0.5 in Q16.16
+    CHECK(quarter.raw == 16384);          // 0.25
+    CHECK((half * half).raw == quarter.raw);   // 0.5 * 0.5 == 0.25 exactly
+    CHECK((quarter / half).raw == half.raw);   // 0.25 / 0.5 == 0.5 exactly
+
+    // Square root is exact for perfect squares and deterministic otherwise.
+    CHECK(Fixed::sqrt(Fixed::fromInt(4)).raw == Fixed::fromInt(2).raw);
+    CHECK(Fixed::sqrt(Fixed::fromInt(9)).raw == Fixed::fromInt(3).raw);
+    const Fixed root2 = Fixed::sqrt(Fixed::fromInt(2));
+    CHECK(root2.raw == 92681); // floor(sqrt(2) * 65536), a fixed integer on every build
+
+    // Saturation rather than undefined overflow.
+    CHECK((Fixed::fromInt(30000) * Fixed::fromInt(30000)).raw == INT32_MAX);
+    // Division by zero saturates by sign.
+    CHECK((Fixed::fromInt(1) / Fixed::zero()).raw == INT32_MAX);
+    CHECK((Fixed::fromInt(-1) / Fixed::zero()).raw == INT32_MIN);
+}
+
+// A tiny deterministic lockstep world: integer Fixed agents stepping toward a
+// goal, perturbed only by the integer DeterministicRng.
+struct Agent {
+    Fixed x, z;
+};
+
+static void stepWorld(std::vector<Agent>& world, DeterministicRng& rng, Fixed goalX, Fixed goalZ) {
+    const Fixed speed = Fixed::fromFraction(1, 10);
+    for (Agent& a : world) {
+        const Fixed dx = goalX - a.x;
+        const Fixed dz = goalZ - a.z;
+        const Fixed dist = Fixed::sqrt(dx * dx + dz * dz);
+        if (dist.raw > 0) {
+            a.x += dx * speed / dist;
+            a.z += dz * speed / dist;
+        }
+        // Deterministic integer perturbation (no float, controlled RNG).
+        a.x += Fixed::fromFraction(rng.nextInt(-1, 1), 100);
+    }
+}
+
+// Run the lockstep sim and return a deterministic hash of the final state.
+static uint64_t runSim(std::uint64_t seed, int steps, int agentCount) {
+    DeterministicRng rng(seed);
+    std::vector<Agent> world(static_cast<std::size_t>(agentCount));
+    for (int i = 0; i < agentCount; ++i) {
+        world[static_cast<std::size_t>(i)].x = Fixed::fromInt(i);
+        world[static_cast<std::size_t>(i)].z = Fixed::fromInt(0);
+    }
+    const Fixed goalX = Fixed::fromInt(50), goalZ = Fixed::fromInt(50);
+    for (int s = 0; s < steps; ++s) stepWorld(world, rng, goalX, goalZ);
+
+    StateHash h;
+    for (const Agent& a : world) {
+        h.addFixed(a.x);
+        h.addFixed(a.z);
+    }
+    h.addI64(static_cast<int64_t>(rng.state())); // include the RNG stream position
+    return h.digest();
+}
+
+// Same as runSim but advances in two separate batches, mimicking a peer that
+// chunks the steps differently. Must yield the identical hash.
+static uint64_t runSimChunked(std::uint64_t seed, int steps, int agentCount) {
+    DeterministicRng rng(seed);
+    std::vector<Agent> world(static_cast<std::size_t>(agentCount));
+    for (int i = 0; i < agentCount; ++i) {
+        world[static_cast<std::size_t>(i)].x = Fixed::fromInt(i);
+        world[static_cast<std::size_t>(i)].z = Fixed::fromInt(0);
+    }
+    const Fixed goalX = Fixed::fromInt(50), goalZ = Fixed::fromInt(50);
+    const int firstBatch = steps / 3;
+    for (int s = 0; s < firstBatch; ++s) stepWorld(world, rng, goalX, goalZ);
+    for (int s = firstBatch; s < steps; ++s) stepWorld(world, rng, goalX, goalZ);
+
+    StateHash h;
+    for (const Agent& a : world) {
+        h.addFixed(a.x);
+        h.addFixed(a.z);
+    }
+    h.addI64(static_cast<int64_t>(rng.state()));
+    return h.digest();
+}
+
+static void testLockstepDeterminism() {
+    // Pinned digest of the lockstep run, captured on a reference build. A platform
+    // or build that diverged (float creep, shift semantics, RNG drift) would
+    // produce a different digest and fail here.
+    const std::uint64_t kGolden = 0x36760d0b0e95a2f0ULL;
+
+    const uint64_t a = runSim(12345, 100, 8);
+    const uint64_t b = runSim(12345, 100, 8);
+
+    CHECK(a == b);                          // identical inputs -> identical state
+    CHECK(a != runSim(54321, 100, 8));      // different seed -> different state
+    CHECK(a == runSimChunked(12345, 100, 8)); // chunking the steps changes nothing
+    CHECK(a == kGolden);                    // pinned: a divergent build would fail here
+}
+
+int main() {
+    testFixedExactArithmetic();
+    testLockstepDeterminism();
+
+    if (g_failures == 0) {
+        std::printf("All determinism tests passed.\n");
+        return 0;
+    }
+    std::printf("%d determinism test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Starts Milestone 14 (Deterministic Replay & Rollback Netcode) by giving the simulation core the pieces it needs to be bit-identical across platforms and builds for lockstep networking. Closes #159.

Floating point is the main cross-platform non-determinism hazard (x87 vs SSE, FMA contraction, fast-math, libm transcendentals), so the core gets a fixed-point real type instead:

- **`src/core/sim/Fixed.h`** - a Q16.16 fixed-point value in an `int32_t`. Every operation (add, sub, mul, div, sqrt, abs, compare) is pure integer arithmetic with 64-bit intermediates, so results are identical on every platform and compiler. Canonical inputs are built without float via `fromInt` / `fromFraction` / `fromRaw`; arithmetic saturates instead of overflowing and division truncates toward zero (both deterministic); `sqrt` uses an integer bit method (no float). Shifts avoid undefined left-shift-of-negative.
- **`src/core/sim/StateHash.h`** - a 64-bit FNV-1a checksum fed the canonical integer representation of state (`Fixed::raw`, RNG state, ints) - never floats - so peers can compare a per-tick digest to detect desync. Order-dependent by design; values are fed in the engine's deterministic iteration order.

The other two non-determinism sources are already controlled: the RNG is the integer SplitMix64 `DeterministicRng` (#152), and the ECS iterates in a fixed archetype/row order.

## Acceptance criteria

- [x] Identical inputs produce identical state on different machines/builds (a lockstep sim's state hash is reproducible across runs, unchanged under different step chunking, and pinned to a golden digest so a divergent build fails the test)
- [x] Sources of non-determinism (float, iteration order, RNG) are eliminated or controlled (state is integer `Fixed`, randomness is the integer `DeterministicRng`, iteration is a fixed order fed into an order-defined hash)

## Testing

`tests/test_determinism.cpp` (wired as the `test_determinism` CMake target):

- Exact fixed-point arithmetic: `0.5 * 0.5 == 0.25` and `0.25 / 0.5 == 0.5` exactly, `sqrt` of perfect squares exact, `sqrt(2)` a fixed integer (`92681`) on every build, multiply saturation, and divide-by-zero saturating by sign.
- A lockstep simulation built on `Fixed` + `DeterministicRng` whose state hash is identical across repeat runs, differs for a different seed, is unchanged when the steps are chunked differently (as a peer would), and matches a pinned golden digest.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_determinism.cpp -o test_determinism && ./test_determinism
```

All tests pass clean under the address and undefined-behavior sanitizers (UBSan confirms no shift UB).

## Notes

Reuses the integer `DeterministicRng` from #152. This is the deterministic substrate the rest of M14 (replay, rollback, lockstep transport) builds on.