### PR TITLE
feat(doodle): portable renderer-agnostic converter library (#171)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,18 @@ add_executable(test_level_review
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_review.cpp
 )
 
+# Portable Doodle Dungeon converter library (Milestone 17 / #171). Header-only and
+# renderer-agnostic (no OpenGL, no glm), so it builds independently of the engine
+# renderer and can be consumed from a mobile app or any engine.
+add_library(doodle INTERFACE)
+target_include_directories(doodle INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# Isolated tests for the library, linking only the standalone `doodle` target.
+add_executable(test_doodle_library
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_doodle_library.cpp
+)
+target_link_libraries(test_doodle_library PRIVATE doodle)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/doodle/Doodle.h
+++ b/src/doodle/Doodle.h
@@ -1,0 +1,104 @@
+#pragma once
+
+// The full Doodle Dungeon drawing -> scene pipeline, as one portable header.
+#include "cv/Image.h"
+#include "cv/Rectify.h"
+#include "cv/Symbols.h"
+#include "cv/Topology.h"
+#include "cv/Vectorize.h"
+#include "game/DoodleScene.h"
+#include "game/DungeonGame.h"
+#include "game/LevelFormat.h"
+#include "game/LevelReview.h"
+#include "game/TourCamera.h"
+
+#include <string>
+#include <vector>
+
+/**
+ * @file Doodle.h
+ * @brief Portable, renderer-agnostic Doodle Dungeon converter library (issue #171).
+ *
+ * Milestone 17. A single public header that packages the drawing -> scene pipeline
+ * (Milestones 15-16) as a standalone library usable from a mobile app or any
+ * engine. Every piece is header-only and depends only on the C++ standard library
+ * and the engine's glm-free value types - no renderer, no OpenGL, no glm - so it
+ * builds independently of the desktop renderer and is covered by isolated tests.
+ *
+ * The facade in @c IKore::doodle wires the stages into a few calls:
+ *   interpretPhoto : camera image  -> reviewable InterpretedLevel
+ *   buildScene     : level         -> renderer-agnostic SceneDescription
+ *   saveLevel/loadLevel            -> level JSON round-trip
+ * The host reviews/repairs the InterpretedLevel (never fails silently), then draws
+ * the SceneDescription (mesh + boxes + spawns) with its own renderer, or drives
+ * the headless DungeonGame / TourCamera directly.
+ */
+namespace IKore {
+namespace doodle {
+
+// --- Public type aliases (the library's surface) ---------------------------
+using Vec3 = ecs::Vec3;
+using Image = cv::Image;
+using Polyline = cv::Polyline;
+using SymbolInstance = cv::SymbolInstance;
+using Topology = cv::Topology;
+
+using Wall = game::Wall;
+using Symbol = game::Symbol;
+using LevelSpec = game::LevelSpec;
+using SceneDescription = game::SceneDescription;
+using Mesh = game::Mesh;
+using EntitySpawn = game::EntitySpawn;
+using InterpretedLevel = game::InterpretedLevel;
+using LevelIssue = game::LevelIssue;
+using DungeonGame = game::DungeonGame;
+using TourController = game::TourController;
+
+using game::convert;
+using game::loadGame;
+
+/// Options for the whole pipeline (bundles the per-stage options).
+struct Options {
+    bool rectifyFirst{true};       ///< false if the image is already top-down.
+    int rectifiedSize{256};        ///< output size of the rectify step.
+    cv::VectorizeOptions vectorize{};
+    cv::SymbolOptions symbols{};
+    float worldScale{1.0f};        ///< world units per image pixel.
+    float wallHeight{3.0f};
+    float wallThickness{0.2f};
+};
+
+/**
+ * @brief Interpret a camera image into a reviewable level: rectify (optional),
+ *        vectorize walls, recognize symbols, and assemble an editable level.
+ */
+inline InterpretedLevel interpretPhoto(const Image& photo, const Options& opt = {}) {
+    const Image top = opt.rectifyFirst ? cv::rectify(photo, opt.rectifiedSize) : photo;
+    const std::vector<Polyline> walls = cv::vectorizeWalls(top, opt.vectorize);
+    const std::vector<SymbolInstance> symbols = cv::detectSymbols(top, opt.symbols);
+    return game::assembleLevel(walls, symbols, opt.worldScale, opt.wallHeight, opt.wallThickness);
+}
+
+/// Build the renderer-agnostic 3D scene (mesh + boxes + spawns) from a level.
+inline SceneDescription buildScene(const LevelSpec& spec) { return game::convert(spec); }
+
+/// Build the scene directly from a reviewed InterpretedLevel.
+inline SceneDescription buildScene(const InterpretedLevel& level) {
+    return game::convert(level.toLevelSpec());
+}
+
+/// Analyze room/doorway topology from a level's walls.
+inline Topology analyzeTopology(const std::vector<Polyline>& walls, float gridSize = 10.0f) {
+    return cv::buildTopology(walls, gridSize);
+}
+
+/// Serialize a level to the doodle-level JSON format.
+inline std::string saveLevel(const LevelSpec& spec) { return game::toLevelJson(spec); }
+
+/// Parse a level from the doodle-level JSON format.
+inline bool loadLevel(const std::string& text, LevelSpec& out) {
+    return game::fromLevelJson(text, out);
+}
+
+} // namespace doodle
+} // namespace IKore

--- a/tests/test_doodle_library.cpp
+++ b/tests/test_doodle_library.cpp
@@ -1,0 +1,133 @@
+// Test for the portable Doodle converter library - Milestone 17, #171.
+//
+// Verifies the issue's acceptance criteria: the library builds independently of
+// the desktop renderer (this file includes ONLY the public umbrella header and
+// links only the header-only `doodle` target - no renderer, no glm, no OpenGL),
+// and it is covered by isolated unit tests exercising the public facade end to end.
+//
+//   g++ -std=c++17 -I src tests/test_doodle_library.cpp -o test_doodle_library
+
+#include "doodle/Doodle.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static void putRGB(doodle::Image& im, int x, int y, int R, int G, int B) {
+    if (!im.inBounds(x, y)) return;
+    im.set(x, y, 0, static_cast<std::uint8_t>(R));
+    im.set(x, y, 1, static_cast<std::uint8_t>(G));
+    im.set(x, y, 2, static_cast<std::uint8_t>(B));
+}
+
+static doodle::Image whiteImage(int w, int h) {
+    doodle::Image im(w, h, 3);
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) putRGB(im, x, y, 250, 250, 250);
+    }
+    return im;
+}
+
+// Draw a thick dark rectangle outline (walls) into a top-down image.
+static void drawRoom(doodle::Image& im, int x0, int y0, int x1, int y1) {
+    for (int t = -1; t <= 1; ++t) {
+        for (int x = x0; x <= x1; ++x) {
+            putRGB(im, x, y0 + t, 20, 20, 20);
+            putRGB(im, x, y1 + t, 20, 20, 20);
+        }
+        for (int y = y0; y <= y1; ++y) {
+            putRGB(im, x0 + t, y, 20, 20, 20);
+            putRGB(im, x1 + t, y, 20, 20, 20);
+        }
+    }
+}
+
+static void testSceneAndJsonFacade() {
+    doodle::LevelSpec spec;
+    spec.walls.push_back(doodle::Wall{{{10, 0, 10}, {40, 0, 10}, {40, 0, 40}, {10, 0, 40}, {10, 0, 10}}});
+    spec.symbols.push_back(doodle::Symbol{"player", doodle::Vec3{15, 0, 15}, 0.0f});
+    spec.symbols.push_back(doodle::Symbol{"exit", doodle::Vec3{35, 0, 35}, 0.0f});
+
+    const doodle::SceneDescription scene = doodle::buildScene(spec);
+    CHECK(!scene.wallBoxes.empty());        // walls extruded to geometry
+    CHECK(!scene.wallMesh.vertices.empty());
+    CHECK(scene.spawns.size() == 2);
+
+    // JSON round-trips through the library facade.
+    const std::string json = doodle::saveLevel(spec);
+    doodle::LevelSpec reloaded;
+    CHECK(doodle::loadLevel(json, reloaded));
+    CHECK(reloaded.walls.size() == spec.walls.size());
+    CHECK(reloaded.symbols.size() == spec.symbols.size());
+    CHECK(doodle::buildScene(reloaded).spawns.size() == 2);
+}
+
+static void testInterpretPhotoWalls() {
+    doodle::Image top = whiteImage(90, 90);
+    drawRoom(top, 20, 20, 70, 70);
+
+    doodle::Options opt;
+    opt.rectifyFirst = false; // already a top-down drawing
+    const doodle::InterpretedLevel level = doodle::interpretPhoto(top, opt);
+    CHECK(!level.walls.empty()); // the room outline was vectorized into walls
+}
+
+static void testInterpretPhotoSymbol() {
+    doodle::Image top = whiteImage(60, 60);
+    for (int y = 23; y <= 37; ++y) {
+        for (int x = 23; x <= 37; ++x) {
+            if ((x - 30) * (x - 30) + (y - 30) * (y - 30) <= 49) putRGB(top, x, y, 30, 180, 30);
+        }
+    }
+    doodle::Options opt;
+    opt.rectifyFirst = false;
+    const doodle::InterpretedLevel level = doodle::interpretPhoto(top, opt);
+    CHECK(level.hasSymbolType("player")); // the green mark became a player start
+}
+
+static void testEndToEndPlayable() {
+    doodle::Image top = whiteImage(90, 90);
+    drawRoom(top, 20, 20, 70, 70);
+
+    doodle::Options opt;
+    opt.rectifyFirst = false;
+    doodle::InterpretedLevel level = doodle::interpretPhoto(top, opt);
+
+    // The host reviews and places the required objects.
+    level.addSymbol("player", doodle::Vec3{30, 0, 30});
+    level.addSymbol("exit", doodle::Vec3{60, 0, 60});
+    level.addSymbol("coin", doodle::Vec3{45, 0, 45});
+    CHECK(level.readyToPlay());
+
+    const doodle::SceneDescription scene = doodle::buildScene(level);
+    const doodle::DungeonGame game = doodle::loadGame(scene);
+    CHECK(game.hasExit);
+    CHECK(game.totalCoins == 1);
+    CHECK(game.playerPosition.x == 30.0f && game.playerPosition.z == 30.0f);
+}
+
+int main() {
+    testSceneAndJsonFacade();
+    testInterpretPhotoWalls();
+    testInterpretPhotoSymbol();
+    testEndToEndPlayable();
+
+    if (g_failures == 0) {
+        std::printf("All doodle library tests passed.\n");
+        return 0;
+    }
+    std::printf("%d doodle library test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Starts Milestone 17 (Mobile & UGC) by factoring the drawing -> scene pipeline (Milestones 15-16) into a standalone, renderer-agnostic C++ library usable from a mobile app or any engine. Closes #171.

- **`src/doodle/Doodle.h`** - one public umbrella header that pulls together the CV stages (rectify, vectorize, topology, symbols) and the game/scene stages (LevelSpec, converter, level JSON, review, DungeonGame, TourCamera) and exposes a small facade in `namespace IKore::doodle`:
  - `interpretPhoto` : camera `Image` -> reviewable `InterpretedLevel` (rectify -> vectorize walls -> recognize symbols -> assemble)
  - `buildScene` : level -> renderer-agnostic `SceneDescription`
  - `analyzeTopology` : walls -> rooms / doorways / connectivity
  - `saveLevel` / `loadLevel` : doodle-level JSON round-trip

  It re-exports the public types (`Image`, `LevelSpec`, `SceneDescription`, `Mesh`, `InterpretedLevel`, `DungeonGame`, ...) so consumers need not reach into internal namespaces.

- **CMake** - a standalone `INTERFACE` library target `doodle` (header-only, include-only) that carries no renderer, glm, or OpenGL dependency, so it builds independently of the desktop engine. The whole `cv/`, `game/`, and `core/ecs/` subset it spans is pure std plus the engine's glm-free value types (verified: the only "glm"/"OpenGL" mentions are in comments).

## Acceptance criteria

- [x] The library builds independently of the desktop renderer (a header-only `INTERFACE` target with no renderer/glm/OpenGL dependency; the test links only `doodle`)
- [x] It is covered by isolated unit tests (the test includes only the public umbrella header and exercises the facade end to end)

## Testing

`tests/test_doodle_library.cpp` (wired as the `test_doodle_library` CMake target, linking only the standalone `doodle` library, including only `doodle/Doodle.h`):

- Building a scene from a `LevelSpec` and round-tripping the level through JSON.
- Interpreting a top-down drawing into walls.
- Recognizing a colored mark as a player start.
- **End to end**: interpret a room, review/place the required objects, then build a scene and load it into a playable `DungeonGame` (correct exit, coin, and player position).

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_doodle_library.cpp -o test_doodle_library && ./test_doodle_library
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

Packages the M15/M16 cores behind a single header + `INTERFACE` target. A mobile app or another engine can consume the whole drawing-to-playable-map pipeline without adopting the IKore renderer or ECS beyond the glm-free value types.