### PR TITLE
feat(game): level-spec and 3D-scene JSON formats with save/load (#163)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,11 @@ add_executable(test_doodle_scene
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_doodle_scene.cpp
 )
 
+# Level-spec + 3D-scene JSON save/load (Milestone 15 / #163) - header-only.
+add_executable(test_level_format
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_format.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/assets/levels/sample_dungeon.level.json
+++ b/assets/levels/sample_dungeon.level.json
@@ -1,0 +1,17 @@
+{
+  "format": "doodle-level",
+  "version": 1,
+  "wallHeight": 3.0,
+  "wallThickness": 0.2,
+  "walls": [
+    {"polyline": [[0, 0], [20, 0], [20, 15], [0, 15], [0, 0]]},
+    {"polyline": [[8, 0], [8, 9]]}
+  ],
+  "symbols": [
+    {"type": "player", "x": 2, "z": 2, "yaw": 0},
+    {"type": "enemy", "x": 16, "z": 4, "yaw": 0},
+    {"type": "enemy", "x": 12, "z": 12, "yaw": 0},
+    {"type": "treasure", "x": 18, "z": 13, "yaw": 0},
+    {"type": "door", "x": 8, "z": 11, "yaw": 0}
+  ]
+}

--- a/docs/DOODLE_LEVEL_FORMAT.md
+++ b/docs/DOODLE_LEVEL_FORMAT.md
@@ -1,0 +1,91 @@
+# Doodle Dungeon level and scene formats
+
+Milestone 15 defines two small JSON formats and the conversion between them. Both
+are pure data, have no renderer dependency, and round-trip through save/load.
+
+- `doodle-level` - the intermediate, hand-authorable level spec: wall polylines
+  plus placed symbols. A drawing front end (or a person, by hand) emits this.
+- `doodle-scene` - the emitted 3D scene the engine loads: oriented wall boxes plus
+  entity spawns. It is produced by converting a level spec.
+
+Pipeline:
+
+```
+doodle-level JSON  --fromLevelJson-->  LevelSpec
+LevelSpec          --convert-------->  SceneDescription   (extruded geometry + spawns)
+SceneDescription   --toSceneJson---->  doodle-scene JSON
+SceneDescription   --emitToRegistry->  ECS entities       (a playable scene)
+```
+
+All types live in `IKore::game` (`game/DoodleScene.h`, `game/LevelFormat.h`).
+
+## doodle-level
+
+Coordinates are on the XZ ground plane (the drawing plane); walls rise along +Y.
+
+| Field           | Type     | Meaning                                              |
+| --------------- | -------- | ---------------------------------------------------- |
+| `format`        | string   | `"doodle-level"`.                                    |
+| `version`       | integer  | Schema version (currently `1`).                      |
+| `wallHeight`    | number   | Extrusion height for every wall (world units).       |
+| `wallThickness` | number   | Wall box thickness (world units).                    |
+| `walls`         | array    | Wall polylines (see below).                          |
+| `symbols`       | array    | Placed symbols (see below).                          |
+
+A wall is an object with a `polyline`: an array of `[x, z]` points. Each
+consecutive pair of points becomes one extruded wall segment. A closed room
+repeats its first point at the end. Zero-length segments are ignored.
+
+A symbol is an object:
+
+| Field  | Type   | Meaning                                          |
+| ------ | ------ | ------------------------------------------------ |
+| `type` | string | `"player"`, `"enemy"`, `"treasure"`, `"door"`, ... |
+| `x`    | number | X position on the ground plane.                  |
+| `z`    | number | Z position on the ground plane.                  |
+| `yaw`  | number | Optional facing in radians (default `0`).        |
+
+Example (see `assets/levels/sample_dungeon.level.json`):
+
+```json
+{
+  "format": "doodle-level",
+  "version": 1,
+  "wallHeight": 3.0,
+  "wallThickness": 0.2,
+  "walls": [
+    {"polyline": [[0, 0], [20, 0], [20, 15], [0, 15], [0, 0]]},
+    {"polyline": [[8, 0], [8, 9]]}
+  ],
+  "symbols": [
+    {"type": "player", "x": 2, "z": 2, "yaw": 0},
+    {"type": "enemy", "x": 16, "z": 4},
+    {"type": "treasure", "x": 18, "z": 13}
+  ]
+}
+```
+
+## doodle-scene
+
+The converter extrudes each wall segment into an oriented box and turns each
+symbol into an entity spawn.
+
+| Field    | Type    | Meaning                          |
+| -------- | ------- | -------------------------------- |
+| `format` | string  | `"doodle-scene"`.                |
+| `version`| integer | Schema version (currently `1`).  |
+| `walls`  | array   | Oriented wall boxes (see below). |
+| `spawns` | array   | Entity spawns (see below).       |
+
+A wall box has `center` `[x, y, z]`, `size` `[sx, sy, sz]`, and a `yaw` (radians,
+about the Y axis). A spawn has `type`, `position` `[x, y, z]`, and `yaw`.
+
+The triangle mesh produced by `convert` is not stored in the scene JSON; it is
+derived deterministically from the wall boxes, so the boxes are the canonical
+geometry. `emitToRegistry` creates one entity per wall box (with a `Transform`)
+and one per spawn (a `Transform` plus a `SpawnTag` carrying its type).
+
+## Round-tripping
+
+`toLevelJson` / `fromLevelJson` and `toSceneJson` / `fromSceneJson` are inverses
+for the fields above, so a level or scene can be saved and reloaded without loss.

--- a/src/game/LevelFormat.h
+++ b/src/game/LevelFormat.h
@@ -1,0 +1,380 @@
+#pragma once
+
+#include "game/DoodleScene.h"
+
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <string>
+#include <vector>
+
+/**
+ * @file LevelFormat.h
+ * @brief Level-spec and 3D-scene JSON save/load for Doodle Dungeon (issue #163).
+ *
+ * Milestone 15. Defines two JSON formats and their (de)serialization:
+ *   - "doodle-level": the intermediate, hand-authorable level spec (wall polylines
+ *     + placed symbols + extrusion params) - what a drawing front end emits.
+ *   - "doodle-scene": the emitted 3D scene the engine loads (oriented wall boxes +
+ *     entity spawns) - the output of converting a level spec (#162).
+ *
+ * Both round-trip through save/load. The schema is documented in
+ * docs/DOODLE_LEVEL_FORMAT.md, with a hand-authored sample in
+ * assets/levels/sample_dungeon.level.json.
+ *
+ * A small self-contained JSON value + parser lives in game::detail (kept separate
+ * from the world importers' parsers to avoid any coupling). Header-only and
+ * dependency-free.
+ */
+namespace IKore {
+namespace game {
+namespace detail {
+
+/// Minimal JSON value (objects, arrays, numbers, strings, bools, null).
+struct Json {
+    enum class Type { Null, Bool, Num, Str, Arr, Obj };
+    Type type{Type::Null};
+    bool boolean{false};
+    double num{0.0};
+    std::string str;
+    std::vector<Json> arr;
+    std::map<std::string, Json> obj;
+
+    bool isArr() const { return type == Type::Arr; }
+    bool isObj() const { return type == Type::Obj; }
+    double asNum() const { return type == Type::Num ? num : 0.0; }
+    const std::string& asStr() const {
+        static const std::string empty;
+        return type == Type::Str ? str : empty;
+    }
+    std::size_t size() const { return arr.size(); }
+    const Json& operator[](std::size_t i) const {
+        static const Json null;
+        return i < arr.size() ? arr[i] : null;
+    }
+    bool has(const std::string& key) const { return type == Type::Obj && obj.count(key) > 0; }
+    const Json& at(const std::string& key) const {
+        static const Json null;
+        auto it = obj.find(key);
+        return it != obj.end() ? it->second : null;
+    }
+};
+
+class JsonParser {
+public:
+    explicit JsonParser(const std::string& s) : m_s(s) {}
+    bool parse(Json& out) {
+        if (!value(out)) return false;
+        ws();
+        return true;
+    }
+
+private:
+    void ws() {
+        while (m_i < m_s.size() && std::isspace(static_cast<unsigned char>(m_s[m_i]))) ++m_i;
+    }
+    bool value(Json& v) {
+        ws();
+        if (m_i >= m_s.size()) return false;
+        const char c = m_s[m_i];
+        if (c == '{') return object(v);
+        if (c == '[') return array(v);
+        if (c == '"') {
+            v.type = Json::Type::Str;
+            return string(v.str);
+        }
+        if (c == 't' || c == 'f') return boolean(v);
+        if (c == 'n') {
+            if (m_s.compare(m_i, 4, "null") == 0) {
+                m_i += 4;
+                v.type = Json::Type::Null;
+                return true;
+            }
+            return false;
+        }
+        return number(v);
+    }
+    bool string(std::string& out) {
+        if (m_s[m_i] != '"') return false;
+        ++m_i;
+        out.clear();
+        while (m_i < m_s.size() && m_s[m_i] != '"') {
+            char c = m_s[m_i++];
+            if (c == '\\' && m_i < m_s.size()) {
+                const char e = m_s[m_i++];
+                switch (e) {
+                    case 'n': out += '\n'; break;
+                    case 't': out += '\t'; break;
+                    case 'r': out += '\r'; break;
+                    default: out += e; break; // covers " \\ /
+                }
+            } else {
+                out += c;
+            }
+        }
+        if (m_i < m_s.size() && m_s[m_i] == '"') {
+            ++m_i;
+            return true;
+        }
+        return false;
+    }
+    bool number(Json& v) {
+        char* end = nullptr;
+        const double d = std::strtod(m_s.c_str() + m_i, &end);
+        if (end == m_s.c_str() + m_i) return false;
+        m_i = static_cast<std::size_t>(end - m_s.c_str());
+        v.type = Json::Type::Num;
+        v.num = d;
+        return true;
+    }
+    bool boolean(Json& v) {
+        if (m_s.compare(m_i, 4, "true") == 0) {
+            m_i += 4;
+            v.type = Json::Type::Bool;
+            v.boolean = true;
+            return true;
+        }
+        if (m_s.compare(m_i, 5, "false") == 0) {
+            m_i += 5;
+            v.type = Json::Type::Bool;
+            v.boolean = false;
+            return true;
+        }
+        return false;
+    }
+    bool array(Json& v) {
+        v.type = Json::Type::Arr;
+        ++m_i;
+        ws();
+        if (m_i < m_s.size() && m_s[m_i] == ']') {
+            ++m_i;
+            return true;
+        }
+        while (m_i < m_s.size()) {
+            Json e;
+            if (!value(e)) return false;
+            v.arr.push_back(std::move(e));
+            ws();
+            if (m_i < m_s.size() && m_s[m_i] == ',') {
+                ++m_i;
+                continue;
+            }
+            if (m_i < m_s.size() && m_s[m_i] == ']') {
+                ++m_i;
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+    bool object(Json& v) {
+        v.type = Json::Type::Obj;
+        ++m_i;
+        ws();
+        if (m_i < m_s.size() && m_s[m_i] == '}') {
+            ++m_i;
+            return true;
+        }
+        while (m_i < m_s.size()) {
+            ws();
+            if (m_i >= m_s.size() || m_s[m_i] != '"') return false;
+            std::string key;
+            if (!string(key)) return false;
+            ws();
+            if (m_i >= m_s.size() || m_s[m_i] != ':') return false;
+            ++m_i;
+            Json val;
+            if (!value(val)) return false;
+            v.obj.emplace(std::move(key), std::move(val));
+            ws();
+            if (m_i < m_s.size() && m_s[m_i] == ',') {
+                ++m_i;
+                continue;
+            }
+            if (m_i < m_s.size() && m_s[m_i] == '}') {
+                ++m_i;
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    const std::string& m_s;
+    std::size_t m_i{0};
+};
+
+inline bool parse(const std::string& text, Json& out) { return JsonParser(text).parse(out); }
+
+/// Compact JSON number: integral magnitudes without a decimal point.
+inline std::string numToStr(double v) {
+    char buf[40];
+    if (std::isfinite(v) && v == std::floor(v) && std::fabs(v) < 1e15) {
+        std::snprintf(buf, sizeof(buf), "%lld", static_cast<long long>(v));
+    } else {
+        std::snprintf(buf, sizeof(buf), "%.6g", v);
+    }
+    return buf;
+}
+
+inline std::string escape(const std::string& s) {
+    std::string o;
+    for (char c : s) {
+        switch (c) {
+            case '"': o += "\\\""; break;
+            case '\\': o += "\\\\"; break;
+            case '\n': o += "\\n"; break;
+            case '\t': o += "\\t"; break;
+            case '\r': o += "\\r"; break;
+            default: o += c; break;
+        }
+    }
+    return o;
+}
+
+inline std::string vec3Json(const ecs::Vec3& v) {
+    return "[" + numToStr(v.x) + ", " + numToStr(v.y) + ", " + numToStr(v.z) + "]";
+}
+
+} // namespace detail
+
+// --- doodle-level (the hand-authorable level spec) -------------------------
+
+/// Serialize a LevelSpec to the "doodle-level" JSON format.
+inline std::string toLevelJson(const LevelSpec& s) {
+    std::string o = "{\n  \"format\": \"doodle-level\",\n  \"version\": 1,\n";
+    o += "  \"wallHeight\": " + detail::numToStr(s.wallHeight) + ",\n";
+    o += "  \"wallThickness\": " + detail::numToStr(s.wallThickness) + ",\n";
+    o += "  \"walls\": [";
+    for (std::size_t i = 0; i < s.walls.size(); ++i) {
+        o += i ? "," : "";
+        o += "\n    {\"polyline\": [";
+        const std::vector<ecs::Vec3>& pl = s.walls[i].polyline;
+        for (std::size_t j = 0; j < pl.size(); ++j) {
+            if (j) o += ", ";
+            o += "[" + detail::numToStr(pl[j].x) + ", " + detail::numToStr(pl[j].z) + "]";
+        }
+        o += "]}";
+    }
+    o += s.walls.empty() ? "]" : "\n  ]";
+    o += ",\n  \"symbols\": [";
+    for (std::size_t i = 0; i < s.symbols.size(); ++i) {
+        o += i ? "," : "";
+        const Symbol& sy = s.symbols[i];
+        o += "\n    {\"type\": \"" + detail::escape(sy.type) + "\", \"x\": " +
+             detail::numToStr(sy.position.x) + ", \"z\": " + detail::numToStr(sy.position.z) +
+             ", \"yaw\": " + detail::numToStr(sy.yaw) + "}";
+    }
+    o += s.symbols.empty() ? "]" : "\n  ]";
+    o += "\n}\n";
+    return o;
+}
+
+/// Parse a "doodle-level" JSON string into a LevelSpec. Returns false if invalid.
+inline bool fromLevelJson(const std::string& text, LevelSpec& out) {
+    detail::Json root;
+    if (!detail::parse(text, root) || !root.isObj()) return false;
+    out = LevelSpec{};
+    out.wallHeight = root.has("wallHeight") ? static_cast<float>(root.at("wallHeight").asNum()) : 3.0f;
+    out.wallThickness =
+        root.has("wallThickness") ? static_cast<float>(root.at("wallThickness").asNum()) : 0.2f;
+
+    const detail::Json& walls = root.at("walls");
+    if (walls.isArr()) {
+        for (std::size_t i = 0; i < walls.size(); ++i) {
+            const detail::Json& pl = walls[i].at("polyline");
+            Wall wall;
+            if (pl.isArr()) {
+                for (std::size_t j = 0; j < pl.size(); ++j) {
+                    const detail::Json& pt = pl[j];
+                    if (pt.isArr() && pt.size() >= 2) {
+                        wall.polyline.push_back(ecs::Vec3{static_cast<float>(pt[0].asNum()), 0.0f,
+                                                          static_cast<float>(pt[1].asNum())});
+                    }
+                }
+            }
+            out.walls.push_back(std::move(wall));
+        }
+    }
+
+    const detail::Json& syms = root.at("symbols");
+    if (syms.isArr()) {
+        for (std::size_t i = 0; i < syms.size(); ++i) {
+            const detail::Json& s = syms[i];
+            Symbol sym;
+            sym.type = s.at("type").asStr();
+            sym.position = ecs::Vec3{static_cast<float>(s.at("x").asNum()), 0.0f,
+                                     static_cast<float>(s.at("z").asNum())};
+            sym.yaw = s.has("yaw") ? static_cast<float>(s.at("yaw").asNum()) : 0.0f;
+            out.symbols.push_back(std::move(sym));
+        }
+    }
+    return true;
+}
+
+// --- doodle-scene (the emitted 3D scene the engine loads) ------------------
+
+/// Serialize a converted SceneDescription to the "doodle-scene" JSON format.
+inline std::string toSceneJson(const SceneDescription& scene) {
+    std::string o = "{\n  \"format\": \"doodle-scene\",\n  \"version\": 1,\n";
+    o += "  \"walls\": [";
+    for (std::size_t i = 0; i < scene.wallBoxes.size(); ++i) {
+        o += i ? "," : "";
+        const world::Box& b = scene.wallBoxes[i];
+        o += "\n    {\"center\": " + detail::vec3Json(b.center) + ", \"size\": " +
+             detail::vec3Json(b.size) + ", \"yaw\": " + detail::numToStr(b.yaw) + "}";
+    }
+    o += scene.wallBoxes.empty() ? "]" : "\n  ]";
+    o += ",\n  \"spawns\": [";
+    for (std::size_t i = 0; i < scene.spawns.size(); ++i) {
+        o += i ? "," : "";
+        const EntitySpawn& s = scene.spawns[i];
+        o += "\n    {\"type\": \"" + detail::escape(s.type) + "\", \"position\": " +
+             detail::vec3Json(s.position) + ", \"yaw\": " + detail::numToStr(s.yaw) + "}";
+    }
+    o += scene.spawns.empty() ? "]" : "\n  ]";
+    o += "\n}\n";
+    return o;
+}
+
+/// Parse a "doodle-scene" JSON string into a SceneDescription (boxes + spawns).
+/// The triangle mesh is derived, so it is left empty here.
+inline bool fromSceneJson(const std::string& text, SceneDescription& out) {
+    detail::Json root;
+    if (!detail::parse(text, root) || !root.isObj()) return false;
+    out = SceneDescription{};
+    auto readVec3 = [](const detail::Json& a) {
+        return ecs::Vec3{static_cast<float>(a[0].asNum()), static_cast<float>(a[1].asNum()),
+                         static_cast<float>(a[2].asNum())};
+    };
+
+    const detail::Json& walls = root.at("walls");
+    if (walls.isArr()) {
+        for (std::size_t i = 0; i < walls.size(); ++i) {
+            const detail::Json& w = walls[i];
+            world::Box b;
+            b.center = readVec3(w.at("center"));
+            b.size = readVec3(w.at("size"));
+            b.yaw = static_cast<float>(w.at("yaw").asNum());
+            out.wallBoxes.push_back(b);
+        }
+    }
+    const detail::Json& spawns = root.at("spawns");
+    if (spawns.isArr()) {
+        for (std::size_t i = 0; i < spawns.size(); ++i) {
+            const detail::Json& s = spawns[i];
+            EntitySpawn spawn;
+            spawn.type = s.at("type").asStr();
+            spawn.position = readVec3(s.at("position"));
+            spawn.yaw = static_cast<float>(s.at("yaw").asNum());
+            out.spawns.push_back(spawn);
+        }
+    }
+    return true;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_level_format.cpp
+++ b/tests/test_level_format.cpp
@@ -1,0 +1,165 @@
+// Test for the level-spec + 3D-scene JSON formats - Milestone 15, #163.
+//
+// Verifies the issue's acceptance criteria:
+//   - A documented schema round-trips through save/load: a LevelSpec and a
+//     converted SceneDescription each survive toJson -> fromJson unchanged.
+//   - A hand-authored sample level loads into a playable scene: the sample JSON
+//     (matching assets/levels/sample_dungeon.level.json) parses, converts, and
+//     emits walls plus a player and other entity spawns into an ECS registry.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_level_format.cpp -o test_level_format
+
+#include "core/ecs/Registry.h"
+#include "core/ecs/View.h"
+#include "core/ecs/components/Components.h"
+#include "game/DoodleScene.h"
+#include "game/LevelFormat.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-3f) {
+    return std::fabs(a - b) <= eps;
+}
+
+// Matches assets/levels/sample_dungeon.level.json (kept in sync by hand).
+static const char* kSampleLevel = R"({
+  "format": "doodle-level",
+  "version": 1,
+  "wallHeight": 3.0,
+  "wallThickness": 0.2,
+  "walls": [
+    {"polyline": [[0, 0], [20, 0], [20, 15], [0, 15], [0, 0]]},
+    {"polyline": [[8, 0], [8, 9]]}
+  ],
+  "symbols": [
+    {"type": "player", "x": 2, "z": 2, "yaw": 0},
+    {"type": "enemy", "x": 16, "z": 4, "yaw": 0},
+    {"type": "enemy", "x": 12, "z": 12, "yaw": 0},
+    {"type": "treasure", "x": 18, "z": 13, "yaw": 0},
+    {"type": "door", "x": 8, "z": 11, "yaw": 0}
+  ]
+})";
+
+static LevelSpec sampleSpec() {
+    LevelSpec s;
+    s.wallHeight = 3.0f;
+    s.wallThickness = 0.2f;
+    Wall outer;
+    outer.polyline = {{0, 0, 0}, {20, 0, 0}, {20, 0, 15}, {0, 0, 15}, {0, 0, 0}};
+    Wall inner;
+    inner.polyline = {{8, 0, 0}, {8, 0, 9}};
+    s.walls = {outer, inner};
+    s.symbols = {
+        {"player", {2, 0, 2}, 0.0f},
+        {"enemy", {16, 0, 4}, 0.0f},
+        {"treasure", {18, 0, 13}, 0.0f},
+    };
+    return s;
+}
+
+static void testLevelSpecRoundTrips() {
+    const LevelSpec in = sampleSpec();
+    LevelSpec out;
+    CHECK(fromLevelJson(toLevelJson(in), out));
+
+    CHECK(approx(out.wallHeight, in.wallHeight));
+    CHECK(approx(out.wallThickness, in.wallThickness));
+    CHECK(out.walls.size() == in.walls.size());
+    for (std::size_t w = 0; w < in.walls.size(); ++w) {
+        CHECK(out.walls[w].polyline.size() == in.walls[w].polyline.size());
+        for (std::size_t p = 0; p < in.walls[w].polyline.size(); ++p) {
+            CHECK(approx(out.walls[w].polyline[p].x, in.walls[w].polyline[p].x));
+            CHECK(approx(out.walls[w].polyline[p].z, in.walls[w].polyline[p].z));
+        }
+    }
+    CHECK(out.symbols.size() == in.symbols.size());
+    for (std::size_t i = 0; i < in.symbols.size(); ++i) {
+        CHECK(out.symbols[i].type == in.symbols[i].type);
+        CHECK(approx(out.symbols[i].position.x, in.symbols[i].position.x));
+        CHECK(approx(out.symbols[i].position.z, in.symbols[i].position.z));
+    }
+}
+
+static void testSceneRoundTrips() {
+    const SceneDescription scene = convert(sampleSpec());
+    SceneDescription out;
+    CHECK(fromSceneJson(toSceneJson(scene), out));
+
+    CHECK(out.wallBoxes.size() == scene.wallBoxes.size());
+    for (std::size_t i = 0; i < scene.wallBoxes.size(); ++i) {
+        CHECK(approx(out.wallBoxes[i].center.x, scene.wallBoxes[i].center.x));
+        CHECK(approx(out.wallBoxes[i].center.y, scene.wallBoxes[i].center.y));
+        CHECK(approx(out.wallBoxes[i].center.z, scene.wallBoxes[i].center.z));
+        CHECK(approx(out.wallBoxes[i].size.x, scene.wallBoxes[i].size.x));
+        CHECK(approx(out.wallBoxes[i].yaw, scene.wallBoxes[i].yaw));
+    }
+    CHECK(out.spawns.size() == scene.spawns.size());
+    for (std::size_t i = 0; i < scene.spawns.size(); ++i) {
+        CHECK(out.spawns[i].type == scene.spawns[i].type);
+        CHECK(approx(out.spawns[i].position.x, scene.spawns[i].position.x));
+    }
+}
+
+static void testSampleLevelLoadsToPlayableScene() {
+    LevelSpec spec;
+    CHECK(fromLevelJson(kSampleLevel, spec));
+    CHECK(spec.walls.size() == 2);   // outer room + inner wall
+    CHECK(spec.symbols.size() == 5); // player, 2 enemies, treasure, door
+    CHECK(approx(spec.wallHeight, 3.0f));
+
+    const SceneDescription scene = convert(spec);
+    CHECK(scene.wallBoxes.size() == 5);          // 4 outer segments + 1 inner
+    CHECK(!scene.wallMesh.vertices.empty());     // extruded geometry exists
+    CHECK(scene.spawns.size() == 5);
+
+    ecs::Registry reg;
+    const std::size_t created = emitToRegistry(scene, reg);
+    CHECK(created == 10);                         // 5 walls + 5 spawns
+    CHECK(reg.aliveCount() == 10);
+
+    // A playable scene: walls, a player start, and other tagged entities.
+    int players = 0, total = 0;
+    reg.view<ecs::Transform, SpawnTag>().each([&](ecs::Entity, ecs::Transform&, SpawnTag& tag) {
+        ++total;
+        if (tag.type == "player") ++players;
+    });
+    CHECK(total == 5);
+    CHECK(players == 1);
+}
+
+static void testMalformedReturnsFalse() {
+    LevelSpec spec;
+    CHECK(!fromLevelJson("{ this is not json", spec));
+    CHECK(!fromLevelJson("[1, 2, 3]", spec)); // valid JSON but not an object
+    CHECK(!fromLevelJson("", spec));
+}
+
+int main() {
+    testLevelSpecRoundTrips();
+    testSceneRoundTrips();
+    testSampleLevelLoadsToPlayableScene();
+    testMalformedReturnsFalse();
+
+    if (g_failures == 0) {
+        std::printf("All level-format tests passed.\n");
+        return 0;
+    }
+    std::printf("%d level-format test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements Milestone 15 / #163: define the intermediate level-spec JSON and the emitted 3D-scene JSON, with save/load, a documented schema, and a hand-authored sample level. Closes #163.

New header `src/game/LevelFormat.h` (namespace `IKore::game`), header-only:

- **`doodle-level`** - the intermediate, hand-authorable level spec (wall polylines + placed symbols + extrusion params). `toLevelJson` / `fromLevelJson` serialize a `LevelSpec` to and from it.
- **`doodle-scene`** - the emitted 3D scene the engine loads (oriented wall boxes + entity spawns), produced by converting a level spec (#162). `toSceneJson` / `fromSceneJson` round-trip it (the triangle mesh is derived, so it is not stored).

A small self-contained JSON value + parser lives in `game::detail`, kept separate from the world importers' parsers to avoid coupling, so the module stays header-only and dependency-free.

Also adds:
- `docs/DOODLE_LEVEL_FORMAT.md` documenting both schemas and the `level -> scene -> entities` pipeline.
- `assets/levels/sample_dungeon.level.json`: a hand-authored room with an inner wall, a player start, two enemies, a treasure, and a door.

## Acceptance criteria

- [x] A documented schema round-trips through save/load (`docs/DOODLE_LEVEL_FORMAT.md`; both `LevelSpec` and `SceneDescription` survive `toJson` -> `fromJson` unchanged)
- [x] A hand-authored sample level loads into a playable scene (the sample JSON parses, converts to wall geometry, and emits walls + a player start + other spawns into the ECS)

## Testing

`tests/test_level_format.cpp` (wired as the `test_level_format` CMake target):

- A `LevelSpec` and a converted `SceneDescription` each survive a `toJson` -> `fromJson` round-trip (walls, symbols, params; boxes, spawns).
- The hand-authored sample (matching `assets/levels/sample_dungeon.level.json`) parses to 2 walls + 5 symbols, converts to 5 wall boxes plus extruded mesh geometry, and `emitToRegistry` produces a playable scene of 10 entities - walls plus exactly one `player` start and the other tagged spawns.
- Malformed JSON and valid-but-non-object JSON are rejected.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_level_format.cpp -o test_level_format && ./test_level_format
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

Builds on #162 (`LevelSpec` / `SceneDescription` / `convert` / `emitToRegistry`). The level JSON is the artifact a drawing front end will emit; the scene JSON is what the engine loads.