### PR TITLE
feat(game): renderer-agnostic drawing-to-scene converter (#162)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,6 +531,11 @@ add_executable(test_desync
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_desync.cpp
 )
 
+# Renderer-agnostic drawing->scene converter (Milestone 15 / #162) - header-only.
+add_executable(test_doodle_scene
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_doodle_scene.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/game/DoodleScene.h
+++ b/src/game/DoodleScene.h
@@ -1,0 +1,179 @@
+#pragma once
+
+#include "core/ecs/Registry.h"
+#include "core/ecs/components/Components.h"
+#include "world/SvgFloorPlanImporter.h" // world::Box / FloorPlan / emitToRegistry
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/**
+ * @file DoodleScene.h
+ * @brief Renderer-agnostic drawing -> 3D scene converter (issue #162).
+ *
+ * Milestone 15 (Doodle Dungeon) core. Converts a LevelSpec - the output of a
+ * hand-drawn floor plan: wall polylines plus placed symbols - into a 3D scene
+ * description: extruded wall geometry and a list of entity spawns.
+ *
+ * It deliberately has NO renderer dependency so it is unit-testable headless: it
+ * emits a plain Mesh (positions, normals, indices - exactly the vertex/index data
+ * a MeshComponent builder consumes) and reuses the glm-free world::Box /
+ * FloorPlan / emitToRegistry primitives, rather than depending on the glm- and
+ * OpenGL-coupled MeshComponent / SerializationData directly (which would break the
+ * headless requirement, the same reason the ECS uses a local Vec3 instead of glm).
+ *
+ * Header-only and dependency-free (std + the header-only ECS / world primitives).
+ */
+namespace IKore {
+namespace game {
+
+/// A wall as a polyline of XZ points (y is ignored; walls rise along +Y).
+struct Wall {
+    std::vector<ecs::Vec3> polyline;
+};
+
+/// A placed symbol (e.g. "player", "enemy", "door", "treasure") at a position.
+struct Symbol {
+    std::string type;
+    ecs::Vec3 position{};
+    float yaw{0.0f};
+};
+
+/// The drawing: wall polylines + symbols, with extrusion parameters.
+struct LevelSpec {
+    std::vector<Wall> walls;
+    std::vector<Symbol> symbols;
+    float wallHeight{3.0f};
+    float wallThickness{0.2f};
+};
+
+/// A renderer-agnostic mesh vertex (position + normal).
+struct MeshVertex {
+    ecs::Vec3 position{};
+    ecs::Vec3 normal{};
+};
+
+/// Plain triangle mesh data, consumable by any renderer's mesh builder.
+struct Mesh {
+    std::vector<MeshVertex> vertices;
+    std::vector<std::uint32_t> indices;
+};
+
+/// An entity to spawn from a symbol.
+struct EntitySpawn {
+    std::string type;
+    ecs::Vec3 position{};
+    float yaw{0.0f};
+};
+
+/// ECS tag carrying a spawned entity's symbol type (so spawns are queryable).
+struct SpawnTag {
+    std::string type;
+};
+
+/// The converted scene: extruded wall geometry (mesh + boxes) and entity spawns.
+struct SceneDescription {
+    Mesh wallMesh;                      ///< all walls extruded into one mesh.
+    std::vector<world::Box> wallBoxes;  ///< the same walls as oriented boxes.
+    std::vector<EntitySpawn> spawns;    ///< symbols turned into entity spawns.
+};
+
+namespace detail {
+
+/// Append an oriented box (24 verts / 36 indices, outward normals) to @p mesh.
+inline void appendBox(Mesh& mesh, const ecs::Vec3& center, float sx, float sy, float sz, float yaw) {
+    const float hx = sx * 0.5f, hy = sy * 0.5f, hz = sz * 0.5f;
+    const float cs = std::cos(yaw), sn = std::sin(yaw);
+    auto place = [&](float lx, float ly, float lz) {
+        return ecs::Vec3{center.x + (lx * cs - lz * sn), center.y + ly, center.z + (lx * sn + lz * cs)};
+    };
+    auto rot = [&](float nx, float nz) { return ecs::Vec3{nx * cs - nz * sn, 0.0f, nx * sn + nz * cs}; };
+
+    struct Face {
+        ecs::Vec3 n;
+        ecs::Vec3 v[4];
+    };
+    const Face faces[6] = {
+        {rot(1, 0), {place(hx, -hy, -hz), place(hx, hy, -hz), place(hx, hy, hz), place(hx, -hy, hz)}},
+        {rot(-1, 0), {place(-hx, -hy, hz), place(-hx, hy, hz), place(-hx, hy, -hz), place(-hx, -hy, -hz)}},
+        {rot(0, 1), {place(-hx, -hy, hz), place(-hx, hy, hz), place(hx, hy, hz), place(hx, -hy, hz)}},
+        {rot(0, -1), {place(hx, -hy, -hz), place(hx, hy, -hz), place(-hx, hy, -hz), place(-hx, -hy, -hz)}},
+        {{0.0f, 1.0f, 0.0f}, {place(-hx, hy, -hz), place(-hx, hy, hz), place(hx, hy, hz), place(hx, hy, -hz)}},
+        {{0.0f, -1.0f, 0.0f}, {place(-hx, -hy, hz), place(-hx, -hy, -hz), place(hx, -hy, -hz), place(hx, -hy, hz)}},
+    };
+    for (const Face& f : faces) {
+        const auto base = static_cast<std::uint32_t>(mesh.vertices.size());
+        for (int i = 0; i < 4; ++i) mesh.vertices.push_back(MeshVertex{f.v[i], f.n});
+        mesh.indices.push_back(base + 0);
+        mesh.indices.push_back(base + 1);
+        mesh.indices.push_back(base + 2);
+        mesh.indices.push_back(base + 0);
+        mesh.indices.push_back(base + 2);
+        mesh.indices.push_back(base + 3);
+    }
+}
+
+} // namespace detail
+
+/**
+ * @brief Convert a LevelSpec into a 3D scene description.
+ *
+ * Each wall polyline segment is extruded from the floor (y = 0) to wallHeight as
+ * an oriented box, added both to the merged wall mesh and as a world::Box. Each
+ * symbol becomes an EntitySpawn at its position.
+ */
+inline SceneDescription convert(const LevelSpec& spec) {
+    SceneDescription out;
+    const float height = spec.wallHeight > 0.0f ? spec.wallHeight : 1.0f;
+    const float thickness = spec.wallThickness > 0.0f ? spec.wallThickness : 0.1f;
+
+    for (const Wall& wall : spec.walls) {
+        for (std::size_t i = 0; i + 1 < wall.polyline.size(); ++i) {
+            const ecs::Vec3 a = wall.polyline[i];
+            const ecs::Vec3 b = wall.polyline[i + 1];
+            const float dx = b.x - a.x, dz = b.z - a.z;
+            const float len = std::sqrt(dx * dx + dz * dz);
+            if (len < 1e-6f) continue; // skip degenerate segment
+            const float yaw = std::atan2(dz, dx);
+            const ecs::Vec3 center{(a.x + b.x) * 0.5f, height * 0.5f, (a.z + b.z) * 0.5f};
+
+            world::Box box;
+            box.center = center;
+            box.size = ecs::Vec3{len, height, thickness};
+            box.yaw = yaw;
+            out.wallBoxes.push_back(box);
+            detail::appendBox(out.wallMesh, center, len, height, thickness, yaw);
+        }
+    }
+
+    for (const Symbol& s : spec.symbols) {
+        out.spawns.push_back(EntitySpawn{s.type, s.position, s.yaw});
+    }
+    return out;
+}
+
+/**
+ * @brief Place a converted scene into an ecs::Registry: one entity per wall box
+ *        (via the importer emit path) and one per spawn (Transform + SpawnTag).
+ * @return the number of entities created.
+ */
+inline std::size_t emitToRegistry(const SceneDescription& scene, ecs::Registry& registry) {
+    world::FloorPlan plan;
+    plan.walls = scene.wallBoxes;
+    plan.hasFloor = false;
+    std::size_t created = world::emitToRegistry(plan, registry);
+
+    for (const EntitySpawn& s : scene.spawns) {
+        const ecs::Entity e = registry.create();
+        registry.add<ecs::Transform>(
+            e, ecs::Transform{s.position, ecs::Vec3{0.0f, s.yaw, 0.0f}, ecs::Vec3{1.0f, 1.0f, 1.0f}});
+        registry.add<SpawnTag>(e, SpawnTag{s.type});
+        ++created;
+    }
+    return created;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_doodle_scene.cpp
+++ b/tests/test_doodle_scene.cpp
@@ -1,0 +1,159 @@
+// Test for the renderer-agnostic drawing -> scene converter - M15, #162.
+//
+// Verifies the issue's acceptance criteria:
+//   - The converter has no renderer dependencies and is unit-testable headless:
+//     this test builds and runs with only the header-only ECS / world / game
+//     headers (no glm, no OpenGL).
+//   - Wall polylines extrude to 3D geometry: a room outline becomes oriented wall
+//     boxes and a triangle mesh that rises from the floor (y=0) to wallHeight.
+//   - Symbols become entity spawns: placed symbols turn into EntitySpawns and,
+//     when emitted, into ECS entities carrying their type.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_doodle_scene.cpp -o test_doodle_scene
+
+#include "core/ecs/Registry.h"
+#include "core/ecs/View.h"
+#include "core/ecs/components/Components.h"
+#include "game/DoodleScene.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-3f) {
+    return std::fabs(a - b) <= eps;
+}
+
+// A square room (closed polyline, 4 segments) plus three symbols.
+static LevelSpec sampleLevel() {
+    LevelSpec spec;
+    spec.wallHeight = 3.0f;
+    spec.wallThickness = 0.2f;
+    Wall room;
+    room.polyline = {{0, 0, 0}, {10, 0, 0}, {10, 0, 10}, {0, 0, 10}, {0, 0, 0}};
+    spec.walls.push_back(room);
+    spec.symbols = {
+        {"player", {5, 0, 5}, 0.0f},
+        {"enemy", {8, 0, 2}, 0.0f},
+        {"treasure", {2, 0, 8}, 0.0f},
+    };
+    return spec;
+}
+
+static void testWallsExtrudeTo3DGeometry() {
+    const SceneDescription scene = convert(sampleLevel());
+
+    // Four segments -> four oriented wall boxes.
+    CHECK(scene.wallBoxes.size() == 4);
+    // First segment (0,0)->(10,0): centered at (5,1.5,0), length 10, flat (yaw 0).
+    const world::Box& b0 = scene.wallBoxes[0];
+    CHECK(approx(b0.center.x, 5.0f) && approx(b0.center.z, 0.0f));
+    CHECK(approx(b0.center.y, 1.5f));           // half of wallHeight
+    CHECK(approx(b0.size.x, 10.0f));            // segment length
+    CHECK(approx(b0.size.y, 3.0f));             // wallHeight
+    CHECK(approx(b0.size.z, 0.2f));             // wallThickness
+    CHECK(approx(b0.yaw, 0.0f));
+    // Second segment (10,0)->(10,10): turns 90 degrees.
+    CHECK(approx(scene.wallBoxes[1].yaw, 3.14159265f / 2.0f, 1e-3f));
+
+    // The extruded mesh: 24 verts + 36 indices per box, all indices in range.
+    CHECK(scene.wallMesh.vertices.size() == 24u * 4u);
+    CHECK(scene.wallMesh.indices.size() == 36u * 4u);
+    bool indicesInRange = true;
+    for (std::uint32_t idx : scene.wallMesh.indices) {
+        if (idx >= scene.wallMesh.vertices.size()) indicesInRange = false;
+    }
+    CHECK(indicesInRange);
+
+    // Geometry rises from the floor (y=0) to wallHeight, and normals are unit.
+    float minY = 1e9f, maxY = -1e9f;
+    bool normalsUnit = true;
+    for (const MeshVertex& v : scene.wallMesh.vertices) {
+        minY = std::min(minY, v.position.y);
+        maxY = std::max(maxY, v.position.y);
+        if (!approx(v.normal.length(), 1.0f, 1e-3f)) normalsUnit = false;
+    }
+    CHECK(approx(minY, 0.0f));
+    CHECK(approx(maxY, 3.0f));
+    CHECK(normalsUnit);
+}
+
+static void testSymbolsBecomeEntitySpawns() {
+    const SceneDescription scene = convert(sampleLevel());
+
+    CHECK(scene.spawns.size() == 3);
+    // Spawns preserve type and position.
+    bool foundPlayer = false;
+    for (const EntitySpawn& s : scene.spawns) {
+        if (s.type == "player") {
+            foundPlayer = true;
+            CHECK(approx(s.position.x, 5.0f) && approx(s.position.z, 5.0f));
+        }
+    }
+    CHECK(foundPlayer);
+}
+
+static void testEmitToRegistry() {
+    const SceneDescription scene = convert(sampleLevel());
+    ecs::Registry reg;
+    const std::size_t created = emitToRegistry(scene, reg);
+
+    // 4 wall entities + 3 spawn entities.
+    CHECK(created == 7);
+    CHECK(reg.aliveCount() == 7);
+    CHECK(reg.view<ecs::Transform>().count() == 7);
+    // Only the spawns carry a SpawnTag.
+    CHECK((reg.view<ecs::Transform, SpawnTag>().count() == 3));
+
+    // The spawn tags carry the symbol types.
+    int taggedPlayers = 0;
+    reg.view<ecs::Transform, SpawnTag>().each([&](ecs::Entity, ecs::Transform&, SpawnTag& tag) {
+        if (tag.type == "player") ++taggedPlayers;
+    });
+    CHECK(taggedPlayers == 1);
+}
+
+static void testEmptyAndDegenerate() {
+    // An empty spec yields an empty scene.
+    const SceneDescription empty = convert(LevelSpec{});
+    CHECK(empty.wallBoxes.empty());
+    CHECK(empty.wallMesh.vertices.empty());
+    CHECK(empty.spawns.empty());
+
+    // A zero-length segment is skipped (no degenerate box).
+    LevelSpec spec;
+    Wall w;
+    w.polyline = {{1, 0, 1}, {1, 0, 1}, {4, 0, 1}}; // first segment degenerate
+    spec.walls.push_back(w);
+    const SceneDescription scene = convert(spec);
+    CHECK(scene.wallBoxes.size() == 1); // only the real segment survives
+}
+
+int main() {
+    testWallsExtrudeTo3DGeometry();
+    testSymbolsBecomeEntitySpawns();
+    testEmitToRegistry();
+    testEmptyAndDegenerate();
+
+    if (g_failures == 0) {
+        std::printf("All doodle scene converter tests passed.\n");
+        return 0;
+    }
+    std::printf("%d doodle scene test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Starts Milestone 15 (Doodle Dungeon, Desktop PoC) with `src/game/DoodleScene.h`: convert a `LevelSpec` - the output of a hand-drawn floor plan, i.e. wall polylines plus placed symbols - into a 3D scene description with no renderer dependency, so it is unit-testable headless. Closes #162.

- **`convert(LevelSpec)`** - each wall polyline segment is extruded from the floor (`y=0`) to `wallHeight` as an oriented box, added both to a merged triangle `Mesh` (24 verts / 36 indices per box, outward normals) and as a `world::Box`. Each placed symbol becomes an `EntitySpawn` at its position.
- **`emitToRegistry(SceneDescription)`** - places the wall boxes through the importer emit path (`world::FloorPlan` + `world::emitToRegistry`) and spawns one entity per symbol with a `Transform` and a `SpawnTag` carrying its type.

### Renderer-agnostic by design

It deliberately produces a plain `Mesh` (positions, normals, indices - exactly the vertex/index data a `MeshComponent` builder consumes) and reuses the glm-free `world::Box` / `FloorPlan` primitives, rather than depending on the glm- and OpenGL-coupled `MeshComponent` / `SerializationData` directly, which would break the headless requirement (the same reason the ECS uses a local `Vec3` instead of glm). The engine's `MeshComponent` can consume this mesh data to build its GPU buffers.

## Acceptance criteria

- [x] The converter has no renderer dependencies and is unit-testable headless (header-only; builds and runs with only the ECS / world / game headers, no glm or OpenGL)
- [x] Wall polylines extrude to 3D geometry; symbols become entity spawns (segments extrude to wall boxes + a triangle mesh rising from `y=0` to `wallHeight`; symbols turn into `EntitySpawn`s and tagged ECS entities)

## Testing

`tests/test_doodle_scene.cpp` (wired as the `test_doodle_scene` CMake target):

- A square room outline extrudes to four oriented wall boxes (correct center, length, height, thickness, and a 90-degree turn) and a mesh of 24 verts / 36 indices per box, with all indices in range, geometry rising from `y=0` to `wallHeight`, and unit-length normals.
- Symbols become `EntitySpawn`s preserving type and position.
- `emitToRegistry` creates one entity per wall plus one `SpawnTag`-tagged entity per symbol, queryable via the ECS view.
- Empty specs and zero-length (degenerate) segments are handled.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_doodle_scene.cpp -o test_doodle_scene && ./test_doodle_scene
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

This is the headless core of the Doodle Dungeon vertical slice; later M15 issues add the drawing capture/recognition front end and wire the mesh into the renderer.