### PR TITLE
feat(game): UGC catalog with share codes, feed, and stars (#174)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,6 +600,11 @@ add_executable(test_glyph_net
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_glyph_net.cpp
 )
 
+# UGC catalog: share codes, feed, stars (Milestone 17 / #174) - header-only.
+add_executable(test_level_catalog
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_catalog.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/game/LevelCatalog.h
+++ b/src/game/LevelCatalog.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @file LevelCatalog.h
+ * @brief UGC: share codes, a browsable feed, and stars (issue #174).
+ *
+ * Milestone 17 (Mobile & UGC). The headless service core behind user-generated
+ * content: publish a map and get a short share code, look a map up by code to
+ * play it, award stars, and browse the feed by New / Top / Hot. A backend hosts
+ * this in production; the logic is pure data so it is unit-testable off-device.
+ *
+ * The level payload is opaque to the catalog (the doodle-level JSON produced by
+ * the converter library), so publishing and fetching stays decoupled from the
+ * game: a fetched entry's JSON loads straight back into a playable level.
+ *
+ * Timestamps are caller-supplied (no wall clock here) so ordering is
+ * deterministic. Header-only, std only.
+ */
+namespace IKore {
+namespace game {
+
+struct LevelEntry {
+    std::string code;
+    std::string author;
+    std::string title;
+    std::string levelJson; ///< opaque payload (the doodle-level JSON).
+    std::int64_t publishedAt{0};
+    int stars{0};
+    int plays{0};
+};
+
+class LevelCatalog {
+public:
+    /// Publish a map; returns its unique share code.
+    std::string publish(const std::string& author, const std::string& title,
+                        const std::string& levelJson, std::int64_t publishedAt) {
+        LevelEntry e;
+        e.code = makeCode(m_entries.size());
+        e.author = author;
+        e.title = title;
+        e.levelJson = levelJson;
+        e.publishedAt = publishedAt;
+        m_index[e.code] = m_entries.size();
+        m_entries.push_back(std::move(e));
+        return m_entries.back().code;
+    }
+
+    /// Look up a map by its share code (nullptr if unknown).
+    const LevelEntry* getByCode(const std::string& code) const {
+        auto it = m_index.find(code);
+        return it == m_index.end() ? nullptr : &m_entries[it->second];
+    }
+
+    /// Award a star to a map. Returns false for an unknown code.
+    bool star(const std::string& code) {
+        auto it = m_index.find(code);
+        if (it == m_index.end()) return false;
+        ++m_entries[it->second].stars;
+        return true;
+    }
+
+    /// Record that a map was played. Returns false for an unknown code.
+    bool recordPlay(const std::string& code) {
+        auto it = m_index.find(code);
+        if (it == m_index.end()) return false;
+        ++m_entries[it->second].plays;
+        return true;
+    }
+
+    std::size_t size() const { return m_entries.size(); }
+
+    /// Feed sorted newest first.
+    std::vector<LevelEntry> browseNew(std::size_t limit = 50) const {
+        return sorted(limit, [](const LevelEntry& a, const LevelEntry& b) {
+            if (a.publishedAt != b.publishedAt) return a.publishedAt > b.publishedAt;
+            return a.code > b.code;
+        });
+    }
+
+    /// Feed sorted by most stars (newest breaks ties).
+    std::vector<LevelEntry> browseTop(std::size_t limit = 50) const {
+        return sorted(limit, [](const LevelEntry& a, const LevelEntry& b) {
+            if (a.stars != b.stars) return a.stars > b.stars;
+            return a.publishedAt > b.publishedAt;
+        });
+    }
+
+    /// Feed sorted by a recency-weighted popularity score relative to @p now.
+    std::vector<LevelEntry> browseHot(std::int64_t now, std::size_t limit = 50) const {
+        const auto score = [now](const LevelEntry& e) {
+            const double age = static_cast<double>(now - e.publishedAt);
+            return (e.stars + 1.0) / (std::max(0.0, age) + 2.0);
+        };
+        return sorted(limit, [&score](const LevelEntry& a, const LevelEntry& b) {
+            const double sa = score(a), sb = score(b);
+            if (sa != sb) return sa > sb;
+            return a.publishedAt > b.publishedAt;
+        });
+    }
+
+    /// The rotating weekly drawing prompt for a given week index.
+    static std::string weeklyPrompt(int weekIndex) {
+        static const std::vector<std::string> prompts = {
+            "Draw a castle keep", "Draw a twisting maze", "Draw a haunted manor",
+            "Draw a treasure vault", "Draw a monster lair", "Draw an island fort",
+        };
+        const int n = static_cast<int>(prompts.size());
+        int i = weekIndex % n;
+        if (i < 0) i += n;
+        return prompts[static_cast<std::size_t>(i)];
+    }
+
+private:
+    static std::string makeCode(std::size_t id) {
+        static const char* kDigits = "0123456789abcdefghijklmnopqrstuvwxyz";
+        std::uint64_t v = static_cast<std::uint64_t>(id);
+        std::string s;
+        do {
+            s += kDigits[v % 36];
+            v /= 36;
+        } while (v > 0);
+        while (s.size() < 6) s += '0';
+        std::reverse(s.begin(), s.end());
+        return "DD-" + s;
+    }
+
+    template <class Less>
+    std::vector<LevelEntry> sorted(std::size_t limit, Less less) const {
+        std::vector<LevelEntry> out = m_entries;
+        std::sort(out.begin(), out.end(), less);
+        if (out.size() > limit) out.resize(limit);
+        return out;
+    }
+
+    std::vector<LevelEntry> m_entries;
+    std::unordered_map<std::string, std::size_t> m_index;
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_level_catalog.cpp
+++ b/tests/test_level_catalog.cpp
@@ -1,0 +1,125 @@
+// Test for UGC share codes / feed / stars - Milestone 17, #174.
+//
+// Verifies the issue's acceptance criteria: a user can publish a map and others
+// can find (by share code) and play it, and stars plus a browsable feed
+// (New / Top / Hot) work end to end. The level payload is the doodle-level JSON,
+// so a fetched entry loads straight back into a playable game.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_level_catalog.cpp -o test_level_catalog
+
+#include "doodle/Doodle.h"
+#include "game/LevelCatalog.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static std::string makeLevelJson() {
+    doodle::LevelSpec s;
+    s.walls.push_back(doodle::Wall{{{10, 0, 10}, {40, 0, 10}, {40, 0, 40}, {10, 0, 40}, {10, 0, 10}}});
+    s.symbols.push_back(doodle::Symbol{"player", doodle::Vec3{15, 0, 15}, 0.0f});
+    s.symbols.push_back(doodle::Symbol{"exit", doodle::Vec3{35, 0, 35}, 0.0f});
+    s.symbols.push_back(doodle::Symbol{"coin", doodle::Vec3{25, 0, 25}, 0.0f});
+    return doodle::saveLevel(s);
+}
+
+static void testPublishFindAndPlay() {
+    LevelCatalog catalog;
+    const std::string codeA = catalog.publish("alice", "Castle", makeLevelJson(), 100);
+    const std::string codeB = catalog.publish("bob", "Cave", makeLevelJson(), 200);
+
+    CHECK(catalog.size() == 2);
+    CHECK(codeA != codeB);                 // unique share codes
+    CHECK(catalog.getByCode("DD-zzzzzz") == nullptr); // unknown code
+
+    const LevelEntry* e = catalog.getByCode(codeA);
+    CHECK(e != nullptr);
+    CHECK(e->author == "alice" && e->title == "Castle");
+
+    // Another user fetches by code and plays the exact map.
+    doodle::LevelSpec loaded;
+    CHECK(doodle::loadLevel(e->levelJson, loaded));
+    const doodle::DungeonGame game = doodle::loadGame(doodle::buildScene(loaded));
+    CHECK(game.hasExit);
+    CHECK(game.totalCoins == 1);
+    CHECK(game.playerPosition.x == 15.0f && game.playerPosition.z == 15.0f);
+}
+
+static void testStarsAndTopFeed() {
+    LevelCatalog catalog;
+    const std::string codeA = catalog.publish("alice", "Castle", makeLevelJson(), 100);
+    const std::string codeB = catalog.publish("bob", "Cave", makeLevelJson(), 200);
+
+    CHECK(catalog.star(codeA));
+    CHECK(catalog.star(codeA));
+    CHECK(catalog.star(codeA));
+    CHECK(catalog.star(codeB));
+    CHECK(!catalog.star("DD-nope")); // unknown code
+
+    CHECK(catalog.getByCode(codeA)->stars == 3);
+
+    const std::vector<LevelEntry> top = catalog.browseTop();
+    CHECK(top.size() == 2);
+    CHECK(top[0].code == codeA); // most stars first
+    CHECK(top[1].code == codeB);
+}
+
+static void testNewAndHotFeeds() {
+    LevelCatalog catalog;
+    const std::string codeA = catalog.publish("alice", "Castle", makeLevelJson(), 100);
+    const std::string codeB = catalog.publish("bob", "Cave", makeLevelJson(), 200);
+
+    // New: most recently published first.
+    const std::vector<LevelEntry> fresh = catalog.browseNew();
+    CHECK(fresh[0].code == codeB);
+    CHECK(fresh[1].code == codeA);
+
+    // Hot with light stars: the newer map wins.
+    catalog.star(codeA);
+    catalog.star(codeB);
+    CHECK(catalog.browseHot(250)[0].code == codeB);
+
+    // Hot rewards popularity: many stars lift the older map above the newer one.
+    for (int i = 0; i < 50; ++i) catalog.star(codeA);
+    CHECK(catalog.browseHot(250)[0].code == codeA);
+}
+
+static void testRecordPlayAndWeeklyPrompt() {
+    LevelCatalog catalog;
+    const std::string code = catalog.publish("alice", "Castle", makeLevelJson(), 100);
+    CHECK(catalog.recordPlay(code));
+    CHECK(!catalog.recordPlay("DD-nope"));
+    CHECK(catalog.getByCode(code)->plays == 1);
+
+    // Weekly prompts rotate and wrap.
+    CHECK(!LevelCatalog::weeklyPrompt(0).empty());
+    CHECK(LevelCatalog::weeklyPrompt(0) != LevelCatalog::weeklyPrompt(1));
+    CHECK(LevelCatalog::weeklyPrompt(0) == LevelCatalog::weeklyPrompt(6)); // 6 prompts, wraps
+}
+
+int main() {
+    testPublishFindAndPlay();
+    testStarsAndTopFeed();
+    testNewAndHotFeeds();
+    testRecordPlayAndWeeklyPrompt();
+
+    if (g_failures == 0) {
+        std::printf("All level catalog (UGC) tests passed.\n");
+        return 0;
+    }
+    std::printf("%d level catalog test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements Milestone 17 / #174 (and completes the milestone): user-generated content - share codes, a browsable feed (New / Top / Hot), stars, and weekly drawing prompts. Closes #174.

New header `src/game/LevelCatalog.h` (namespace `IKore::game`) - the headless service core:

- **`publish(author, title, levelJson, time)`** stores a map and returns a short unique share code; **`getByCode`** looks a map up so others can find and play it.
- **`star`** / **`recordPlay`** update popularity; **`browseNew`**, **`browseTop`**, and **`browseHot`** return the feed sorted by recency, stars, and a recency-weighted popularity score. **`weeklyPrompt`** rotates the weekly drawing prompt.

The level payload is opaque to the catalog (the doodle-level JSON from the converter library), so publishing and fetching stay decoupled from the game, and a fetched entry loads straight back into a playable level. Timestamps are caller-supplied so ordering is deterministic. Pure std, header-only; a backend hosts this in production.

## Acceptance criteria

- [x] A user can publish a map and others can find and play it (publish returns a share code; `getByCode` fetches the JSON, which loads + builds + runs as a playable game)
- [x] Stars and a browsable feed work end-to-end (stars raise a map in Top and Hot; New / Top / Hot feeds sort correctly)

## Testing

`tests/test_level_catalog.cpp` (wired as the `test_level_catalog` CMake target):

- Publish two maps, confirm unique codes, fetch one by code and load -> build -> play it into a valid game (find and play).
- Stars raise a map in the Top feed; the New feed is newest-first.
- The Hot feed favors the newer map with light stars, but a heavily-starred older map overtakes it.
- Play counts increment; weekly prompts rotate and wrap.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_level_catalog.cpp -o test_level_catalog && ./test_level_catalog
```

All tests pass clean under the address and undefined-behavior sanitizers.

## Notes

The payload is the doodle-level JSON from the #171 library, so a published map round-trips into a playable dungeon. This closes out the Doodle Dungeon Mobile & UGC milestone: portable library, mobile shell, on-device symbol ML, and now sharing/browsing.