### PR TITLE
feat(net): GGPO-style rollback and input prediction (#160)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,6 +521,11 @@ add_executable(test_determinism
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_determinism.cpp
 )
 
+# Rollback + input prediction netcode (Milestone 14 / #160) - header-only.
+add_executable(test_rollback
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_rollback.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/net/Rollback.h
+++ b/src/net/Rollback.h
@@ -1,0 +1,203 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <utility>
+#include <vector>
+
+/**
+ * @file Rollback.h
+ * @brief GGPO-style rollback + input prediction netcode (issue #160).
+ *
+ * Milestone 14. A deterministic rollback session built on the simulation core
+ * (#159): every peer runs the same deterministic step from the same inputs, so
+ * given identical inputs they reach identical state. Because remote inputs arrive
+ * late (latency) or out of order / dropped (loss), each peer predicts the missing
+ * inputs (repeat the last known input) and advances anyway. When an authoritative
+ * remote input arrives for a past frame and differs from what was predicted, the
+ * session rolls back to that frame, restores the saved state, and resimulates
+ * forward with the corrected inputs - producing the correct state with no visible
+ * corruption (only a brief silent correction).
+ *
+ * RollbackSession is templated on the user's State (a value type, snapshotted per
+ * frame) and Input (a small value type with operator==). The step function
+ * advances State by one fixed frame given every player's input for that frame:
+ * use the deterministic Fixed math + DeterministicRng from #159 inside it. This
+ * is the engine-agnostic core a NetworkComponent / NetworkSystem can drive.
+ *
+ * Header-only and dependency-free.
+ */
+namespace IKore {
+namespace net {
+
+template <class Input>
+struct InputSlot {
+    Input value{};
+    bool present{false};   ///< an input (predicted or authoritative) exists here.
+    bool confirmed{false}; ///< the input is authoritative (not a prediction).
+};
+
+template <class State, class Input>
+class RollbackSession {
+public:
+    /// step(state, inputsForFrame, frame): advance one fixed frame deterministically.
+    using StepFn = std::function<void(State&, const std::vector<Input>&, int)>;
+
+    RollbackSession(int numPlayers, int localPlayer, State initial, StepFn step,
+                    int maxRollbackFrames = 256)
+        : m_numPlayers(numPlayers),
+          m_local(localPlayer),
+          m_state(std::move(initial)),
+          m_step(std::move(step)),
+          m_window(maxRollbackFrames < 1 ? 1 : maxRollbackFrames) {
+        m_inputs.resize(static_cast<std::size_t>(numPlayers));
+        m_snapshots[0] = m_state; // state at frame 0
+    }
+
+    int currentFrame() const { return m_frame; }
+    const State& state() const { return m_state; }
+    int rollbackCount() const { return m_rollbackCount; }
+    int numPlayers() const { return m_numPlayers; }
+
+    /**
+     * @brief Advance one frame using the local player's authoritative input.
+     *        Missing remote inputs are predicted (repeat last known).
+     */
+    void advanceFrame(const Input& localInput) {
+        ensureFrame(m_frame);
+        setInput(m_local, m_frame, localInput, /*confirmed=*/true);
+        for (int p = 0; p < m_numPlayers; ++p) {
+            if (p == m_local) continue;
+            if (!slot(p, m_frame).present) {
+                setInput(p, m_frame, predict(p, m_frame), /*confirmed=*/false);
+            }
+        }
+        m_snapshots[m_frame] = m_state; // state at this frame, before stepping it
+        simulate(m_frame);
+        ++m_frame;
+        trimSnapshots();
+    }
+
+    /**
+     * @brief Apply an authoritative input from a remote peer for (player, frame).
+     *
+     * If that frame was already simulated with a different predicted input, the
+     * session rolls back to it and resimulates forward. A future frame is simply
+     * recorded and used authoritatively when reached.
+     */
+    void addRemoteInput(int player, int frame, const Input& input) {
+        if (player < 0 || player >= m_numPlayers || frame < 0) return;
+        ensureFrame(frame);
+        InputSlot<Input>& s = slot(player, frame);
+        const bool wasPredicted = s.present && !s.confirmed;
+        const bool mispredicted = wasPredicted && !(s.value == input);
+        s.value = input;
+        s.present = true;
+        s.confirmed = true;
+
+        if (frame < m_frame && mispredicted) rollbackAndResimulate(frame);
+    }
+
+    /// Highest frame F such that every player's input is confirmed for [0, F).
+    int confirmedFrame() const {
+        for (int f = 0;; ++f) {
+            for (int p = 0; p < m_numPlayers; ++p) {
+                const auto& col = m_inputs[static_cast<std::size_t>(p)];
+                if (f >= static_cast<int>(col.size()) || !col[static_cast<std::size_t>(f)].present ||
+                    !col[static_cast<std::size_t>(f)].confirmed) {
+                    return f;
+                }
+            }
+        }
+    }
+
+    /// State at a past frame boundary (if still within the snapshot window).
+    bool snapshotAt(int frame, State& out) const {
+        auto it = m_snapshots.find(frame);
+        if (it == m_snapshots.end()) return false;
+        out = it->second;
+        return true;
+    }
+
+private:
+    InputSlot<Input>& slot(int p, int frame) {
+        return m_inputs[static_cast<std::size_t>(p)][static_cast<std::size_t>(frame)];
+    }
+    const InputSlot<Input>& slot(int p, int frame) const {
+        return m_inputs[static_cast<std::size_t>(p)][static_cast<std::size_t>(frame)];
+    }
+
+    void ensureFrame(int frame) {
+        for (auto& col : m_inputs) {
+            if (static_cast<int>(col.size()) <= frame) col.resize(static_cast<std::size_t>(frame) + 1);
+        }
+    }
+
+    void setInput(int p, int frame, const Input& value, bool confirmed) {
+        InputSlot<Input>& s = slot(p, frame);
+        s.value = value;
+        s.present = true;
+        s.confirmed = confirmed;
+    }
+
+    /// Predict a player's input at @p frame: repeat its most recent known input.
+    Input predict(int p, int frame) const {
+        const auto& col = m_inputs[static_cast<std::size_t>(p)];
+        for (int f = frame - 1; f >= 0; --f) {
+            if (f < static_cast<int>(col.size()) && col[static_cast<std::size_t>(f)].present) {
+                return col[static_cast<std::size_t>(f)].value;
+            }
+        }
+        return Input{};
+    }
+
+    void simulate(int frame) {
+        std::vector<Input> inputs(static_cast<std::size_t>(m_numPlayers));
+        for (int p = 0; p < m_numPlayers; ++p) inputs[static_cast<std::size_t>(p)] = slot(p, frame).value;
+        m_step(m_state, inputs, frame);
+    }
+
+    void rollbackAndResimulate(int target) {
+        auto it = m_snapshots.find(target);
+        if (it == m_snapshots.end()) { // too old to correct; clamp to the oldest we kept
+            it = m_snapshots.begin();
+            target = it->first;
+        }
+        const int head = m_frame;
+        m_state = it->second;
+        m_frame = target;
+        for (int f = target; f < head; ++f) {
+            // Re-predict any still-unconfirmed remote inputs using corrected history.
+            for (int p = 0; p < m_numPlayers; ++p) {
+                if (p == m_local) continue;
+                if (!slot(p, f).confirmed) setInput(p, f, predict(p, f), /*confirmed=*/false);
+            }
+            m_snapshots[f] = m_state;
+            simulate(f);
+            ++m_frame;
+        }
+        ++m_rollbackCount;
+    }
+
+    void trimSnapshots() {
+        const int oldest = m_frame - m_window;
+        if (oldest <= 0) return;
+        while (!m_snapshots.empty() && m_snapshots.begin()->first < oldest) {
+            m_snapshots.erase(m_snapshots.begin());
+        }
+    }
+
+    int m_numPlayers;
+    int m_local;
+    State m_state;
+    StepFn m_step;
+    int m_window;
+    int m_frame{0};
+    int m_rollbackCount{0};
+    std::vector<std::vector<InputSlot<Input>>> m_inputs; // [player][frame]
+    std::map<int, State> m_snapshots;                    // frame -> state at that frame
+};
+
+} // namespace net
+} // namespace IKore

--- a/tests/test_rollback.cpp
+++ b/tests/test_rollback.cpp
@@ -1,0 +1,190 @@
+// Test for GGPO-style rollback + input prediction - Milestone 14, #160.
+//
+// Verifies the issue's acceptance criteria:
+//   - Two clients stay in sync under simulated latency and packet loss: two
+//     RollbackSessions exchange inputs over a delayed, lossy channel and, once all
+//     inputs are delivered, reach byte-identical state equal to a no-network
+//     reference.
+//   - Mispredictions roll back and resimulate without visible corruption: a
+//     session that predicted wrong inputs, on receiving the authoritative ones,
+//     rolls back and lands on exactly the reference state.
+//
+// Built on the deterministic core (#159): integer Fixed state + StateHash.
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_rollback.cpp -o test_rollback
+
+#include "core/sim/Fixed.h"
+#include "core/sim/Simulation.h" // DeterministicRng
+#include "core/sim/StateHash.h"
+#include "net/Rollback.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore;
+using IKore::net::RollbackSession;
+using IKore::sim::DeterministicRng;
+using IKore::sim::Fixed;
+using IKore::sim::StateHash;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// --- The shared deterministic simulation (used by clients and the reference) ---
+
+struct Input {
+    int move{0};
+    bool operator==(const Input& o) const { return move == o.move; }
+};
+
+struct World {
+    Fixed x[2];
+};
+
+// Each agent moves by its input, then is pulled toward the other agent - so a
+// wrong predicted input for one player corrupts both positions until corrected,
+// making rollback observable.
+static void stepWorld(World& w, const std::vector<Input>& in, int /*frame*/) {
+    const Fixed speed = Fixed::fromFraction(1, 4);
+    const Fixed pull = Fixed::fromFraction(1, 16);
+    Fixed nx0 = w.x[0] + Fixed::fromInt(in[0].move) * speed;
+    Fixed nx1 = w.x[1] + Fixed::fromInt(in[1].move) * speed;
+    nx0 = nx0 + (w.x[1] - w.x[0]) * pull;
+    nx1 = nx1 + (w.x[0] - w.x[1]) * pull;
+    w.x[0] = nx0;
+    w.x[1] = nx1;
+}
+
+static uint64_t hashWorld(const World& w) {
+    StateHash h;
+    h.addFixed(w.x[0]);
+    h.addFixed(w.x[1]);
+    return h.digest();
+}
+
+// Ground truth: simulate N frames with all inputs authoritative (no prediction).
+static World referenceRun(const std::vector<Input>& p0, const std::vector<Input>& p1, int n) {
+    World w;
+    for (int f = 0; f < n; ++f) {
+        std::vector<Input> in = {p0[static_cast<std::size_t>(f)], p1[static_cast<std::size_t>(f)]};
+        stepWorld(w, in, f);
+    }
+    return w;
+}
+
+static std::vector<Input> scriptInputs(std::uint64_t seed, int n) {
+    DeterministicRng rng(seed);
+    std::vector<Input> v(static_cast<std::size_t>(n));
+    for (int f = 0; f < n; ++f) v[static_cast<std::size_t>(f)].move = rng.nextInt(-1, 1);
+    return v;
+}
+
+static void testNoRollbackWhenPredictionIsCorrect() {
+    // Player 1 always inputs 0, which equals the default prediction.
+    RollbackSession<World, Input> s(2, /*local=*/0, World{}, stepWorld);
+    const int n = 10;
+    for (int f = 0; f < n; ++f) s.advanceFrame(Input{1});
+    for (int f = 0; f < n; ++f) s.addRemoteInput(1, f, Input{0}); // matches prediction
+
+    CHECK(s.rollbackCount() == 0); // nothing was mispredicted
+    std::vector<Input> p0(static_cast<std::size_t>(n), Input{1});
+    std::vector<Input> p1(static_cast<std::size_t>(n), Input{0});
+    CHECK(hashWorld(s.state()) == hashWorld(referenceRun(p0, p1, n)));
+}
+
+static void testMispredictionRollsBackToCorrectState() {
+    RollbackSession<World, Input> s(2, /*local=*/0, World{}, stepWorld);
+    const int n = 12;
+    std::vector<Input> p0 = scriptInputs(1, n);
+    std::vector<Input> p1 = scriptInputs(2, n); // varied -> default 0 prediction is wrong
+
+    for (int f = 0; f < n; ++f) s.advanceFrame(p0[static_cast<std::size_t>(f)]);
+    // The authoritative remote inputs arrive late; delivering them corrects state.
+    for (int f = 0; f < n; ++f) s.addRemoteInput(1, f, p1[static_cast<std::size_t>(f)]);
+
+    CHECK(s.rollbackCount() > 0); // at least one misprediction was corrected
+    CHECK(s.confirmedFrame() == n);
+    CHECK(hashWorld(s.state()) == hashWorld(referenceRun(p0, p1, n))); // no corruption
+}
+
+// One scheduled remote-input delivery.
+struct Delivery {
+    int arrival; // frame at which it is received
+    int frame;   // frame the input is for
+    Input input;
+};
+
+static void testTwoClientsStaySyncedUnderLatencyAndLoss() {
+    const int n = 60;
+    const int latency = 4;
+    const std::vector<Input> p0 = scriptInputs(101, n);
+    const std::vector<Input> p1 = scriptInputs(202, n);
+
+    RollbackSession<World, Input> a(2, /*local=*/0, World{}, stepWorld, /*window=*/1024);
+    RollbackSession<World, Input> b(2, /*local=*/1, World{}, stepWorld, /*window=*/1024);
+
+    std::vector<Delivery> toA; // player 1 inputs headed to client A
+    std::vector<Delivery> toB; // player 0 inputs headed to client B
+
+    for (int f = 0; f < n; ++f) {
+        a.advanceFrame(p0[static_cast<std::size_t>(f)]);
+        b.advanceFrame(p1[static_cast<std::size_t>(f)]);
+
+        // Schedule cross-delivery with latency; "lost" packets arrive much later.
+        const bool lostA = (f % 7) == 3;
+        const bool lostB = (f % 5) == 2;
+        toA.push_back({f + latency + (lostA ? 20 : 0), f, p1[static_cast<std::size_t>(f)]});
+        toB.push_back({f + latency + (lostB ? 20 : 0), f, p0[static_cast<std::size_t>(f)]});
+
+        for (const Delivery& d : toA) {
+            if (d.arrival == f) a.addRemoteInput(1, d.frame, d.input);
+        }
+        for (const Delivery& d : toB) {
+            if (d.arrival == f) b.addRemoteInput(0, d.frame, d.input);
+        }
+    }
+
+    // Flush every remaining (delayed/lost) input in increasing frame order.
+    auto byFrame = [](const Delivery& x, const Delivery& y) { return x.frame < y.frame; };
+    std::sort(toA.begin(), toA.end(), byFrame);
+    std::sort(toB.begin(), toB.end(), byFrame);
+    for (const Delivery& d : toA) {
+        if (d.arrival >= n) a.addRemoteInput(1, d.frame, d.input);
+    }
+    for (const Delivery& d : toB) {
+        if (d.arrival >= n) b.addRemoteInput(0, d.frame, d.input);
+    }
+
+    const World ref = referenceRun(p0, p1, n);
+    // Both clients converged to each other and to the authoritative reference.
+    CHECK(hashWorld(a.state()) == hashWorld(b.state()));
+    CHECK(hashWorld(a.state()) == hashWorld(ref));
+    CHECK(hashWorld(b.state()) == hashWorld(ref));
+    // Rollback was actually exercised on both sides, and everything is confirmed.
+    CHECK(a.rollbackCount() > 0);
+    CHECK(b.rollbackCount() > 0);
+    CHECK(a.confirmedFrame() == n);
+    CHECK(b.confirmedFrame() == n);
+}
+
+int main() {
+    testNoRollbackWhenPredictionIsCorrect();
+    testMispredictionRollsBackToCorrectState();
+    testTwoClientsStaySyncedUnderLatencyAndLoss();
+
+    if (g_failures == 0) {
+        std::printf("All rollback netcode tests passed.\n");
+        return 0;
+    }
+    std::printf("%d rollback netcode test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements Milestone 14 / #160: GGPO-style rollback + input prediction on top of the deterministic core (#159). Closes #160.

New header `src/net/Rollback.h` (namespace `IKore::net`), header-only. `RollbackSession<State, Input>` runs the same deterministic step on every peer. Because remote inputs arrive late (latency) or out of order / dropped (loss), each peer predicts the missing inputs (repeat the last known input) and advances anyway, saving a per-frame state snapshot. When an authoritative remote input arrives for a frame already simulated with a different prediction, the session rolls back to that frame, restores the snapshot, and resimulates forward with the corrected inputs - landing on the correct state with no visible corruption. A future input is simply recorded and used authoritatively when reached.

### API

- `advanceFrame(localInput)` - record the local input, predict the rest, snapshot, step, advance.
- `addRemoteInput(player, frame, input)` - apply an authoritative input; roll back and resimulate if it corrects a misprediction.
- `confirmedFrame()` - the contiguous prefix where all players' inputs are authoritative (never rolls back); `snapshotAt()` exposes a past state; `rollbackCount()` is available for metrics.

The session is engine-agnostic and templated on a value `State` (snapshotted per frame) and a value `Input`; the deterministic step uses the `Fixed` math + `DeterministicRng` from #159. It is the core a `NetworkComponent` / `NetworkSystem` can drive.

## Acceptance criteria

- [x] Two clients stay in sync under simulated latency and packet loss (two sessions exchange inputs over a delayed, lossy channel and converge to byte-identical state equal to a no-network reference, every frame confirmed)
- [x] Mispredictions roll back and resimulate without visible corruption (a mispredicted run, on receiving authoritative inputs, rolls back and lands exactly on the reference state)

## Testing

`tests/test_rollback.cpp` (wired as the `test_rollback` CMake target), built on the deterministic core (`Fixed` state + `StateHash`):

- A correct prediction causes zero rollbacks and matches the reference.
- A mispredicted run (varied remote inputs vs the default-0 prediction) rolls back on receiving the authoritative inputs and lands exactly on the reference state, with every frame confirmed.
- Two clients exchanging inputs over a channel with latency (4 frames) and packet loss (periodic drops redelivered much later) both roll back and converge to byte-identical state equal to a no-network reference, with `confirmedFrame() == n` on both. The step has cross-agent interaction so a wrong prediction visibly corrupts state until corrected, making the rollback meaningful.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_rollback.cpp -o test_rollback && ./test_rollback
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

Builds on #159 (deterministic `Fixed` + `StateHash` + `DeterministicRng`). The legacy `NetworkComponent`/`NetworkSystem` remain as-is; this is the deterministic rollback core they can drive. Next in M14: lockstep transport / wiring this into the engine's networking.