### PR TITLE
feat(game): confidence + repair review model before play (#170)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,11 @@ add_executable(test_symbols
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_symbols.cpp
 )
 
+# Confidence + repair review model (Milestone 16 / #170) - header-only.
+add_executable(test_level_review
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_review.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/game/LevelReview.h
+++ b/src/game/LevelReview.h
@@ -1,0 +1,174 @@
+#pragma once
+
+#include "cv/Symbols.h"      // cv::SymbolInstance
+#include "cv/Vectorize.h"    // cv::Polyline
+#include "game/DoodleScene.h" // Wall, Symbol, LevelSpec
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+/**
+ * @file LevelReview.h
+ * @brief Confidence + repair model for the interpreted level (issue #170).
+ *
+ * Milestone 16. Between the CV interpretation (walls #167, symbols #169) and play
+ * (#162/#164), the user reviews the detected level and fixes misreads. This is the
+ * headless, testable model behind that UI:
+ *   - assembleLevel turns detected wall polylines and symbols into an editable
+ *     InterpretedLevel; each symbol keeps its confidence and a needsReview flag.
+ *   - Edit operations let the user correct a symbol's type, move / add / delete
+ *     symbols, and edit walls.
+ *   - issues() enumerates every problem (low-confidence marks not yet reviewed,
+ *     missing start/exit, no walls) so nothing is dropped silently, and
+ *     readyToPlay() gates play until they are resolved.
+ *   - toLevelSpec() produces the LevelSpec for the M15 pipeline.
+ *
+ * Header-only; the renderer/ImGui layer draws editable icons over this model.
+ */
+namespace IKore {
+namespace game {
+
+/// A detected symbol the user can review and correct.
+struct ReviewSymbol {
+    std::string type;         ///< game object ("player","enemy","coin","exit",...).
+    ecs::Vec3 position{};
+    float confidence{1.0f};
+    bool needsReview{false};  ///< low-confidence / ambiguous detection.
+    bool reviewed{false};     ///< user confirmed or corrected it.
+};
+
+enum class IssueKind { LowConfidenceSymbol, NoPlayerStart, NoExit, NoWalls };
+
+struct LevelIssue {
+    IssueKind kind;
+    int symbolIndex;     ///< -1 for level-wide issues.
+    std::string message;
+};
+
+class InterpretedLevel {
+public:
+    std::vector<Wall> walls;
+    std::vector<ReviewSymbol> symbols;
+    float wallHeight{3.0f};
+    float wallThickness{0.2f};
+
+    // --- Edit operations (the "repair" the user performs) ------------------
+    void setSymbolType(std::size_t i, const std::string& type) {
+        if (i >= symbols.size()) return;
+        symbols[i].type = type;
+        symbols[i].reviewed = true; // user corrected it
+        symbols[i].needsReview = false;
+    }
+    void markReviewed(std::size_t i) {
+        if (i < symbols.size()) symbols[i].reviewed = true; // accept as detected
+    }
+    void moveSymbol(std::size_t i, const ecs::Vec3& pos) {
+        if (i < symbols.size()) symbols[i].position = pos;
+    }
+    void deleteSymbol(std::size_t i) {
+        if (i < symbols.size()) symbols.erase(symbols.begin() + static_cast<std::ptrdiff_t>(i));
+    }
+    void addSymbol(const std::string& type, const ecs::Vec3& pos) {
+        ReviewSymbol s;
+        s.type = type;
+        s.position = pos;
+        s.confidence = 1.0f;
+        s.needsReview = false;
+        s.reviewed = true; // user placed it deliberately
+        symbols.push_back(s);
+    }
+    void addWall(const Wall& w) { walls.push_back(w); }
+    void deleteWall(std::size_t i) {
+        if (i < walls.size()) walls.erase(walls.begin() + static_cast<std::ptrdiff_t>(i));
+    }
+
+    bool hasSymbolType(const std::string& type) const {
+        for (const ReviewSymbol& s : symbols) {
+            if (s.type == type) return true;
+        }
+        return false;
+    }
+
+    // --- Review / validation ("never fail silently") -----------------------
+
+    /// Every outstanding problem, so nothing is dropped without the user seeing it.
+    std::vector<LevelIssue> issues() const {
+        std::vector<LevelIssue> out;
+        for (std::size_t i = 0; i < symbols.size(); ++i) {
+            if (symbols[i].needsReview && !symbols[i].reviewed) {
+                out.push_back({IssueKind::LowConfidenceSymbol, static_cast<int>(i),
+                               "low-confidence symbol '" + symbols[i].type + "' needs review"});
+            }
+        }
+        if (walls.empty()) out.push_back({IssueKind::NoWalls, -1, "no walls detected"});
+        if (!hasSymbolType("player")) {
+            out.push_back({IssueKind::NoPlayerStart, -1, "no player start placed"});
+        }
+        if (!hasSymbolType("exit") && !hasSymbolType("door")) {
+            out.push_back({IssueKind::NoExit, -1, "no exit placed"});
+        }
+        return out;
+    }
+
+    /// True only when there are no outstanding issues to review.
+    bool readyToPlay() const { return issues().empty(); }
+
+    /// Number of symbols still awaiting review.
+    int pendingReviewCount() const {
+        int n = 0;
+        for (const ReviewSymbol& s : symbols) {
+            if (s.needsReview && !s.reviewed) ++n;
+        }
+        return n;
+    }
+
+    /// Produce the LevelSpec for the converter / game (call once reviewed).
+    LevelSpec toLevelSpec() const {
+        LevelSpec spec;
+        spec.wallHeight = wallHeight;
+        spec.wallThickness = wallThickness;
+        spec.walls = walls;
+        for (const ReviewSymbol& s : symbols) {
+            spec.symbols.push_back(Symbol{s.type, s.position, 0.0f});
+        }
+        return spec;
+    }
+};
+
+/**
+ * @brief Assemble an editable InterpretedLevel from the CV outputs.
+ *
+ * Wall polyline points and symbol centroids (in image pixels) are scaled by
+ * @p worldScale into world units. A symbol flagged low-confidence by the
+ * recognizer is marked needsReview so the user is prompted to confirm it.
+ */
+inline InterpretedLevel assembleLevel(const std::vector<cv::Polyline>& wallPolylines,
+                                      const std::vector<cv::SymbolInstance>& symbols,
+                                      float worldScale = 1.0f, float wallHeight = 3.0f,
+                                      float wallThickness = 0.2f) {
+    InterpretedLevel level;
+    level.wallHeight = wallHeight;
+    level.wallThickness = wallThickness;
+
+    for (const cv::Polyline& poly : wallPolylines) {
+        Wall w;
+        for (const cv::Point& p : poly) {
+            w.polyline.push_back(ecs::Vec3{p.x * worldScale, 0.0f, p.y * worldScale});
+        }
+        level.walls.push_back(std::move(w));
+    }
+    for (const cv::SymbolInstance& s : symbols) {
+        ReviewSymbol r;
+        r.type = s.result.object;
+        r.position = ecs::Vec3{s.cx * worldScale, 0.0f, s.cy * worldScale};
+        r.confidence = s.result.confidence;
+        r.needsReview = s.result.lowConfidence;
+        r.reviewed = false;
+        level.symbols.push_back(std::move(r));
+    }
+    return level;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_level_review.cpp
+++ b/tests/test_level_review.cpp
@@ -1,0 +1,155 @@
+// Test for the confidence + repair review model - Milestone 16, #170.
+//
+// Verifies the issue's acceptance criteria: users can review and correct the
+// interpretation before playing, and the system never fails silently on ambiguous
+// input (every problem is surfaced and gates play until resolved). Ends by handing
+// the reviewed level to the M15 converter + game for a playable scene.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_level_review.cpp -o test_level_review
+
+#include "cv/Symbols.h"
+#include "cv/Vectorize.h"
+#include "game/DoodleScene.h"
+#include "game/DungeonGame.h"
+#include "game/LevelReview.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static cv::SymbolInstance sym(float x, float y, const std::string& obj, float conf, bool low) {
+    cv::SymbolInstance s;
+    s.cx = x;
+    s.cy = y;
+    s.result.object = obj;
+    s.result.confidence = conf;
+    s.result.lowConfidence = low;
+    return s;
+}
+
+static std::vector<cv::Polyline> roomWalls() {
+    return {{{10, 10}, {50, 10}, {50, 50}, {10, 50}, {10, 10}}};
+}
+
+static bool hasIssue(const std::vector<LevelIssue>& issues, IssueKind kind) {
+    for (const LevelIssue& i : issues) {
+        if (i.kind == kind) return true;
+    }
+    return false;
+}
+
+static void testAssembleFlagsLowConfidence() {
+    const std::vector<cv::SymbolInstance> symbols = {
+        sym(15, 15, "player", 0.9f, false),
+        sym(45, 45, "exit", 0.85f, false),
+        sym(30, 30, "coin", 0.8f, false),
+        sym(20, 40, "coin", 0.2f, true), // ambiguous, defaulted -> needs review
+    };
+    InterpretedLevel level = assembleLevel(roomWalls(), symbols, 1.0f);
+
+    CHECK(level.symbols.size() == 4);
+    CHECK(level.walls.size() == 1);
+    CHECK(level.pendingReviewCount() == 1);
+    CHECK(level.symbols[0].position.x == 15.0f && level.symbols[0].position.z == 15.0f);
+
+    // The ambiguous mark is surfaced, not dropped, and blocks play.
+    const std::vector<LevelIssue> issues = level.issues();
+    CHECK(hasIssue(issues, IssueKind::LowConfidenceSymbol));
+    CHECK(!level.readyToPlay());
+
+    // User corrects the misread; it is now reviewed and no longer blocks.
+    level.setSymbolType(3, "enemy");
+    CHECK(level.pendingReviewCount() == 0);
+    CHECK(level.readyToPlay());
+    CHECK(level.symbols[3].type == "enemy");
+}
+
+static void testMissingStartAndExitAreReported() {
+    const std::vector<cv::SymbolInstance> symbols = {sym(30, 30, "coin", 0.8f, false)};
+    InterpretedLevel level = assembleLevel(roomWalls(), symbols, 1.0f);
+
+    std::vector<LevelIssue> issues = level.issues();
+    CHECK(hasIssue(issues, IssueKind::NoPlayerStart));
+    CHECK(hasIssue(issues, IssueKind::NoExit));
+    CHECK(!level.readyToPlay());
+
+    level.addSymbol("player", ecs::Vec3{15, 0, 15});
+    level.addSymbol("exit", ecs::Vec3{45, 0, 45});
+    CHECK(level.readyToPlay());
+}
+
+static void testEditsAndSilentFailureGuard() {
+    InterpretedLevel level = assembleLevel(
+        roomWalls(),
+        {sym(15, 15, "player", 0.9f, false), sym(45, 45, "exit", 0.9f, false),
+         sym(30, 30, "coin", 0.8f, false)},
+        1.0f);
+    CHECK(level.readyToPlay());
+
+    // Move / add / delete edits.
+    level.moveSymbol(2, ecs::Vec3{33, 0, 33});
+    CHECK(level.symbols[2].position.x == 33.0f);
+    level.addWall(Wall{{{60, 10, 0}, {60, 0, 50}}});
+    CHECK(level.walls.size() == 2);
+    level.deleteWall(1);
+    CHECK(level.walls.size() == 1);
+
+    // Deleting the player start is caught (never fails silently).
+    for (std::size_t i = 0; i < level.symbols.size(); ++i) {
+        if (level.symbols[i].type == "player") {
+            level.deleteSymbol(i);
+            break;
+        }
+    }
+    CHECK(!level.readyToPlay());
+    CHECK(hasIssue(level.issues(), IssueKind::NoPlayerStart));
+}
+
+static void testReviewedLevelIsPlayable() {
+    InterpretedLevel level = assembleLevel(
+        roomWalls(),
+        {sym(15, 15, "player", 0.9f, false), sym(45, 45, "exit", 0.85f, false),
+         sym(30, 30, "coin", 0.8f, false), sym(20, 40, "coin", 0.2f, true)},
+        1.0f);
+    level.setSymbolType(3, "enemy"); // resolve the ambiguous mark
+    CHECK(level.readyToPlay());
+
+    // Hand the reviewed level to the converter + game (the M15 pipeline).
+    const LevelSpec spec = level.toLevelSpec();
+    const SceneDescription scene = convert(spec);
+    CHECK(!scene.wallBoxes.empty());
+
+    const DungeonGame game = loadGame(scene);
+    CHECK(game.hasExit);
+    CHECK(game.totalCoins == 1);        // the one coin
+    CHECK(game.enemies.size() == 1);    // the corrected enemy
+    CHECK(game.playerPosition.x == 15.0f && game.playerPosition.z == 15.0f);
+}
+
+int main() {
+    testAssembleFlagsLowConfidence();
+    testMissingStartAndExitAreReported();
+    testEditsAndSilentFailureGuard();
+    testReviewedLevelIsPlayable();
+
+    if (g_failures == 0) {
+        std::printf("All level review tests passed.\n");
+        return 0;
+    }
+    std::printf("%d level review test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements Milestone 16 / #170: the review-and-repair step between the CV interpretation (walls #167, symbols #169) and play (#162/#164). The user reviews the detected level and fixes misreads, and the system never fails silently on ambiguous input. Closes #170.

New header `src/game/LevelReview.h` (namespace `IKore::game`) - the headless model behind that UI:

- **`assembleLevel`** turns detected wall polylines and symbols into an editable `InterpretedLevel`, scaling image pixels to world units; each symbol keeps its confidence and a `needsReview` flag (set when the recognizer was low-confidence).
- **Edit operations** let the user repair misreads: `setSymbolType` (correct a type), `markReviewed` (accept as detected), `moveSymbol`, `addSymbol`, `deleteSymbol`, `addWall`, `deleteWall`.
- **`issues()`** enumerates every outstanding problem - low-confidence symbols not yet reviewed, no player start, no exit, no walls - so nothing is dropped silently, and **`readyToPlay()`** gates play until they are all resolved. `pendingReviewCount()` reports how many symbols still await review.
- **`toLevelSpec()`** produces the `LevelSpec` for the M15 converter + game once reviewed.

Header-only; the renderer/ImGui layer draws editable icons over this model.

## Acceptance criteria

- [x] Users can review and correct the interpretation prior to playing (edit operations + `assembleLevel` from the CV outputs)
- [x] The system never fails silently on ambiguous input (`issues()` surfaces every low-confidence/missing-piece problem and `readyToPlay()` blocks until resolved)

## Testing

`tests/test_level_review.cpp` (wired as the `test_level_review` CMake target):

- A low-confidence mark is flagged, surfaced as an issue, and blocks play until the user corrects its type.
- A missing player start and exit are reported and clear once added.
- Move / add / delete edits on symbols and walls work, and deleting the player start is caught rather than failing silently.
- **End to end**: a reviewed level flows through `toLevelSpec` -> `convert` -> `loadGame` into a playable scene with the right player, exit, coin, and the corrected enemy.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_level_review.cpp -o test_level_review && ./test_level_review
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

Builds on #167 (walls), #169 (symbols), #162/#163 (`LevelSpec` / converter), and #164 (game). This completes the drawing-to-map CV milestone: a photo becomes a rectified image, then walls + rooms + symbols, then a reviewed, corrected, playable dungeon.