### PR TITLE
feat(cv): binarize/clean and wall vectorization with angle/grid snap (#167)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,6 +556,11 @@ add_executable(test_rectify
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_rectify.cpp
 )
 
+# Binarize/clean + wall vectorization (Milestone 16 / #167) - header-only.
+add_executable(test_vectorize
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_vectorize.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/cv/Vectorize.h
+++ b/src/cv/Vectorize.h
@@ -1,0 +1,302 @@
+#pragma once
+
+#include "cv/Image.h"
+#include "cv/Rectify.h" // cv::Point
+
+#include <cmath>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+/**
+ * @file Vectorize.h
+ * @brief Binarize/clean + wall vectorization with angle/grid snap (issue #167).
+ *
+ * Milestone 16. Turns a (rectified) grayscale drawing of hand-drawn wall lines
+ * into clean, snapped vector polylines:
+ *   grayscale -> adaptive threshold -> denoise (drop small specks) -> thin
+ *   (Zhang-Suen skeleton) -> trace polylines -> simplify (Douglas-Peucker) ->
+ *   snap each segment to 0/45/90 degrees and the grid.
+ *
+ * Pure math on the dependency-free Image (no OpenCV), so it is unit-testable
+ * headless. The resulting polylines feed the M15 LevelSpec / scene converter.
+ * Header-only.
+ */
+namespace IKore {
+namespace cv {
+
+using Polyline = std::vector<Point>;
+
+/// A binary ink mask (1 = ink, 0 = background).
+struct Mask {
+    int width{0};
+    int height{0};
+    std::vector<std::uint8_t> px;
+
+    Mask(int w, int h) : width(w), height(h), px(static_cast<std::size_t>(w) * h, 0) {}
+    std::uint8_t get(int x, int y) const {
+        if (x < 0 || y < 0 || x >= width || y >= height) return 0;
+        return px[static_cast<std::size_t>(y) * width + x];
+    }
+    void set(int x, int y, std::uint8_t v) {
+        if (x >= 0 && y >= 0 && x < width && y < height) px[static_cast<std::size_t>(y) * width + x] = v;
+    }
+    int count() const {
+        int n = 0;
+        for (std::uint8_t v : px) n += (v != 0);
+        return n;
+    }
+};
+
+/// Adaptive threshold: ink where a pixel is darker than its local mean minus @p c.
+inline Mask binarizeAdaptive(const Image& img, int radius = 6, float c = 10.0f) {
+    Mask m(img.width, img.height);
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            float sum = 0.0f;
+            int n = 0;
+            for (int dy = -radius; dy <= radius; ++dy) {
+                for (int dx = -radius; dx <= radius; ++dx) {
+                    const int xx = x + dx, yy = y + dy;
+                    if (img.inBounds(xx, yy)) {
+                        sum += img.luminance(xx, yy);
+                        ++n;
+                    }
+                }
+            }
+            const float mean = n > 0 ? sum / n : 0.0f;
+            if (img.luminance(x, y) < mean - c) m.set(x, y, 1);
+        }
+    }
+    return m;
+}
+
+/// Remove connected ink components smaller than @p minArea (8-connected).
+inline void denoise(Mask& m, int minArea = 12) {
+    Mask visited(m.width, m.height);
+    const int dx8[8] = {1, -1, 0, 0, 1, 1, -1, -1};
+    const int dy8[8] = {0, 0, 1, -1, 1, -1, 1, -1};
+    std::vector<std::pair<int, int>> stack, comp;
+    for (int y = 0; y < m.height; ++y) {
+        for (int x = 0; x < m.width; ++x) {
+            if (!m.get(x, y) || visited.get(x, y)) continue;
+            stack.clear();
+            comp.clear();
+            stack.push_back({x, y});
+            visited.set(x, y, 1);
+            while (!stack.empty()) {
+                const std::pair<int, int> p = stack.back();
+                stack.pop_back();
+                comp.push_back(p);
+                for (int i = 0; i < 8; ++i) {
+                    const int ax = p.first + dx8[i], ay = p.second + dy8[i];
+                    if (m.get(ax, ay) && !visited.get(ax, ay)) {
+                        visited.set(ax, ay, 1);
+                        stack.push_back({ax, ay});
+                    }
+                }
+            }
+            if (static_cast<int>(comp.size()) < minArea) {
+                for (const std::pair<int, int>& p : comp) m.set(p.first, p.second, 0);
+            }
+        }
+    }
+}
+
+/// Zhang-Suen thinning: reduce ink strokes to a 1-pixel-wide skeleton.
+inline Mask thinZhangSuen(const Mask& input) {
+    Mask m = input;
+    std::vector<std::pair<int, int>> toDelete;
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (int step = 0; step < 2; ++step) {
+            toDelete.clear();
+            for (int y = 1; y < m.height - 1; ++y) {
+                for (int x = 1; x < m.width - 1; ++x) {
+                    if (!m.get(x, y)) continue;
+                    const int p2 = m.get(x, y - 1), p3 = m.get(x + 1, y - 1), p4 = m.get(x + 1, y),
+                              p5 = m.get(x + 1, y + 1), p6 = m.get(x, y + 1), p7 = m.get(x - 1, y + 1),
+                              p8 = m.get(x - 1, y), p9 = m.get(x - 1, y - 1);
+                    const int b = p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
+                    if (b < 2 || b > 6) continue;
+                    const int seq[9] = {p2, p3, p4, p5, p6, p7, p8, p9, p2};
+                    int a = 0;
+                    for (int i = 0; i < 8; ++i) {
+                        if (seq[i] == 0 && seq[i + 1] == 1) ++a;
+                    }
+                    if (a != 1) continue;
+                    if (step == 0) {
+                        if (p2 * p4 * p6 != 0) continue;
+                        if (p4 * p6 * p8 != 0) continue;
+                    } else {
+                        if (p2 * p4 * p8 != 0) continue;
+                        if (p2 * p6 * p8 != 0) continue;
+                    }
+                    toDelete.push_back({x, y});
+                }
+            }
+            if (!toDelete.empty()) {
+                changed = true;
+                for (const std::pair<int, int>& p : toDelete) m.set(p.first, p.second, 0);
+            }
+        }
+    }
+    return m;
+}
+
+/// Trace a skeleton into polylines (greedy walk, orthogonal neighbours first).
+inline std::vector<Polyline> tracePolylines(const Mask& sk) {
+    std::vector<Polyline> result;
+    Mask visited(sk.width, sk.height);
+    const int dx8[8] = {1, -1, 0, 0, 1, 1, -1, -1};
+    const int dy8[8] = {0, 0, 1, -1, 1, -1, 1, -1};
+    auto degree = [&](int x, int y) {
+        int d = 0;
+        for (int i = 0; i < 8; ++i) {
+            if (sk.get(x + dx8[i], y + dy8[i])) ++d;
+        }
+        return d;
+    };
+    auto walk = [&](int sx, int sy) {
+        Polyline poly;
+        int cx = sx, cy = sy;
+        while (true) {
+            poly.push_back(Point{static_cast<float>(cx), static_cast<float>(cy)});
+            visited.set(cx, cy, 1);
+            int nx = -1, ny = -1;
+            for (int i = 0; i < 8; ++i) {
+                const int ax = cx + dx8[i], ay = cy + dy8[i];
+                if (sk.get(ax, ay) && !visited.get(ax, ay)) {
+                    nx = ax;
+                    ny = ay;
+                    break;
+                }
+            }
+            if (nx < 0) break;
+            cx = nx;
+            cy = ny;
+        }
+        return poly;
+    };
+    // Open paths from endpoints first, then any remaining loops.
+    for (int y = 0; y < sk.height; ++y) {
+        for (int x = 0; x < sk.width; ++x) {
+            if (sk.get(x, y) && !visited.get(x, y) && degree(x, y) == 1) {
+                Polyline p = walk(x, y);
+                if (p.size() >= 2) result.push_back(std::move(p));
+            }
+        }
+    }
+    for (int y = 0; y < sk.height; ++y) {
+        for (int x = 0; x < sk.width; ++x) {
+            if (sk.get(x, y) && !visited.get(x, y)) {
+                Polyline p = walk(x, y);
+                if (p.size() >= 2) result.push_back(std::move(p));
+            }
+        }
+    }
+    return result;
+}
+
+namespace detail {
+inline void dpRecurse(const Polyline& pts, int i, int j, float eps, std::vector<char>& keep) {
+    if (j <= i + 1) return;
+    const float x1 = pts[i].x, y1 = pts[i].y, x2 = pts[j].x, y2 = pts[j].y;
+    const float dx = x2 - x1, dy = y2 - y1;
+    const float len = std::sqrt(dx * dx + dy * dy);
+    float maxDist = -1.0f;
+    int idx = -1;
+    for (int k = i + 1; k < j; ++k) {
+        float dist;
+        if (len < 1e-6f) {
+            const float ax = pts[k].x - x1, ay = pts[k].y - y1;
+            dist = std::sqrt(ax * ax + ay * ay);
+        } else {
+            dist = std::fabs((pts[k].x - x1) * dy - (pts[k].y - y1) * dx) / len;
+        }
+        if (dist > maxDist) {
+            maxDist = dist;
+            idx = k;
+        }
+    }
+    if (maxDist > eps && idx > 0) {
+        keep[static_cast<std::size_t>(idx)] = 1;
+        dpRecurse(pts, i, idx, eps, keep);
+        dpRecurse(pts, idx, j, eps, keep);
+    }
+}
+} // namespace detail
+
+/// Douglas-Peucker simplification (also merges collinear runs of points).
+inline Polyline douglasPeucker(const Polyline& pts, float eps) {
+    if (pts.size() < 3) return pts;
+    std::vector<char> keep(pts.size(), 0);
+    keep.front() = 1;
+    keep.back() = 1;
+    detail::dpRecurse(pts, 0, static_cast<int>(pts.size()) - 1, eps, keep);
+    Polyline out;
+    for (std::size_t i = 0; i < pts.size(); ++i) {
+        if (keep[i]) out.push_back(pts[i]);
+    }
+    return out;
+}
+
+namespace detail {
+inline float snapValue(float v, float grid) { return grid > 0.0f ? std::round(v / grid) * grid : v; }
+} // namespace detail
+
+/// Snap a polyline: each segment to 0/45/90 degrees and each vertex to the grid.
+inline Polyline snapPolyline(const Polyline& pts, float grid) {
+    if (pts.empty()) return pts;
+    Polyline out;
+    Point prev{detail::snapValue(pts[0].x, grid), detail::snapValue(pts[0].y, grid)};
+    out.push_back(prev);
+    for (std::size_t i = 1; i < pts.size(); ++i) {
+        const float dx = pts[i].x - prev.x, dy = pts[i].y - prev.y;
+        const float adx = std::fabs(dx), ady = std::fabs(dy);
+        Point cur = pts[i];
+        if (adx >= 2.0f * ady) {
+            cur.y = prev.y; // horizontal (0 degrees)
+        } else if (ady >= 2.0f * adx) {
+            cur.x = prev.x; // vertical (90 degrees)
+        } else {
+            const float m = (adx + ady) * 0.5f; // diagonal (45 degrees)
+            cur.x = prev.x + (dx < 0 ? -m : m);
+            cur.y = prev.y + (dy < 0 ? -m : m);
+        }
+        cur.x = detail::snapValue(cur.x, grid);
+        cur.y = detail::snapValue(cur.y, grid);
+        if (!(cur.x == prev.x && cur.y == prev.y)) out.push_back(cur);
+        prev = cur;
+    }
+    return out;
+}
+
+struct VectorizeOptions {
+    int adaptiveRadius{6};
+    float threshC{10.0f};
+    int minComponentArea{12};
+    float simplifyEps{2.5f};
+    float gridSize{10.0f};
+};
+
+/// Full pipeline: a grayscale drawing -> clean, snapped wall polylines.
+inline std::vector<Polyline> vectorizeWalls(const Image& img, const VectorizeOptions& opt = {}) {
+    Mask bin = binarizeAdaptive(img, opt.adaptiveRadius, opt.threshC);
+    denoise(bin, opt.minComponentArea);
+    const Mask skeleton = thinZhangSuen(bin);
+    const std::vector<Polyline> traced = tracePolylines(skeleton);
+
+    std::vector<Polyline> out;
+    for (const Polyline& p : traced) {
+        if (p.size() < 2) continue;
+        Polyline simplified = douglasPeucker(p, opt.simplifyEps);
+        Polyline snapped = snapPolyline(simplified, opt.gridSize);
+        if (snapped.size() >= 2) out.push_back(std::move(snapped));
+    }
+    return out;
+}
+
+} // namespace cv
+} // namespace IKore

--- a/tests/test_vectorize.cpp
+++ b/tests/test_vectorize.cpp
@@ -1,0 +1,149 @@
+// Test for binarize/clean + wall vectorization - Milestone 16, #167.
+//
+// Verifies the issue's acceptance criterion: hand-drawn wall lines become clean,
+// snapped vector polylines. Covers adaptive thresholding (beats a lighting
+// gradient), speck denoising, Douglas-Peucker simplification, angle/grid snapping,
+// and the full pipeline on a hand-drawn-style "L" wall.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_vectorize.cpp -o test_vectorize
+
+#include "cv/Image.h"
+#include "cv/Vectorize.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore::cv;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool isMultipleOf(float v, float grid) {
+    return std::fabs(v / grid - std::round(v / grid)) < 1e-3f;
+}
+
+static void testAdaptiveThresholdBeatsGradient() {
+    // Paper brightens left-to-right; a dark horizontal line crosses the gradient.
+    Image img(40, 40, 1);
+    for (int y = 0; y < 40; ++y) {
+        for (int x = 0; x < 40; ++x) {
+            const float base = 100.0f + (static_cast<float>(x) / 39.0f) * 120.0f; // 100..220
+            float v = base;
+            if (y >= 19 && y <= 21) v = base - 90.0f; // ink line
+            img.set(x, y, 0, clampByte(v));
+        }
+    }
+    const Mask bin = binarizeAdaptive(img, 6, 10.0f);
+    // The line is detected as ink on both the dark and bright sides...
+    CHECK(bin.get(5, 20) == 1);
+    CHECK(bin.get(35, 20) == 1);
+    // ...while the paper is not, on both sides (a global threshold could not).
+    CHECK(bin.get(5, 5) == 0);
+    CHECK(bin.get(35, 5) == 0);
+}
+
+static void testDenoiseRemovesSpecks() {
+    Mask m(40, 40);
+    for (int y = 19; y <= 21; ++y) {
+        for (int x = 5; x <= 35; ++x) m.set(x, y, 1); // a substantial line
+    }
+    m.set(2, 2, 1); // isolated specks
+    m.set(3, 2, 1);
+    denoise(m, 10);
+    CHECK(m.get(2, 2) == 0);   // speck removed
+    CHECK(m.get(3, 2) == 0);
+    CHECK(m.get(20, 20) == 1); // line kept
+}
+
+static void testDouglasPeucker() {
+    Polyline pts;
+    for (int x = 0; x <= 10; ++x) pts.push_back(Point{static_cast<float>(x), 0.0f});
+    for (int y = 1; y <= 10; ++y) pts.push_back(Point{10.0f, static_cast<float>(y)});
+    const Polyline simple = douglasPeucker(pts, 1.0f);
+    CHECK(simple.size() == 3); // start, corner, end
+    CHECK(simple[1].x == 10.0f && simple[1].y == 0.0f);
+}
+
+static void testSnapPolyline() {
+    const Polyline in = {{1, 2}, {31, 5}, {33, 34}};
+    const Polyline out = snapPolyline(in, 10.0f);
+    CHECK(out.size() == 3);
+    CHECK(out[0].y == out[1].y); // first segment horizontal
+    CHECK(out[1].x == out[2].x); // second segment vertical
+    for (const Point& p : out) {
+        CHECK(isMultipleOf(p.x, 10.0f) && isMultipleOf(p.y, 10.0f));
+    }
+}
+
+static void testVectorizeHandDrawnL() {
+    // A hand-drawn-style thick "L": a horizontal stroke and a vertical stroke.
+    Image img(60, 60, 1);
+    for (int y = 0; y < 60; ++y) {
+        for (int x = 0; x < 60; ++x) img.set(x, y, 0, 240); // paper
+    }
+    for (int y = 19; y <= 21; ++y) {
+        for (int x = 10; x <= 40; ++x) img.set(x, y, 0, 20); // horizontal stroke
+    }
+    for (int y = 19; y <= 40; ++y) {
+        for (int x = 38; x <= 40; ++x) img.set(x, y, 0, 20); // vertical stroke
+    }
+
+    VectorizeOptions opt;
+    opt.minComponentArea = 10;
+    opt.gridSize = 10.0f;
+    const std::vector<Polyline> walls = vectorizeWalls(img, opt);
+    CHECK(!walls.empty());
+
+    // Take the longest polyline (the L) and check it is clean and snapped.
+    const Polyline* best = nullptr;
+    for (const Polyline& p : walls) {
+        if (best == nullptr || p.size() > best->size()) best = &p;
+    }
+    CHECK(best != nullptr);
+    if (best == nullptr) return;
+
+    CHECK(best->size() >= 3); // at least two segments meeting at a corner
+
+    bool allAxisAligned = true, allOnGrid = true;
+    float minX = 1e9f, maxX = -1e9f, minY = 1e9f, maxY = -1e9f;
+    for (std::size_t i = 0; i < best->size(); ++i) {
+        const Point& p = (*best)[i];
+        if (!isMultipleOf(p.x, 10.0f) || !isMultipleOf(p.y, 10.0f)) allOnGrid = false;
+        minX = std::min(minX, p.x);
+        maxX = std::max(maxX, p.x);
+        minY = std::min(minY, p.y);
+        maxY = std::max(maxY, p.y);
+        if (i > 0) {
+            const Point& q = (*best)[i - 1];
+            const bool axis = (std::fabs(p.x - q.x) < 1e-3f) || (std::fabs(p.y - q.y) < 1e-3f);
+            if (!axis) allAxisAligned = false;
+        }
+    }
+    CHECK(allAxisAligned);         // every segment is horizontal or vertical (snapped)
+    CHECK(allOnGrid);              // every vertex sits on the grid
+    CHECK(maxX - minX >= 20.0f);   // spans the horizontal stroke
+    CHECK(maxY - minY >= 15.0f);   // spans the vertical stroke
+}
+
+int main() {
+    testAdaptiveThresholdBeatsGradient();
+    testDenoiseRemovesSpecks();
+    testDouglasPeucker();
+    testSnapPolyline();
+    testVectorizeHandDrawnL();
+
+    if (g_failures == 0) {
+        std::printf("All vectorization tests passed.\n");
+        return 0;
+    }
+    std::printf("%d vectorization test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements Milestone 16 / #167: turn a rectified grayscale drawing of hand-drawn wall lines into clean, snapped vector polylines. Closes #167.

New header `src/cv/Vectorize.h` (namespace `IKore::cv`), header-only. Pipeline: grayscale -> adaptive threshold -> denoise -> thin -> trace -> simplify -> snap:

- **`binarizeAdaptive`** - local-mean adaptive threshold, so ink is detected even under an uneven lighting gradient where a global threshold would fail.
- **`denoise`** - drop connected ink components smaller than a minimum area (removes specks while keeping strokes).
- **`thinZhangSuen`** - Zhang-Suen thinning to a 1-pixel skeleton.
- **`tracePolylines`** - walk the skeleton (from endpoints, then loops) into polylines.
- **`douglasPeucker`** - simplify each polyline, merging collinear runs of points.
- **`snapPolyline`** - snap each segment to 0/45/90 degrees and each vertex to the grid.
- **`vectorizeWalls`** - the full pipeline, with a `VectorizeOptions` for thresholds, minimum area, simplify epsilon, and grid size.

Pure math on the dependency-free `Image` (no OpenCV), so it is unit-testable headless. The output polylines feed the M15 `LevelSpec` / scene converter.

## Acceptance criteria

- [x] Hand-drawn wall lines become clean, snapped vector polylines (the pipeline produces axis-aligned, grid-snapped polylines from a thick hand-drawn stroke)

## Testing

`tests/test_vectorize.cpp` (wired as the `test_vectorize` CMake target):

- Adaptive thresholding detects a dark line across a brightness gradient on both the dark and bright sides while leaving paper alone (a global threshold could not).
- `denoise` removes isolated specks and keeps a substantial line.
- Douglas-Peucker reduces a padded "L" of many points to start/corner/end.
- Snapping turns an off-grid, slightly-skewed polyline into grid-aligned horizontal/vertical segments.
- **End to end**: a hand-drawn-style thick "L" (two strokes) becomes a clean polyline whose every segment is axis-aligned and every vertex sits on the grid, spanning both strokes.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_vectorize.cpp -o test_vectorize && ./test_vectorize
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

Builds on #166 (`cv::Image`, rectified top-down image). This is the wall-detection CV stage; a following M16 issue recognizes placed symbols and assembles a `LevelSpec` (feeding the M15 pipeline to a playable dungeon).