### PR TITLE
feat(cv): Tier-1 symbol recognition (color-class + shape) (#169)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,11 @@ add_executable(test_topology
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_topology.cpp
 )
 
+# Tier-1 symbol recognition (Milestone 16 / #169) - header-only.
+add_executable(test_symbols
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_symbols.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/cv/Symbols.h
+++ b/src/cv/Symbols.h
@@ -1,0 +1,230 @@
+#pragma once
+
+#include "cv/Image.h"
+#include "cv/Vectorize.h" // Mask
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * @file Symbols.h
+ * @brief Tier-1 symbol recognition: color-class + shape-subtype (issue #169).
+ *
+ * Milestone 16. Classifies the drawn symbols in a (rectified) image into the
+ * Tier-1 vocabulary - start, exit, coin, enemy - and maps them to game objects:
+ *   - Color class is the primary discriminator (green=start/player, red=enemy,
+ *     yellow=coin, blue=exit), by hue with a saturation gate.
+ *   - Shape subtype (from the blob fill ratio: square / circle / triangle / cross)
+ *     is recorded and folds into the confidence.
+ * A low-confidence or unrecognizable mark falls back to a sensible default object
+ * rather than failing.
+ *
+ * Pure pixel logic on the dependency-free Image / Mask (no OpenCV), unit-testable
+ * headless. Header-only.
+ */
+namespace IKore {
+namespace cv {
+
+enum class ColorClass { Green, Red, Yellow, Blue, Unknown };
+enum class ShapeClass { Circle, Square, Triangle, Cross, Unknown };
+
+/// The game object a color class maps to (matching the LevelSpec spawn vocabulary).
+inline const char* colorObject(ColorClass c) {
+    switch (c) {
+        case ColorClass::Green: return "player"; // start
+        case ColorClass::Red: return "enemy";
+        case ColorClass::Yellow: return "coin";
+        case ColorClass::Blue: return "exit";
+        default: return "";
+    }
+}
+
+struct ColorScore {
+    ColorClass cls{ColorClass::Unknown};
+    float confidence{0.0f};
+};
+
+/// Classify an RGB color into a Tier-1 color class (hue nearest-reference + sat).
+inline ColorScore classifyColor(int R, int G, int B) {
+    const float r = static_cast<float>(R), g = static_cast<float>(G), b = static_cast<float>(B);
+    const float mx = std::max({r, g, b});
+    const float mn = std::min({r, g, b});
+    const float sat = mx > 0.0f ? (mx - mn) / mx : 0.0f;
+    if (mx < 50.0f || sat < 0.25f) return {ColorClass::Unknown, 0.0f}; // too dark or gray
+
+    const float d = mx - mn;
+    float h = 0.0f;
+    if (mx == r) h = 60.0f * std::fmod((g - b) / d, 6.0f);
+    else if (mx == g) h = 60.0f * ((b - r) / d + 2.0f);
+    else h = 60.0f * ((r - g) / d + 4.0f);
+    if (h < 0.0f) h += 360.0f;
+
+    const std::pair<float, ColorClass> refs[4] = {{0.0f, ColorClass::Red},
+                                                  {60.0f, ColorClass::Yellow},
+                                                  {120.0f, ColorClass::Green},
+                                                  {240.0f, ColorClass::Blue}};
+    float best = 1e9f;
+    ColorClass bc = ColorClass::Unknown;
+    for (const std::pair<float, ColorClass>& rf : refs) {
+        float dd = std::fabs(h - rf.first);
+        dd = std::min(dd, 360.0f - dd);
+        if (dd < best) {
+            best = dd;
+            bc = rf.second;
+        }
+    }
+    const float hueConf = std::max(0.0f, 1.0f - best / 45.0f);
+    const float satConf = std::min(1.0f, (sat - 0.2f) / 0.5f);
+    const float conf = std::max(0.0f, std::min(1.0f, hueConf * satConf));
+    if (conf <= 0.0f) return {ColorClass::Unknown, 0.0f};
+    return {bc, conf};
+}
+
+struct ShapeScore {
+    ShapeClass cls{ShapeClass::Unknown};
+    float confidence{0.0f};
+};
+
+/// Classify a blob's shape from its fill ratio (area / bounding-box area).
+inline ShapeScore classifyShape(int bboxW, int bboxH, int area) {
+    if (bboxW <= 0 || bboxH <= 0) return {ShapeClass::Unknown, 0.0f};
+    const float fill = static_cast<float>(area) / static_cast<float>(bboxW * bboxH);
+    const std::pair<float, ShapeClass> cands[4] = {{1.0f, ShapeClass::Square},
+                                                   {0.785f, ShapeClass::Circle},
+                                                   {0.5f, ShapeClass::Triangle},
+                                                   {0.38f, ShapeClass::Cross}};
+    float best = 1e9f;
+    ShapeClass bc = ShapeClass::Unknown;
+    for (const std::pair<float, ShapeClass>& c : cands) {
+        const float dd = std::fabs(fill - c.first);
+        if (dd < best) {
+            best = dd;
+            bc = c.second;
+        }
+    }
+    return {bc, std::max(0.0f, 1.0f - best / 0.2f)};
+}
+
+struct SymbolResult {
+    std::string object;              ///< game object (or the default on low confidence).
+    ColorClass color{ColorClass::Unknown};
+    ShapeClass shape{ShapeClass::Unknown};
+    float confidence{0.0f};
+    bool lowConfidence{false};       ///< true when it fell back to the default.
+};
+
+/// Recognize a symbol from its average color and blob shape. Falls back to
+/// @p defaultObject when the color is unknown or the combined confidence is low.
+inline SymbolResult recognizeSymbol(int r, int g, int b, int bboxW, int bboxH, int area,
+                                    const std::string& defaultObject = "coin",
+                                    float minConfidence = 0.35f) {
+    const ColorScore cs = classifyColor(r, g, b);
+    const ShapeScore sh = classifyShape(bboxW, bboxH, area);
+    SymbolResult out;
+    out.color = cs.cls;
+    out.shape = sh.cls;
+    if (cs.cls == ColorClass::Unknown) {
+        out.object = defaultObject;
+        out.confidence = cs.confidence;
+        out.lowConfidence = true;
+        return out;
+    }
+    const float conf = 0.7f * cs.confidence + 0.3f * sh.confidence;
+    out.confidence = conf;
+    if (conf < minConfidence) {
+        out.object = defaultObject;
+        out.lowConfidence = true;
+        return out;
+    }
+    out.object = colorObject(cs.cls);
+    out.lowConfidence = false;
+    return out;
+}
+
+struct SymbolInstance {
+    float cx{0.0f};
+    float cy{0.0f};
+    int minX{0}, minY{0}, maxX{0}, maxY{0};
+    int area{0};
+    SymbolResult result;
+};
+
+struct SymbolOptions {
+    float minSaturation{0.25f};
+    int minArea{20};
+    std::string defaultObject{"coin"};
+    float minConfidence{0.35f};
+};
+
+/// Detect and classify all colored symbol blobs in @p img (needs 3+ channels).
+inline std::vector<SymbolInstance> detectSymbols(const Image& img, const SymbolOptions& opt = {}) {
+    std::vector<SymbolInstance> out;
+    if (img.channels < 3 || img.width <= 0 || img.height <= 0) return out;
+
+    auto colored = [&](int x, int y) {
+        const float r = img.at(x, y, 0), g = img.at(x, y, 1), b = img.at(x, y, 2);
+        const float mx = std::max({r, g, b});
+        const float mn = std::min({r, g, b});
+        const float sat = mx > 0.0f ? (mx - mn) / mx : 0.0f;
+        return mx >= 50.0f && sat >= opt.minSaturation;
+    };
+
+    Mask visited(img.width, img.height);
+    const int dx8[8] = {1, -1, 0, 0, 1, 1, -1, -1};
+    const int dy8[8] = {0, 0, 1, -1, 1, -1, 1, -1};
+    std::vector<int> stack;
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            if (!colored(x, y) || visited.get(x, y)) continue;
+            stack.clear();
+            stack.push_back(y * img.width + x);
+            visited.set(x, y, 1);
+            long sumR = 0, sumG = 0, sumB = 0;
+            int area = 0, minX = x, minY = y, maxX = x, maxY = y;
+            double sx = 0, sy = 0;
+            while (!stack.empty()) {
+                const int cell = stack.back();
+                stack.pop_back();
+                const int cxx = cell % img.width, cyy = cell / img.width;
+                ++area;
+                sumR += img.at(cxx, cyy, 0);
+                sumG += img.at(cxx, cyy, 1);
+                sumB += img.at(cxx, cyy, 2);
+                sx += cxx;
+                sy += cyy;
+                minX = std::min(minX, cxx);
+                minY = std::min(minY, cyy);
+                maxX = std::max(maxX, cxx);
+                maxY = std::max(maxY, cyy);
+                for (int i = 0; i < 8; ++i) {
+                    const int ax = cxx + dx8[i], ay = cyy + dy8[i];
+                    if (ax < 0 || ay < 0 || ax >= img.width || ay >= img.height) continue;
+                    if (visited.get(ax, ay) || !colored(ax, ay)) continue;
+                    visited.set(ax, ay, 1);
+                    stack.push_back(ay * img.width + ax);
+                }
+            }
+            if (area < opt.minArea) continue;
+            SymbolInstance s;
+            s.area = area;
+            s.minX = minX;
+            s.minY = minY;
+            s.maxX = maxX;
+            s.maxY = maxY;
+            s.cx = static_cast<float>(sx / area);
+            s.cy = static_cast<float>(sy / area);
+            s.result = recognizeSymbol(static_cast<int>(sumR / area), static_cast<int>(sumG / area),
+                                       static_cast<int>(sumB / area), maxX - minX + 1, maxY - minY + 1,
+                                       area, opt.defaultObject, opt.minConfidence);
+            out.push_back(std::move(s));
+        }
+    }
+    return out;
+}
+
+} // namespace cv
+} // namespace IKore

--- a/tests/test_symbols.cpp
+++ b/tests/test_symbols.cpp
@@ -1,0 +1,164 @@
+// Test for Tier-1 symbol recognition - Milestone 16, #169.
+//
+// Verifies the issue's acceptance criteria: Tier-1 symbols (start/exit/coin/enemy)
+// are recognized by color class (+ shape subtype) and mapped to the correct game
+// objects, and an unknown/low-confidence mark falls back to a sensible default
+// rather than failing.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_symbols.cpp -o test_symbols
+
+#include "cv/Image.h"
+#include "cv/Symbols.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore::cv;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static void fillRect(Image& im, int cx, int cy, int r, int R, int G, int B, int c) {
+    (void)c;
+    for (int y = cy - r; y <= cy + r; ++y) {
+        for (int x = cx - r; x <= cx + r; ++x) {
+            if (im.inBounds(x, y)) {
+                im.set(x, y, 0, static_cast<std::uint8_t>(R));
+                im.set(x, y, 1, static_cast<std::uint8_t>(G));
+                im.set(x, y, 2, static_cast<std::uint8_t>(B));
+            }
+        }
+    }
+}
+
+static void fillCircle(Image& im, int cx, int cy, int r, int R, int G, int B) {
+    for (int y = cy - r; y <= cy + r; ++y) {
+        for (int x = cx - r; x <= cx + r; ++x) {
+            if ((x - cx) * (x - cx) + (y - cy) * (y - cy) <= r * r && im.inBounds(x, y)) {
+                im.set(x, y, 0, static_cast<std::uint8_t>(R));
+                im.set(x, y, 1, static_cast<std::uint8_t>(G));
+                im.set(x, y, 2, static_cast<std::uint8_t>(B));
+            }
+        }
+    }
+}
+
+static void putRGB(Image& im, int x, int y, int R, int G, int B) {
+    if (!im.inBounds(x, y)) return;
+    im.set(x, y, 0, static_cast<std::uint8_t>(R));
+    im.set(x, y, 1, static_cast<std::uint8_t>(G));
+    im.set(x, y, 2, static_cast<std::uint8_t>(B));
+}
+
+static void drawX(Image& im, int cx, int cy, int r, int R, int G, int B) {
+    for (int t = -r; t <= r; ++t) {
+        for (int w = -1; w <= 1; ++w) {
+            putRGB(im, cx + t + w, cy + t, R, G, B); // one diagonal
+            putRGB(im, cx + t + w, cy - t, R, G, B); // the other
+        }
+    }
+}
+
+static void testClassifyColor() {
+    CHECK(classifyColor(30, 180, 30).cls == ColorClass::Green);
+    CHECK(classifyColor(200, 30, 30).cls == ColorClass::Red);
+    CHECK(classifyColor(235, 215, 20).cls == ColorClass::Yellow);
+    CHECK(classifyColor(30, 60, 210).cls == ColorClass::Blue);
+    CHECK(classifyColor(30, 180, 30).confidence > 0.5f);
+    // Gray / dark marks are not a color class.
+    CHECK(classifyColor(150, 150, 150).cls == ColorClass::Unknown);
+    CHECK(classifyColor(20, 20, 25).cls == ColorClass::Unknown);
+}
+
+static void testClassifyShape() {
+    CHECK(classifyShape(14, 14, 196).cls == ShapeClass::Square);   // fill 1.0
+    CHECK(classifyShape(16, 16, 201).cls == ShapeClass::Circle);   // fill ~0.785
+    CHECK(classifyShape(20, 20, 200).cls == ShapeClass::Triangle); // fill 0.5
+    CHECK(classifyShape(20, 20, 140).cls == ShapeClass::Cross);    // fill ~0.35
+}
+
+static void testRecognizeMapsToGameObjects() {
+    CHECK(recognizeSymbol(30, 180, 30, 16, 16, 200).object == "player"); // start
+    CHECK(recognizeSymbol(200, 30, 30, 18, 18, 120).object == "enemy");
+    CHECK(recognizeSymbol(235, 215, 20, 16, 16, 200).object == "coin");
+    CHECK(recognizeSymbol(30, 60, 210, 14, 14, 196).object == "exit");
+    CHECK(!recognizeSymbol(30, 180, 30, 16, 16, 200).lowConfidence);
+}
+
+static void testUnknownFallsBackToDefault() {
+    const SymbolResult gray = recognizeSymbol(150, 150, 150, 16, 16, 200, "coin");
+    CHECK(gray.object == "coin");   // sensible default, not a failure
+    CHECK(gray.lowConfidence);
+    CHECK(gray.color == ColorClass::Unknown);
+
+    // The default is configurable.
+    const SymbolResult custom = recognizeSymbol(150, 150, 150, 16, 16, 200, "player");
+    CHECK(custom.object == "player");
+    CHECK(custom.lowConfidence);
+}
+
+static const SymbolInstance* nearest(const std::vector<SymbolInstance>& syms, float x, float y) {
+    const SymbolInstance* best = nullptr;
+    float bestD = 1e9f;
+    for (const SymbolInstance& s : syms) {
+        const float d = (s.cx - x) * (s.cx - x) + (s.cy - y) * (s.cy - y);
+        if (d < bestD) {
+            bestD = d;
+            best = &s;
+        }
+    }
+    return best;
+}
+
+static void testDetectSymbolsEndToEnd() {
+    Image img(110, 60, 3);
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            for (int c = 0; c < 3; ++c) img.set(x, y, c, 250); // white paper
+        }
+    }
+    fillCircle(img, 15, 30, 8, 30, 180, 30);   // green start
+    drawX(img, 42, 30, 9, 200, 30, 30);        // red enemy
+    fillCircle(img, 70, 30, 8, 235, 215, 20);  // yellow coin
+    fillRect(img, 96, 30, 7, 30, 60, 210, 0);  // blue exit
+
+    const std::vector<SymbolInstance> syms = detectSymbols(img);
+    CHECK(syms.size() == 4);
+
+    const SymbolInstance* start = nearest(syms, 15, 30);
+    const SymbolInstance* enemy = nearest(syms, 42, 30);
+    const SymbolInstance* coin = nearest(syms, 70, 30);
+    const SymbolInstance* exit = nearest(syms, 96, 30);
+    CHECK(start && start->result.object == "player");
+    CHECK(enemy && enemy->result.object == "enemy");
+    CHECK(coin && coin->result.object == "coin");
+    CHECK(exit && exit->result.object == "exit");
+    // Centroids land on the drawn marks.
+    CHECK(start && std::fabs(start->cx - 15.0f) < 3.0f);
+    CHECK(exit && std::fabs(exit->cx - 96.0f) < 3.0f);
+}
+
+int main() {
+    testClassifyColor();
+    testClassifyShape();
+    testRecognizeMapsToGameObjects();
+    testUnknownFallsBackToDefault();
+    testDetectSymbolsEndToEnd();
+
+    if (g_failures == 0) {
+        std::printf("All symbol recognition tests passed.\n");
+        return 0;
+    }
+    std::printf("%d symbol recognition test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements Milestone 16 / #169: recognize the drawn symbols in a rectified image using the color-class + shape-subtype scheme, over the Tier-1 vocabulary (start / exit / coin / enemy), with graceful defaults for low-confidence marks. Closes #169.

New header `src/cv/Symbols.h` (namespace `IKore::cv`), header-only:

- **`classifyColor`** - hue nearest-reference with a saturation gate maps a mark to a Tier-1 color class (green/red/yellow/blue); low-saturation or dark marks are `Unknown`. Color is the primary discriminator.
- **`classifyShape`** - the blob fill ratio (area / bounding-box area) classifies the shape subtype (square / circle / triangle / cross); it is recorded and folds into the confidence.
- **`colorObject`** - maps the color class to the game object matching the `LevelSpec` spawn vocabulary: green -> player (start), red -> enemy, yellow -> coin, blue -> exit.
- **`recognizeSymbol`** - combines color and shape into a `SymbolResult`; when the color is `Unknown` or the combined confidence is low it falls back to a configurable default object (default `"coin"`) rather than failing.
- **`detectSymbols`** - finds colored blobs (connected components of saturated pixels), computes each blob's average color, bounding box, area, and centroid, and classifies it into a `SymbolInstance`.

Pure pixel logic on the dependency-free `Image` / `Mask` (no OpenCV), unit-testable headless.

## Acceptance criteria

- [x] Tier-1 symbols are recognized and mapped to the correct game objects (green->player, red->enemy, yellow->coin, blue->exit)
- [x] Unknown marks fall back to a sensible default rather than failing (a gray/low-confidence mark returns the configurable default with `lowConfidence` set)

## Testing

`tests/test_symbols.cpp` (wired as the `test_symbols` CMake target):

- Color classification of the four Tier-1 colors, plus gray/dark marks as `Unknown`.
- Shape classification by fill ratio (square / circle / triangle / cross).
- Recognition mapping each color to the right game object.
- An unknown/gray mark falling back to the default object (and to a configured override), flagged `lowConfidence`.
- **End to end**: an image with a green circle, a red X, a yellow circle, and a blue square is detected as four symbols mapped to player / enemy / coin / exit at the correct positions.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_symbols.cpp -o test_symbols && ./test_symbols
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

Builds on #166 (`cv::Image`). Symbols output the `LevelSpec` spawn vocabulary, so with the walls (#167) and topology (#168) a following issue can assemble a full `LevelSpec` -> the M15 playable pipeline, closing the hand-drawing-to-playable-map loop.