### PR TITLE
feat(ui): FPS and performance stats overlay (#53)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,6 +605,11 @@ add_executable(test_level_catalog
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_catalog.cpp
 )
 
+# Performance-overlay stats core (Milestone 9 / #53) - header-only.
+add_executable(test_perf_stats
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_perf_stats.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/PerfStats.h
+++ b/src/core/PerfStats.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <vector>
+
+#if defined(__linux__)
+#include <fstream>
+#include <unistd.h>
+#endif
+
+/**
+ * @file PerfStats.h
+ * @brief Rolling frame-time / FPS / memory stats for the perf overlay (issue #53).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless, renderer-agnostic core
+ * behind the ImGui performance overlay: record a frame time each frame and read
+ * back the instantaneous and averaged FPS / frame time, min/max, a rolling history
+ * for the graph, and resident memory. The ImGui panel in DebugUI draws these
+ * values; keeping the aggregation here lets it be unit-tested without a GL context.
+ *
+ * record() is a cheap deque push (no allocation once warmed, no I/O), so it costs
+ * nothing measurable when the overlay is hidden. Memory is only sampled on
+ * refreshMemory(), which the overlay calls while visible.
+ *
+ * Header-only, std only (plus /proc on Linux for RSS).
+ */
+namespace IKore {
+
+class PerfStats {
+public:
+    explicit PerfStats(std::size_t historyCapacity = 120)
+        : m_capacity(historyCapacity == 0 ? 1 : historyCapacity) {}
+
+    /// Record one frame's duration (seconds).
+    void record(double frameSeconds) {
+        const float ms = static_cast<float>(frameSeconds * 1000.0);
+        m_history.push_back(ms);
+        while (m_history.size() > m_capacity) m_history.pop_front();
+        m_last = ms;
+        ++m_count;
+    }
+
+    float lastFrameMs() const { return m_last; }
+    double fps() const { return m_last > 0.0f ? 1000.0 / m_last : 0.0; }
+
+    float avgFrameMs() const {
+        if (m_history.empty()) return 0.0f;
+        float sum = 0.0f;
+        for (float v : m_history) sum += v;
+        return sum / static_cast<float>(m_history.size());
+    }
+    double avgFps() const {
+        const float a = avgFrameMs();
+        return a > 0.0f ? 1000.0 / a : 0.0;
+    }
+
+    float minFrameMs() const {
+        if (m_history.empty()) return 0.0f;
+        float m = m_history.front();
+        for (float v : m_history) {
+            if (v < m) m = v;
+        }
+        return m;
+    }
+    float maxFrameMs() const {
+        if (m_history.empty()) return 0.0f;
+        float m = m_history.front();
+        for (float v : m_history) {
+            if (v > m) m = v;
+        }
+        return m;
+    }
+
+    std::size_t frameCount() const { return m_count; }
+    std::size_t historySize() const { return m_history.size(); }
+    std::size_t capacity() const { return m_capacity; }
+
+    /// Rolling frame-time history (ms), oldest first - contiguous for a graph.
+    std::vector<float> historyMs() const { return std::vector<float>(m_history.begin(), m_history.end()); }
+
+    void reset() {
+        m_history.clear();
+        m_last = 0.0f;
+        m_count = 0;
+        m_memoryBytes = 0;
+    }
+
+    /// Last sampled resident set size in bytes (0 if never sampled / unsupported).
+    long memoryBytes() const { return m_memoryBytes; }
+    /// Sample resident memory now (called by the overlay while visible).
+    void refreshMemory() { m_memoryBytes = residentBytes(); }
+
+    /// Current process resident set size in bytes (0 where unsupported).
+    static long residentBytes() {
+#if defined(__linux__)
+        std::ifstream statm("/proc/self/statm");
+        long totalPages = 0, residentPages = 0;
+        if (statm >> totalPages >> residentPages) {
+            return residentPages * sysconf(_SC_PAGESIZE);
+        }
+        return 0;
+#else
+        return 0;
+#endif
+    }
+
+private:
+    std::deque<float> m_history;
+    std::size_t m_capacity;
+    float m_last{0.0f};
+    std::size_t m_count{0};
+    long m_memoryBytes{0};
+};
+
+} // namespace IKore

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -946,7 +946,9 @@ int main() {
         // Render Entity Debug Overlay (after all scene rendering)
         IKore::getEntityDebugSystem().renderDebugOverlay();
 
-        // Render the Dear ImGui debug overlay on top (no-op while hidden)
+        // Record frame timing for the perf overlay, then draw the Dear ImGui
+        // debug overlay on top (both cheap / no-op while hidden).
+        debugUI.update(static_cast<float>(deltaTime));
         debugUI.render(static_cast<float>(deltaTime));
 
         glfwSwapBuffers(window);

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -6,6 +6,8 @@
 
 #include "core/Logger.h"
 
+#include <vector>
+
 namespace IKore {
 
 bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
@@ -46,6 +48,12 @@ void DebugUI::shutdown() {
     m_initialized = false;
 }
 
+void DebugUI::update(float deltaTimeSeconds) {
+    // Cheap frame-time recording; runs even while the overlay is hidden so the
+    // graph is populated when it is opened.
+    m_perf.record(deltaTimeSeconds);
+}
+
 void DebugUI::render(float deltaTimeSeconds) {
     // Hidden or uninitialized overlay costs nothing.
     if (!m_initialized || !m_visible) return;
@@ -82,12 +90,40 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::TextDisabled("Docking is enabled: drag a window onto another to dock it.");
 
     ImGui::Separator();
+    ImGui::Checkbox("Show performance overlay (#53)", &m_showPerf);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
+
+    renderPerfOverlay();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
     }
+}
+
+void DebugUI::renderPerfOverlay() {
+    if (!m_showPerf) return;
+
+    m_perf.refreshMemory(); // sampled only while the overlay is on screen
+
+    ImGui::Begin("Performance", &m_showPerf);
+    ImGui::Text("FPS: %.1f  (avg %.1f)", m_perf.fps(), m_perf.avgFps());
+    ImGui::Text("Frame: %.3f ms  (avg %.3f, min %.3f, max %.3f)", static_cast<double>(m_perf.lastFrameMs()),
+                static_cast<double>(m_perf.avgFrameMs()), static_cast<double>(m_perf.minFrameMs()),
+                static_cast<double>(m_perf.maxFrameMs()));
+
+    const std::vector<float> history = m_perf.historyMs();
+    if (!history.empty()) {
+        const float scaleMax = m_perf.maxFrameMs() * 1.25f + 1.0f;
+        ImGui::PlotLines("Frame ms", history.data(), static_cast<int>(history.size()), 0, nullptr, 0.0f,
+                         scaleMax, ImVec2(0.0f, 60.0f));
+    }
+
+    const long memoryBytes = m_perf.memoryBytes();
+    if (memoryBytes > 0) {
+        ImGui::Text("Memory (RSS): %.1f MB", static_cast<double>(memoryBytes) / (1024.0 * 1024.0));
+    }
+    ImGui::End();
 }
 
 } // namespace IKore

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "core/PerfStats.h"
+
 struct GLFWwindow;
 
 /**
@@ -41,16 +43,28 @@ public:
      */
     void render(float deltaTimeSeconds);
 
+    /**
+     * @brief Record this frame's timing into the perf stats (issue #53).
+     *
+     * Called every frame regardless of visibility - a cheap deque push - so the
+     * FPS/frame-time graph has history the moment the overlay is opened, while a
+     * hidden overlay still costs nothing to draw.
+     */
+    void update(float deltaTimeSeconds);
+
     void setVisible(bool visible) { m_visible = visible; }
     bool isVisible() const { return m_visible; }
     void toggle() { m_visible = !m_visible; }
 
 private:
     void buildUI(float deltaTimeSeconds);
+    void renderPerfOverlay();
 
     bool m_initialized{false};
     bool m_visible{false};
     bool m_showDemoWindow{false};
+    bool m_showPerf{true};
+    PerfStats m_perf;
 };
 
 } // namespace IKore

--- a/tests/test_perf_stats.cpp
+++ b/tests/test_perf_stats.cpp
@@ -1,0 +1,96 @@
+// Test for the performance-overlay stats core - Milestone 9, #53.
+//
+// Verifies the headless aggregation behind the ImGui FPS/perf overlay: FPS and
+// frame time (instantaneous and averaged), min/max, the bounded rolling history
+// for the graph, and the resident-memory readout. The ImGui panel that draws
+// these lives in DebugUI and is exercised in the engine build.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_perf_stats.cpp -o test_perf_stats
+
+#include "core/PerfStats.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(double a, double b, double eps = 1e-2) { return std::fabs(a - b) <= eps; }
+
+static void testSteadyFrames() {
+    PerfStats p;
+    for (int i = 0; i < 100; ++i) p.record(1.0 / 60.0); // steady 60 FPS
+
+    CHECK(approx(p.lastFrameMs(), 1000.0 / 60.0));
+    CHECK(approx(p.fps(), 60.0, 0.1));
+    CHECK(approx(p.avgFrameMs(), 1000.0 / 60.0));
+    CHECK(approx(p.avgFps(), 60.0, 0.1));
+    CHECK(approx(p.minFrameMs(), p.maxFrameMs())); // all equal
+    CHECK(p.frameCount() == 100);
+}
+
+static void testVariedFramesMinMaxAvg() {
+    PerfStats p;
+    for (int i = 0; i < 10; ++i) {
+        p.record(1.0 / 60.0); // ~16.667 ms
+        p.record(1.0 / 30.0); // ~33.333 ms
+    }
+    CHECK(approx(p.minFrameMs(), 1000.0 / 60.0));
+    CHECK(approx(p.maxFrameMs(), 1000.0 / 30.0));
+    CHECK(approx(p.avgFrameMs(), (1000.0 / 60.0 + 1000.0 / 30.0) / 2.0, 0.05));
+}
+
+static void testHistoryIsBounded() {
+    PerfStats p(10); // small ring
+    for (int i = 0; i < 25; ++i) p.record(0.01);
+    CHECK(p.historySize() == 10);       // capped at capacity
+    CHECK(p.frameCount() == 25);        // total count keeps growing
+    const std::vector<float> hist = p.historyMs();
+    CHECK(hist.size() == 10);
+    CHECK(approx(hist.back(), 10.0));   // last recorded (0.01 s -> 10 ms)
+}
+
+static void testZeroFrameIsSafe() {
+    PerfStats p;
+    p.record(0.0);
+    CHECK(p.fps() == 0.0); // no division by zero
+    CHECK(p.lastFrameMs() == 0.0f);
+}
+
+static void testMemoryReadout() {
+    PerfStats p;
+    p.refreshMemory();
+    const long bytes = p.memoryBytes();
+#if defined(__linux__)
+    CHECK(bytes > 0); // this test process has a resident set
+#else
+    CHECK(bytes >= 0);
+#endif
+    CHECK(PerfStats::residentBytes() >= 0);
+}
+
+int main() {
+    testSteadyFrames();
+    testVariedFramesMinMaxAvg();
+    testHistoryIsBounded();
+    testZeroFrameIsSafe();
+    testMemoryReadout();
+
+    if (g_failures == 0) {
+        std::printf("All perf-stats tests passed.\n");
+        return 0;
+    }
+    std::printf("%d perf-stats test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements Milestone 9 / #53: an FPS and performance stats overlay, built on the Dear ImGui foundation (#144). Closes #53.

- **`src/core/PerfStats.h`** - the headless, renderer-agnostic stats core. `record()` pushes a frame time into a bounded rolling history (a cheap deque push, so it costs nothing measurable while the overlay is hidden) and exposes instantaneous and averaged FPS / frame time, min/max, the history for the graph, and resident memory (RSS via `/proc` on Linux, sampled only on `refreshMemory()`).
- **`src/ui/DebugUI`** - `DebugUI` now owns a `PerfStats`. `update()` records the frame each loop iteration (even while hidden, so the graph has history the moment it is opened), and a new **Performance** panel draws FPS, frame time (last / avg / min / max), a frame-time `PlotLines` graph, and memory, with a toggle. The panel docks into the layout from #144.
- **`src/main.cpp`** - calls `debugUI.update(deltaTime)` each frame before `render()`.

The stats aggregation is unit-tested headless; the ImGui panel that draws it is built in the engine target.

## Acceptance criteria

- [x] FPS, frame time, and the graph update every frame and match the engine's measured timing (`PerfStats` records the loop's `deltaTime`; the panel reads it back)
- [x] The overlay toggles on and off and adds no measurable cost when hidden (`render()` early-returns while hidden; `update()` is a cheap deque push; memory is only sampled while the panel is visible)

## Testing

`tests/test_perf_stats.cpp` (wired as the `test_perf_stats` CMake target) covers the headless core:

- Steady 60 FPS yields the expected FPS / frame time with equal min/max.
- Varied frames produce the expected min / max / average.
- The rolling history is bounded to its capacity while the total frame count keeps growing.
- A zero-length frame does not divide by zero.
- The resident-memory readout is positive on Linux.

Verified locally with:

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_perf_stats.cpp -o test_perf_stats && ./test_perf_stats
```

All tests pass clean under the address and undefined-behavior sanitizers. The `DebugUI` header was also syntax-checked standalone; the ImGui panel and the `main.cpp` hook compile in the engine (CodeQL) build.

## Notes

First of the Milestone 9 feature panels on top of the #144 ImGui framework. The `PerfStats` core is reused by the benchmarking panel (#62).