### PR TITLE
feat(cv): camera capture perspective rectification (#166)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,6 +551,11 @@ add_executable(test_tour_camera
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tour_camera.cpp
 )
 
+# Camera capture + perspective rectification (Milestone 16 / #166) - header-only.
+add_executable(test_rectify
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_rectify.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/cv/Image.h
+++ b/src/cv/Image.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+/**
+ * @file Image.h
+ * @brief A minimal, dependency-free raster image for the drawing->map CV core.
+ *
+ * Milestone 16. A plain interleaved byte buffer (no OpenCV, no file I/O) so the
+ * computer-vision steps - paper detection, perspective rectification, white
+ * balance (issue #166) - are unit-testable headless. The device camera / image
+ * decoder feeds pixels into this buffer in the live app.
+ */
+namespace IKore {
+namespace cv {
+
+struct Image {
+    int width{0};
+    int height{0};
+    int channels{0};
+    std::vector<std::uint8_t> data; ///< row-major, channel-interleaved.
+
+    Image() = default;
+    Image(int w, int h, int c)
+        : width(w), height(h), channels(c),
+          data(static_cast<std::size_t>(w) * static_cast<std::size_t>(h) * c, 0) {}
+
+    bool inBounds(int x, int y) const { return x >= 0 && y >= 0 && x < width && y < height; }
+
+    std::uint8_t at(int x, int y, int c) const {
+        return data[(static_cast<std::size_t>(y) * width + x) * channels + c];
+    }
+    void set(int x, int y, int c, std::uint8_t v) {
+        data[(static_cast<std::size_t>(y) * width + x) * channels + c] = v;
+    }
+
+    /// Rec.601 luminance at a pixel (or channel 0 for single-channel images).
+    float luminance(int x, int y) const {
+        if (channels >= 3) {
+            return 0.299f * at(x, y, 0) + 0.587f * at(x, y, 1) + 0.114f * at(x, y, 2);
+        }
+        return channels >= 1 ? static_cast<float>(at(x, y, 0)) : 0.0f;
+    }
+
+    /// Bilinear sample of channel @p c at (fx, fy), clamped to the edges.
+    float sample(float fx, float fy, int c) const {
+        if (width <= 0 || height <= 0) return 0.0f;
+        if (fx < 0.0f) fx = 0.0f;
+        if (fy < 0.0f) fy = 0.0f;
+        if (fx > width - 1.0f) fx = width - 1.0f;
+        if (fy > height - 1.0f) fy = height - 1.0f;
+        const int x0 = static_cast<int>(std::floor(fx));
+        const int y0 = static_cast<int>(std::floor(fy));
+        const int x1 = x0 + 1 < width ? x0 + 1 : x0;
+        const int y1 = y0 + 1 < height ? y0 + 1 : y0;
+        const float tx = fx - x0, ty = fy - y0;
+        const float a = at(x0, y0, c), b = at(x1, y0, c);
+        const float cc = at(x0, y1, c), d = at(x1, y1, c);
+        const float top = a + (b - a) * tx;
+        const float bot = cc + (d - cc) * tx;
+        return top + (bot - top) * ty;
+    }
+};
+
+/// Round and clamp a float to a byte.
+inline std::uint8_t clampByte(float v) {
+    if (v <= 0.0f) return 0;
+    if (v >= 255.0f) return 255;
+    return static_cast<std::uint8_t>(v + 0.5f);
+}
+
+} // namespace cv
+} // namespace IKore

--- a/src/cv/Rectify.h
+++ b/src/cv/Rectify.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#include "cv/Image.h"
+
+#include <cmath>
+#include <cstdint>
+
+/**
+ * @file Rectify.h
+ * @brief Paper detection + perspective rectification + white balance (issue #166).
+ *
+ * Milestone 16 (Drawing -> Map CV). Turns a photo of a hand drawing taken at an
+ * angle into a clean, square, top-down image:
+ *   1. detectPaperQuad - find the bright paper quadrilateral on a darker
+ *      background (luminance threshold + extreme-corner selection).
+ *   2. computeHomography / warpPerspective - solve the 4-point homography and
+ *      inverse-map the photo into a square (this is the rectification + auto-crop).
+ *   3. whiteBalance - white-patch scaling so the paper reads as white.
+ *   4. rectify - the full pipeline.
+ *
+ * Pure math on the dependency-free Image (no OpenCV), so it is unit-testable
+ * headless. Header-only.
+ */
+namespace IKore {
+namespace cv {
+
+struct Point {
+    float x{0.0f};
+    float y{0.0f};
+};
+
+/// Paper corners in image space, ordered top-left, top-right, bottom-right, bottom-left.
+struct Quad {
+    Point tl, tr, br, bl;
+};
+
+/// 3x3 homography, row-major. Maps (x,y,1) -> (X,Y) after the perspective divide.
+struct Mat3 {
+    double m[9]{1, 0, 0, 0, 1, 0, 0, 0, 1};
+};
+
+namespace detail {
+
+/// Solve an n x n linear system A x = b in place (Gaussian elimination, pivoting).
+inline bool solveLinear(int n, double* A, double* b, double* x) {
+    for (int col = 0; col < n; ++col) {
+        int pivot = col;
+        double best = std::fabs(A[col * n + col]);
+        for (int r = col + 1; r < n; ++r) {
+            const double v = std::fabs(A[r * n + col]);
+            if (v > best) {
+                best = v;
+                pivot = r;
+            }
+        }
+        if (best < 1e-12) return false; // singular
+        if (pivot != col) {
+            for (int k = 0; k < n; ++k) {
+                const double t = A[col * n + k];
+                A[col * n + k] = A[pivot * n + k];
+                A[pivot * n + k] = t;
+            }
+            const double tb = b[col];
+            b[col] = b[pivot];
+            b[pivot] = tb;
+        }
+        const double diag = A[col * n + col];
+        for (int r = 0; r < n; ++r) {
+            if (r == col) continue;
+            const double f = A[r * n + col] / diag;
+            for (int k = col; k < n; ++k) A[r * n + k] -= f * A[col * n + k];
+            b[r] -= f * b[col];
+        }
+    }
+    for (int i = 0; i < n; ++i) x[i] = b[i] / A[i * n + i];
+    return true;
+}
+
+} // namespace detail
+
+/// Homography mapping the four @p from points to the four @p to points.
+inline Mat3 computeHomography(const Point from[4], const Point to[4]) {
+    double A[64] = {0};
+    double b[8] = {0};
+    for (int i = 0; i < 4; ++i) {
+        const double x = from[i].x, y = from[i].y, X = to[i].x, Y = to[i].y;
+        double* r0 = &A[(2 * i) * 8];
+        r0[0] = x; r0[1] = y; r0[2] = 1; r0[6] = -x * X; r0[7] = -y * X;
+        b[2 * i] = X;
+        double* r1 = &A[(2 * i + 1) * 8];
+        r1[3] = x; r1[4] = y; r1[5] = 1; r1[6] = -x * Y; r1[7] = -y * Y;
+        b[2 * i + 1] = Y;
+    }
+    double h[8] = {0};
+    Mat3 out;
+    if (!detail::solveLinear(8, A, b, h)) return out; // identity on degenerate input
+    for (int i = 0; i < 8; ++i) out.m[i] = h[i];
+    out.m[8] = 1.0;
+    return out;
+}
+
+/// Apply a homography to a point (with the perspective divide).
+inline Point applyHomography(const Mat3& h, float x, float y) {
+    const double denom = h.m[6] * x + h.m[7] * y + h.m[8];
+    const double inv = std::fabs(denom) > 1e-12 ? 1.0 / denom : 0.0;
+    return Point{static_cast<float>((h.m[0] * x + h.m[1] * y + h.m[2]) * inv),
+                 static_cast<float>((h.m[3] * x + h.m[4] * y + h.m[5]) * inv)};
+}
+
+/**
+ * @brief Detect the bright paper quad on a darker background.
+ *
+ * Pixels brighter than @p threshFrac of the peak luminance are treated as paper;
+ * the quad corners are the extremes of (x+y) and (x-y) over those pixels (a robust
+ * convex-corner pick for a roughly rectangular sheet).
+ */
+inline Quad detectPaperQuad(const Image& img, float threshFrac = 0.5f) {
+    Quad q{{0, 0},
+           {static_cast<float>(img.width - 1), 0},
+           {static_cast<float>(img.width - 1), static_cast<float>(img.height - 1)},
+           {0, static_cast<float>(img.height - 1)}};
+    if (img.width <= 1 || img.height <= 1) return q;
+
+    float maxLum = 0.0f;
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) maxLum = std::fmax(maxLum, img.luminance(x, y));
+    }
+    const float thresh = threshFrac * maxLum;
+
+    bool any = false;
+    float minSum = 0, maxSum = 0, minDiff = 0, maxDiff = 0;
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            if (img.luminance(x, y) <= thresh) continue;
+            const float sum = static_cast<float>(x + y);
+            const float diff = static_cast<float>(x - y);
+            if (!any) {
+                minSum = maxSum = sum;
+                minDiff = maxDiff = diff;
+                q.tl = q.br = q.tr = q.bl = Point{static_cast<float>(x), static_cast<float>(y)};
+                any = true;
+                continue;
+            }
+            if (sum < minSum) { minSum = sum; q.tl = {static_cast<float>(x), static_cast<float>(y)}; }
+            if (sum > maxSum) { maxSum = sum; q.br = {static_cast<float>(x), static_cast<float>(y)}; }
+            if (diff > maxDiff) { maxDiff = diff; q.tr = {static_cast<float>(x), static_cast<float>(y)}; }
+            if (diff < minDiff) { minDiff = diff; q.bl = {static_cast<float>(x), static_cast<float>(y)}; }
+        }
+    }
+    return q;
+}
+
+/// Warp @p src into an @p outW x @p outH image using a destination->source map.
+inline Image warpPerspective(const Image& src, const Mat3& dstToSrc, int outW, int outH) {
+    Image out(outW, outH, src.channels);
+    for (int y = 0; y < outH; ++y) {
+        for (int x = 0; x < outW; ++x) {
+            const Point s = applyHomography(dstToSrc, static_cast<float>(x), static_cast<float>(y));
+            for (int c = 0; c < src.channels; ++c) {
+                out.set(x, y, c, clampByte(src.sample(s.x, s.y, c)));
+            }
+        }
+    }
+    return out;
+}
+
+/// White-patch white balance: scale each channel so its peak maps to white.
+inline void whiteBalance(Image& img) {
+    if (img.channels <= 0 || img.data.empty()) return;
+    std::vector<float> peak(static_cast<std::size_t>(img.channels), 1.0f);
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            for (int c = 0; c < img.channels; ++c) {
+                peak[static_cast<std::size_t>(c)] =
+                    std::fmax(peak[static_cast<std::size_t>(c)], static_cast<float>(img.at(x, y, c)));
+            }
+        }
+    }
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            for (int c = 0; c < img.channels; ++c) {
+                const float scale = 255.0f / peak[static_cast<std::size_t>(c)];
+                img.set(x, y, c, clampByte(img.at(x, y, c) * scale));
+            }
+        }
+    }
+}
+
+/**
+ * @brief Rectify a photo to a clean @p outSize x @p outSize top-down image:
+ *        detect the paper, perspective-warp it to a square, and white-balance.
+ */
+inline Image rectify(const Image& photo, int outSize) {
+    const Quad q = detectPaperQuad(photo);
+    const Point dst[4] = {{0, 0},
+                          {static_cast<float>(outSize), 0},
+                          {static_cast<float>(outSize), static_cast<float>(outSize)},
+                          {0, static_cast<float>(outSize)}};
+    const Point src[4] = {q.tl, q.tr, q.br, q.bl};
+    const Mat3 dstToSrc = computeHomography(dst, src); // inverse map for sampling
+    Image out = warpPerspective(photo, dstToSrc, outSize, outSize);
+    whiteBalance(out);
+    return out;
+}
+
+} // namespace cv
+} // namespace IKore

--- a/tests/test_rectify.cpp
+++ b/tests/test_rectify.cpp
@@ -1,0 +1,151 @@
+// Test for camera capture + perspective rectification - Milestone 16, #166.
+//
+// Verifies the issue's acceptance criterion: a photo taken at an angle is
+// rectified to a square, legible top-down view. A synthetic "photo" is built by
+// projecting a known paper pattern (white sheet with an inset corner marker) onto
+// an angled quad on a dark background, with a color tint; rectify() must recover a
+// square, white-balanced, correctly-oriented top-down image.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_rectify.cpp -o test_rectify
+
+#include "cv/Image.h"
+#include "cv/Rectify.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore::cv;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool near(float a, float b, float eps) { return std::fabs(a - b) <= eps; }
+
+static void testHomographyRoundTrip() {
+    const Point from[4] = {{0, 0}, {10, 0}, {10, 10}, {0, 10}};
+    const Point to[4] = {{2, 1}, {12, 2}, {11, 13}, {1, 11}};
+    const Mat3 h = computeHomography(from, to);
+    for (int i = 0; i < 4; ++i) {
+        const Point p = applyHomography(h, from[i].x, from[i].y);
+        CHECK(near(p.x, to[i].x, 1e-3f));
+        CHECK(near(p.y, to[i].y, 1e-3f));
+    }
+}
+
+static void testDetectPaperQuad() {
+    // A bright quad on a dark background; corners deliberately not axis-aligned.
+    Image img(120, 120, 1);
+    const Point corners[4] = {{20, 12}, {100, 28}, {92, 104}, {14, 96}};
+    const Point dst[4] = {{0, 0}, {80, 0}, {80, 80}, {0, 80}};
+    const Mat3 imgToUnit = computeHomography(corners, dst);
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            const Point u = applyHomography(imgToUnit, static_cast<float>(x), static_cast<float>(y));
+            if (u.x >= 0 && u.x < 80 && u.y >= 0 && u.y < 80) img.set(x, y, 0, 240); // paper
+        }
+    }
+    const Quad q = detectPaperQuad(img);
+    CHECK(near(q.tl.x, 20, 4) && near(q.tl.y, 12, 4));
+    CHECK(near(q.tr.x, 100, 4) && near(q.tr.y, 28, 4));
+    CHECK(near(q.br.x, 92, 4) && near(q.br.y, 104, 4));
+    CHECK(near(q.bl.x, 14, 4) && near(q.bl.y, 96, 4));
+}
+
+static void testWhiteBalance() {
+    Image img(8, 8, 3);
+    for (int y = 0; y < 8; ++y) {
+        for (int x = 0; x < 8; ++x) {
+            img.set(x, y, 0, 200); // a flat, tinted gray
+            img.set(x, y, 1, 170);
+            img.set(x, y, 2, 140);
+        }
+    }
+    whiteBalance(img);
+    // Each channel's peak is scaled to white, so the flat patch becomes ~white.
+    CHECK(img.at(4, 4, 0) >= 254);
+    CHECK(img.at(4, 4, 1) >= 254);
+    CHECK(img.at(4, 4, 2) >= 254);
+}
+
+// A clean 80x80 "paper": white sheet with an inset black marker near the top-left.
+static Image makePattern() {
+    Image pat(80, 80, 3);
+    for (int y = 0; y < 80; ++y) {
+        for (int x = 0; x < 80; ++x) {
+            for (int c = 0; c < 3; ++c) pat.set(x, y, c, 255);
+        }
+    }
+    for (int y = 8; y < 24; ++y) {
+        for (int x = 8; x < 24; ++x) {
+            for (int c = 0; c < 3; ++c) pat.set(x, y, c, 0); // corner marker
+        }
+    }
+    return pat;
+}
+
+static void testRectifyAngledPhoto() {
+    const Image pat = makePattern();
+
+    // Build the angled photo: paint the pattern onto a convex quad over a dark,
+    // color-tinted background.
+    Image photo(220, 220, 3);
+    for (int y = 0; y < photo.height; ++y) {
+        for (int x = 0; x < photo.width; ++x) {
+            photo.set(x, y, 0, 28);
+            photo.set(x, y, 1, 30);
+            photo.set(x, y, 2, 26);
+        }
+    }
+    const Point quad[4] = {{45, 35}, {180, 60}, {165, 195}, {35, 170}};
+    const Point patCorners[4] = {{0, 0}, {80, 0}, {80, 80}, {0, 80}};
+    const Mat3 photoToPat = computeHomography(quad, patCorners);
+    const float tint[3] = {0.82f, 0.86f, 0.72f};
+    for (int y = 0; y < photo.height; ++y) {
+        for (int x = 0; x < photo.width; ++x) {
+            const Point p = applyHomography(photoToPat, static_cast<float>(x), static_cast<float>(y));
+            if (p.x >= 0 && p.x < 80 && p.y >= 0 && p.y < 80) {
+                for (int c = 0; c < 3; ++c) photo.set(x, y, c, clampByte(pat.sample(p.x, p.y, c) * tint[c]));
+            }
+        }
+    }
+
+    // Detection should recover the paper corners.
+    const Quad q = detectPaperQuad(photo);
+    CHECK(near(q.tl.x, 45, 8) && near(q.tl.y, 35, 8));
+    CHECK(near(q.br.x, 165, 8) && near(q.br.y, 195, 8));
+
+    // Rectify to a clean 80x80 top-down square.
+    const Image out = rectify(photo, 80);
+    CHECK(out.width == 80 && out.height == 80 && out.channels == 3);
+
+    // Legible + white-balanced: the paper reads white, the marker reads dark, and
+    // the marker is in the top-left (orientation preserved).
+    CHECK(out.luminance(40, 40) > 180.0f);  // center is white
+    CHECK(out.luminance(16, 16) < 110.0f);  // marker (top-left) is dark
+    CHECK(out.luminance(64, 16) > 150.0f);  // top-right is white
+    CHECK(out.luminance(16, 64) > 150.0f);  // bottom-left is white
+    CHECK(out.luminance(64, 64) > 150.0f);  // bottom-right is white
+    CHECK(out.luminance(5, 5) > 150.0f);    // corner border is white (marker is inset)
+}
+
+int main() {
+    testHomographyRoundTrip();
+    testDetectPaperQuad();
+    testWhiteBalance();
+    testRectifyAngledPhoto();
+
+    if (g_failures == 0) {
+        std::printf("All rectification tests passed.\n");
+        return 0;
+    }
+    std::printf("%d rectification test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Starts Milestone 16 (Drawing -> Map CV) with a dependency-free image-rectification core that turns a photo of a hand drawing taken at an angle into a clean, square, top-down image. Closes #166.

- **`src/cv/Image.h`** - a minimal interleaved byte-buffer image (no OpenCV, no file I/O) with bilinear sampling and luminance, so the CV steps are unit-testable headless. The device camera / image decoder feeds pixels into this buffer in the live app.
- **`src/cv/Rectify.h`**:
  - `detectPaperQuad` - find the bright paper quadrilateral on a darker background (luminance threshold + extreme-corner selection ordered TL/TR/BR/BL).
  - `computeHomography` / `applyHomography` - solve the 4-point homography (an 8x8 linear system via Gaussian elimination with pivoting) and apply it.
  - `warpPerspective` - inverse-map a destination square from the source photo with bilinear sampling (the rectification and auto-crop in one step).
  - `whiteBalance` - white-patch scaling so the paper reads as white.
  - `rectify` - the full pipeline: detect -> warp to square -> white balance.

## Acceptance criteria

- [x] A photo taken at an angle is rectified to a square, legible top-down view (a synthetic angled, tinted photo of a paper pattern is recovered to a square, white-balanced, correctly-oriented top-down image)

## Testing

`tests/test_rectify.cpp` (wired as the `test_rectify` CMake target):

- The homography round-trips its four correspondences (maps `from[i]` to `to[i]`).
- Paper-quad detection recovers the corners of a bright skewed quad on a dark background.
- White balance maps a tinted flat patch to white.
- **End to end**: a synthetic angled, color-tinted photo is built by projecting a known paper pattern (a white sheet with an inset corner marker) onto a convex quad over a dark background; `rectify` recovers a square `80x80` top-down image - white paper (center and borders bright), the marker dark and in the top-left (orientation preserved), and white-balanced.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_rectify.cpp -o test_rectify && ./test_rectify
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

This is the headless rectification core; the live app feeds camera frames into `Image` and renders the rectified result. It is the first CV stage of the drawing-to-map pipeline; later M16 issues detect walls/symbols in the rectified image and emit a `LevelSpec` (feeding the M15 converter).