### PR TITLE
feat(net): desync detection, diagnostics, and input-log replay (#161)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,11 @@ add_executable(test_rollback
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_rollback.cpp
 )
 
+# Desync detection + diagnostics + input-log replay (Milestone 14 / #161) - header-only.
+add_executable(test_desync
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_desync.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/net/Desync.h
+++ b/src/net/Desync.h
@@ -1,0 +1,188 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <sstream>
+#include <string>
+#include <vector>
+
+/**
+ * @file Desync.h
+ * @brief Desync detection, diagnostics, and input-log replay (issue #161).
+ *
+ * Milestone 14. Tooling on top of the deterministic core (#159) and rollback
+ * netcode (#160) to find and diagnose desyncs and to reproduce a session from a
+ * recorded input log:
+ *
+ *   - ChecksumTrace: the per-tick state checksums (from StateHash) that peers
+ *     exchange. firstDivergence() reports the first tick whose checksum differs,
+ *     with both hashes - the cheap, network-exchangeable detector.
+ *   - diagnoseStates(): given the full per-tick state on each side (local debug
+ *     capture), find the first diverging tick and a caller-supplied description of
+ *     what differs - the actionable "tick + diverging state" diagnostic.
+ *   - InputLog + replay(): record every player's input per tick (optionally
+ *     serialized to text); replay feeds the log back through the deterministic
+ *     step to reproduce the exact checksum trace, so a recorded log reproduces a
+ *     session deterministically.
+ *
+ * Header-only and dependency-free; templated on the user's State / Input so it
+ * works with any deterministic simulation.
+ */
+namespace IKore {
+namespace net {
+
+/// Per-tick state checksums (e.g. StateHash digests). Peers compare these.
+struct ChecksumTrace {
+    std::vector<std::uint64_t> hashes;
+
+    void record(std::uint64_t hash) { hashes.push_back(hash); }
+    std::size_t size() const { return hashes.size(); }
+    std::uint64_t at(std::size_t tick) const { return hashes[tick]; }
+};
+
+/// The result of a desync check: where (and how) two traces diverged.
+struct DesyncReport {
+    bool desynced{false};
+    int tick{-1};               ///< first diverging tick, or -1 if in sync.
+    std::uint64_t localHash{0};
+    std::uint64_t remoteHash{0};
+    std::string detail;         ///< human-readable description of the divergence.
+
+    std::string summary() const {
+        if (!desynced) return "in sync";
+        char buf[160];
+        std::snprintf(buf, sizeof(buf),
+                      "desync at tick %d: local=0x%016llx remote=0x%016llx", tick,
+                      static_cast<unsigned long long>(localHash),
+                      static_cast<unsigned long long>(remoteHash));
+        std::string s = buf;
+        if (!detail.empty()) s += " | " + detail;
+        return s;
+    }
+};
+
+/**
+ * @brief First tick at which two checksum traces differ.
+ *
+ * Reports a checksum mismatch at the earliest differing tick, or - if one peer
+ * simply ran fewer ticks - a length mismatch at the shorter length.
+ */
+inline DesyncReport firstDivergence(const ChecksumTrace& local, const ChecksumTrace& remote) {
+    DesyncReport r;
+    const std::size_t n = local.size() < remote.size() ? local.size() : remote.size();
+    for (std::size_t i = 0; i < n; ++i) {
+        if (local.at(i) != remote.at(i)) {
+            r.desynced = true;
+            r.tick = static_cast<int>(i);
+            r.localHash = local.at(i);
+            r.remoteHash = remote.at(i);
+            r.detail = "checksum mismatch";
+            return r;
+        }
+    }
+    if (local.size() != remote.size()) {
+        r.desynced = true;
+        r.tick = static_cast<int>(n);
+        char buf[96];
+        std::snprintf(buf, sizeof(buf), "trace length mismatch (local %zu vs remote %zu)",
+                      local.size(), remote.size());
+        r.detail = buf;
+    }
+    return r;
+}
+
+/**
+ * @brief First tick whose state differs, with a caller-supplied description.
+ *
+ * @p diff is called as diff(tick, localState, remoteState) and returns a non-empty
+ * string describing the difference (empty if the two states are identical). This
+ * turns a bare checksum mismatch into an actionable "tick + diverging fields"
+ * report for local debugging.
+ */
+template <class State, class DiffFn>
+DesyncReport diagnoseStates(const std::vector<State>& local, const std::vector<State>& remote,
+                            DiffFn diff) {
+    DesyncReport r;
+    const std::size_t n = local.size() < remote.size() ? local.size() : remote.size();
+    for (std::size_t i = 0; i < n; ++i) {
+        const std::string d = diff(static_cast<int>(i), local[i], remote[i]);
+        if (!d.empty()) {
+            r.desynced = true;
+            r.tick = static_cast<int>(i);
+            r.detail = d;
+            return r;
+        }
+    }
+    if (local.size() != remote.size()) {
+        r.desynced = true;
+        r.tick = static_cast<int>(n);
+        r.detail = "trace length mismatch";
+    }
+    return r;
+}
+
+/// A recorded log of every player's input per tick (a reproducible session).
+template <class Input>
+struct InputLog {
+    std::uint64_t seed{0};
+    int numPlayers{0};
+    std::vector<std::vector<Input>> ticks; ///< ticks[t][player].
+
+    void record(const std::vector<Input>& perPlayer) { ticks.push_back(perPlayer); }
+    std::size_t size() const { return ticks.size(); }
+};
+
+/**
+ * @brief Replay a recorded input log through the deterministic step, returning the
+ *        per-tick checksum trace. Identical inputs reproduce identical state.
+ *
+ * @p step advances State by one tick: step(State&, inputsForTick, tick).
+ * @p hash maps a State to its checksum (e.g. via StateHash).
+ */
+template <class State, class Input, class StepFn, class HashFn>
+ChecksumTrace replay(const InputLog<Input>& log, State state, StepFn step, HashFn hash) {
+    ChecksumTrace trace;
+    for (std::size_t t = 0; t < log.ticks.size(); ++t) {
+        step(state, log.ticks[t], static_cast<int>(t));
+        trace.record(hash(state));
+    }
+    return trace;
+}
+
+/// Serialize a log to text (header line + one line of encoded inputs per tick).
+/// @p encode maps an Input to a whitespace-free token.
+template <class Input, class EncodeFn>
+std::string serializeLog(const InputLog<Input>& log, EncodeFn encode) {
+    std::ostringstream out;
+    out << log.seed << ' ' << log.numPlayers << ' ' << log.ticks.size() << '\n';
+    for (const std::vector<Input>& tick : log.ticks) {
+        for (std::size_t p = 0; p < tick.size(); ++p) {
+            if (p) out << ' ';
+            out << encode(tick[p]);
+        }
+        out << '\n';
+    }
+    return out.str();
+}
+
+/// Parse a log produced by serializeLog. @p decode maps a token back to an Input.
+template <class Input, class DecodeFn>
+InputLog<Input> parseLog(const std::string& text, DecodeFn decode) {
+    InputLog<Input> log;
+    std::istringstream in(text);
+    std::size_t numTicks = 0;
+    in >> log.seed >> log.numPlayers >> numTicks;
+    for (std::size_t t = 0; t < numTicks; ++t) {
+        std::vector<Input> tick;
+        for (int p = 0; p < log.numPlayers; ++p) {
+            std::string token;
+            in >> token;
+            tick.push_back(decode(token));
+        }
+        log.ticks.push_back(std::move(tick));
+    }
+    return log;
+}
+
+} // namespace net
+} // namespace IKore

--- a/tests/test_desync.cpp
+++ b/tests/test_desync.cpp
@@ -1,0 +1,190 @@
+// Test for desync detection, diagnostics, and input-log replay - M14, #161.
+//
+// Verifies the issue's acceptance criteria:
+//   - Desyncs are detected with an actionable diagnostic (tick + diverging state):
+//     firstDivergence reports the first mismatching checksum tick with both
+//     hashes, and diagnoseStates names what diverged.
+//   - A recorded input log reproduces a session deterministically: replaying a
+//     log (including after a serialize/parse round-trip) reproduces the exact
+//     per-tick checksum trace of the original run.
+//
+// Built on the deterministic core (#159). Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_desync.cpp -o test_desync
+
+#include "core/sim/Fixed.h"
+#include "core/sim/Simulation.h" // DeterministicRng
+#include "core/sim/StateHash.h"
+#include "net/Desync.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::net;
+using IKore::sim::DeterministicRng;
+using IKore::sim::Fixed;
+using IKore::sim::StateHash;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+struct Input {
+    int move{0};
+};
+
+struct World {
+    Fixed x[2];
+};
+
+static void stepWorld(World& w, const std::vector<Input>& in, int /*tick*/) {
+    const Fixed speed = Fixed::fromFraction(1, 4);
+    const Fixed pull = Fixed::fromFraction(1, 16);
+    Fixed nx0 = w.x[0] + Fixed::fromInt(in[0].move) * speed;
+    Fixed nx1 = w.x[1] + Fixed::fromInt(in[1].move) * speed;
+    nx0 = nx0 + (w.x[1] - w.x[0]) * pull;
+    nx1 = nx1 + (w.x[0] - w.x[1]) * pull;
+    w.x[0] = nx0;
+    w.x[1] = nx1;
+}
+
+static std::uint64_t hashWorld(const World& w) {
+    StateHash h;
+    h.addFixed(w.x[0]);
+    h.addFixed(w.x[1]);
+    return h.digest();
+}
+
+// Run a session: fill an input log, a checksum trace, and per-tick states.
+static void runSession(const std::vector<Input>& p0, const std::vector<Input>& p1, int n,
+                       InputLog<Input>& log, ChecksumTrace& trace, std::vector<World>& states) {
+    log.numPlayers = 2;
+    World w;
+    for (int t = 0; t < n; ++t) {
+        const std::vector<Input> tickInputs = {p0[static_cast<std::size_t>(t)],
+                                               p1[static_cast<std::size_t>(t)]};
+        log.record(tickInputs);
+        stepWorld(w, tickInputs, t);
+        trace.record(hashWorld(w));
+        states.push_back(w);
+    }
+}
+
+static std::vector<Input> scriptInputs(std::uint64_t seed, int n) {
+    DeterministicRng rng(seed);
+    std::vector<Input> v(static_cast<std::size_t>(n));
+    for (int t = 0; t < n; ++t) v[static_cast<std::size_t>(t)].move = rng.nextInt(-1, 1);
+    return v;
+}
+
+static void testReplayReproducesSession() {
+    const int n = 40;
+    const std::vector<Input> p0 = scriptInputs(11, n);
+    const std::vector<Input> p1 = scriptInputs(22, n);
+
+    InputLog<Input> log;
+    ChecksumTrace live;
+    std::vector<World> states;
+    runSession(p0, p1, n, log, live, states);
+
+    // Replaying the log reproduces the exact checksum trace.
+    const ChecksumTrace replayed = replay(log, World{}, stepWorld, hashWorld);
+    CHECK(!firstDivergence(live, replayed).desynced);
+    CHECK(live.size() == replayed.size());
+
+    // Replay is itself deterministic.
+    const ChecksumTrace replayed2 = replay(log, World{}, stepWorld, hashWorld);
+    CHECK(!firstDivergence(replayed, replayed2).desynced);
+
+    // The log survives serialize -> parse and still reproduces the session.
+    const std::string text =
+        serializeLog(log, [](const Input& i) { return std::to_string(i.move); });
+    const InputLog<Input> parsed =
+        parseLog<Input>(text, [](const std::string& s) { return Input{std::stoi(s)}; });
+    CHECK(parsed.size() == log.size());
+    CHECK(parsed.numPlayers == 2);
+    const ChecksumTrace fromText = replay(parsed, World{}, stepWorld, hashWorld);
+    CHECK(!firstDivergence(live, fromText).desynced);
+}
+
+static void testDesyncDetectedWithDiagnostic() {
+    const int n = 30;
+    const std::vector<Input> p0 = scriptInputs(101, n);
+    const std::vector<Input> p1 = scriptInputs(202, n);
+
+    InputLog<Input> log;
+    ChecksumTrace traceA;
+    std::vector<World> statesA;
+    runSession(p0, p1, n, log, traceA, statesA);
+
+    // A second peer that diverges: flip one input at a known tick.
+    const int badTick = 12;
+    std::vector<Input> p1bad = p1;
+    p1bad[static_cast<std::size_t>(badTick)].move += 1;
+    InputLog<Input> logB;
+    ChecksumTrace traceB;
+    std::vector<World> statesB;
+    runSession(p0, p1bad, n, logB, traceB, statesB);
+
+    // Checksum-level detection: first mismatch is exactly at the bad tick.
+    const DesyncReport r = firstDivergence(traceA, traceB);
+    CHECK(r.desynced);
+    CHECK(r.tick == badTick);
+    CHECK(r.localHash != r.remoteHash);
+    CHECK(r.summary().find("tick 12") != std::string::npos);
+
+    // State-level diagnostic names the diverging tick and field.
+    const DesyncReport diag = diagnoseStates(
+        statesA, statesB, [](int, const World& a, const World& b) -> std::string {
+            if (a.x[0].raw != b.x[0].raw || a.x[1].raw != b.x[1].raw) {
+                char buf[160];
+                std::snprintf(buf, sizeof(buf), "x0 raw %d vs %d, x1 raw %d vs %d", a.x[0].raw,
+                              b.x[0].raw, a.x[1].raw, b.x[1].raw);
+                return std::string(buf);
+            }
+            return std::string();
+        });
+    CHECK(diag.desynced);
+    CHECK(diag.tick == badTick);
+    CHECK(!diag.detail.empty());
+
+    // Identical traces report no desync.
+    const DesyncReport same = firstDivergence(traceA, traceA);
+    CHECK(!same.desynced);
+    CHECK(same.tick == -1);
+    CHECK(same.summary() == "in sync");
+}
+
+static void testLengthMismatchReported() {
+    ChecksumTrace a;
+    ChecksumTrace b;
+    for (int i = 0; i < 10; ++i) {
+        a.record(static_cast<std::uint64_t>(i));
+        if (i < 6) b.record(static_cast<std::uint64_t>(i));
+    }
+    const DesyncReport r = firstDivergence(a, b);
+    CHECK(r.desynced);
+    CHECK(r.tick == 6); // diverges where the shorter trace ends
+    CHECK(r.detail.find("length mismatch") != std::string::npos);
+}
+
+int main() {
+    testReplayReproducesSession();
+    testDesyncDetectedWithDiagnostic();
+    testLengthMismatchReported();
+
+    if (g_failures == 0) {
+        std::printf("All desync detection / replay tests passed.\n");
+        return 0;
+    }
+    std::printf("%d desync test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements Milestone 14 / #161: tooling to detect and diagnose desyncs, and to reproduce a session from a recorded input log, on top of the deterministic core (#159) and rollback netcode (#160). Closes #161.

New header `src/net/Desync.h` (namespace `IKore::net`), header-only and templated on the user's `State` / `Input`:

- **`ChecksumTrace` + `firstDivergence`** - peers exchange a per-tick state checksum trace (from `StateHash`); `firstDivergence` reports the earliest tick whose checksums differ (with both hashes) or, if a peer ran fewer ticks, a length mismatch. This is the cheap, network-exchangeable detector, and `DesyncReport::summary()` gives an actionable one-line string.
- **`diagnoseStates`** - given the full per-tick state captured on each side, find the first diverging tick and a caller-supplied description of what differs - the actionable "tick + diverging state" diagnostic for local debugging.
- **`InputLog` + `replay`** - record every player's input per tick (with `serializeLog` / `parseLog` to persist it as text via an `Input` codec); `replay` feeds the log back through the deterministic step and returns the reproduced checksum trace.

## Acceptance criteria

- [x] Desyncs are detected with an actionable diagnostic (tick + diverging state) - `firstDivergence` pinpoints the first mismatching tick with both hashes, and `diagnoseStates` names the diverging fields
- [x] A recorded input log reproduces a session deterministically - `replay` reproduces the exact checksum trace, including after a serialize/parse round-trip

## Testing

`tests/test_desync.cpp` (wired as the `test_desync` CMake target), built on the deterministic core (`Fixed` state + `StateHash`):

- Replaying a recorded log reproduces the original checksum trace exactly; replay is itself deterministic; and the log still reproduces the session after a `serializeLog` -> `parseLog` text round-trip.
- A peer that flips a single input at tick 12 is detected at exactly that tick with differing hashes and a summary containing "tick 12", and `diagnoseStates` reports the same tick with a field-level detail string; identical traces report "in sync" (`tick == -1`).
- A shorter trace is reported as a length mismatch at the truncation point.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_desync.cpp -o test_desync && ./test_desync
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

Builds on #159 (`StateHash`) and #160 (rollback/inputs). The checksum trace is exactly what `RollbackSession` peers can exchange to detect divergence, and the input log is the recorded-session artifact for deterministic replay.