### PR TITLE
[M9] Add in-engine debug console (#54)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,6 +610,11 @@ add_executable(test_perf_stats
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_perf_stats.cpp
 )
 
+# In-engine debug console core (Milestone 9 / #54) - header-only.
+add_executable(test_debug_console
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_debug_console.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/DebugConsole.h
+++ b/src/core/DebugConsole.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+/**
+ * @file DebugConsole.h
+ * @brief In-engine debug console model: commands, history, autocomplete (issue #54).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless, renderer-agnostic core
+ * behind the ImGui debug console: register commands from engine systems, execute a
+ * typed line (tokenized, with quoted arguments) against them, keep a bounded
+ * scrollback, navigate input history, and tab-complete command names. Log lines
+ * can be mirrored in via print() (see the logging system, #63).
+ *
+ * The ImGui panel in DebugUI owns the text input and draws the scrollback; keeping
+ * the parsing/history/completion here makes it unit-testable without a GL context.
+ * Header-only, std only.
+ */
+namespace IKore {
+
+class DebugConsole {
+public:
+    /// A command handler: receives the parsed arguments, returns output text.
+    using Handler = std::function<std::string(const std::vector<std::string>&)>;
+
+    explicit DebugConsole(std::size_t scrollbackCapacity = 1000)
+        : m_capacity(scrollbackCapacity == 0 ? 1 : scrollbackCapacity) {
+        registerCommand("help", "list commands", [this](const std::vector<std::string>&) {
+            return helpText();
+        });
+        registerCommand("clear", "clear the console", [this](const std::vector<std::string>&) {
+            clear();
+            return std::string();
+        });
+    }
+
+    /// Register (or replace) a command.
+    void registerCommand(const std::string& name, const std::string& help, Handler handler) {
+        m_commands[name] = Command{help, std::move(handler)};
+    }
+
+    bool hasCommand(const std::string& name) const { return m_commands.count(name) > 0; }
+
+    std::vector<std::string> commandNames() const {
+        std::vector<std::string> names;
+        for (const auto& kv : m_commands) names.push_back(kv.first);
+        return names; // std::map iterates in sorted order
+    }
+
+    /**
+     * @brief Run a command line: echo it, dispatch to the command, append output,
+     *        and record it in history. Returns the command's output text.
+     */
+    std::string execute(const std::string& line) {
+        m_historyCursor = -1;
+        const std::string trimmed = trim(line);
+        if (trimmed.empty()) return std::string();
+
+        print("> " + trimmed);
+        m_history.push_back(trimmed);
+
+        const std::vector<std::string> tokens = tokenize(trimmed);
+        if (tokens.empty()) return std::string();
+        const std::string& name = tokens[0];
+        auto it = m_commands.find(name);
+        if (it == m_commands.end()) {
+            print("unknown command: " + name + " (type 'help')");
+            return std::string();
+        }
+        const std::vector<std::string> args(tokens.begin() + 1, tokens.end());
+        const std::string output = it->second.handler(args);
+        if (!output.empty()) print(output);
+        return output;
+    }
+
+    /// Append a raw line to the scrollback (e.g. a mirrored log line).
+    void print(const std::string& text) {
+        m_lines.push_back(text);
+        while (m_lines.size() > m_capacity) m_lines.pop_front();
+    }
+
+    void clear() { m_lines.clear(); }
+    const std::deque<std::string>& lines() const { return m_lines; }
+
+    /// Recall the previous (older) history entry; the oldest clamps.
+    std::string historyPrev() {
+        if (m_history.empty()) return std::string();
+        if (m_historyCursor == -1) {
+            m_historyCursor = static_cast<int>(m_history.size()) - 1;
+        } else if (m_historyCursor > 0) {
+            --m_historyCursor;
+        }
+        return m_history[static_cast<std::size_t>(m_historyCursor)];
+    }
+    /// Recall the next (newer) history entry; past the newest returns empty.
+    std::string historyNext() {
+        if (m_historyCursor == -1) return std::string();
+        if (m_historyCursor < static_cast<int>(m_history.size()) - 1) {
+            ++m_historyCursor;
+            return m_history[static_cast<std::size_t>(m_historyCursor)];
+        }
+        m_historyCursor = -1;
+        return std::string();
+    }
+
+    /// Command names beginning with @p prefix (sorted).
+    std::vector<std::string> matches(const std::string& prefix) const {
+        std::vector<std::string> out;
+        for (const auto& kv : m_commands) {
+            if (kv.first.compare(0, prefix.size(), prefix) == 0) out.push_back(kv.first);
+        }
+        return out;
+    }
+
+    /// Longest common completion for @p prefix (the full name if unique).
+    std::string complete(const std::string& prefix) const {
+        const std::vector<std::string> m = matches(prefix);
+        if (m.empty()) return prefix;
+        std::string common = m.front();
+        for (std::size_t i = 1; i < m.size(); ++i) {
+            std::size_t k = 0;
+            while (k < common.size() && k < m[i].size() && common[k] == m[i][k]) ++k;
+            common.resize(k);
+        }
+        return common.size() >= prefix.size() ? common : prefix;
+    }
+
+    /// Split a line into tokens, honoring double-quoted arguments.
+    static std::vector<std::string> tokenize(const std::string& s) {
+        std::vector<std::string> out;
+        std::string cur;
+        bool inQuote = false, hasToken = false;
+        for (char c : s) {
+            if (inQuote) {
+                if (c == '"') {
+                    inQuote = false;
+                    out.push_back(cur);
+                    cur.clear();
+                    hasToken = false;
+                } else {
+                    cur += c;
+                }
+            } else if (c == '"') {
+                inQuote = true;
+                hasToken = true;
+            } else if (std::isspace(static_cast<unsigned char>(c))) {
+                if (hasToken) {
+                    out.push_back(cur);
+                    cur.clear();
+                    hasToken = false;
+                }
+            } else {
+                cur += c;
+                hasToken = true;
+            }
+        }
+        if (hasToken) out.push_back(cur);
+        return out;
+    }
+
+private:
+    struct Command {
+        std::string help;
+        Handler handler;
+    };
+
+    static std::string trim(const std::string& s) {
+        const std::size_t a = s.find_first_not_of(" \t\r\n");
+        const std::size_t b = s.find_last_not_of(" \t\r\n");
+        return a == std::string::npos ? std::string() : s.substr(a, b - a + 1);
+    }
+
+    std::string helpText() const {
+        std::string out = "commands:";
+        for (const auto& kv : m_commands) out += "\n  " + kv.first + " - " + kv.second.help;
+        return out;
+    }
+
+    std::map<std::string, Command> m_commands;
+    std::deque<std::string> m_lines;
+    std::vector<std::string> m_history;
+    std::size_t m_capacity;
+    int m_historyCursor{-1};
+};
+
+} // namespace IKore

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -6,9 +6,16 @@
 
 #include "core/Logger.h"
 
+#include <string>
 #include <vector>
 
 namespace IKore {
+
+// File-static trampoline: ImGui's InputText callback dispatches here, then into
+// the DebugUI instance passed as user data.
+static int consoleTextEditStub(ImGuiInputTextCallbackData* data) {
+    return static_cast<DebugUI*>(data->UserData)->onConsoleTextEdit(data);
+}
 
 bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     if (m_initialized) return true;
@@ -34,6 +41,11 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
         ImGui::DestroyContext();
         return false;
     }
+
+    m_console.registerCommand("version", "print the engine name", [](const std::vector<std::string>&) {
+        return std::string("IKore Engine");
+    });
+    m_console.print("Console ready. Type 'help'.");
 
     m_initialized = true;
     LOG_INFO("DebugUI: Dear ImGui initialized (press F1 to toggle)");
@@ -91,14 +103,66 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
 
     ImGui::Separator();
     ImGui::Checkbox("Show performance overlay (#53)", &m_showPerf);
+    ImGui::Checkbox("Show console (#54)", &m_showConsole);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
     renderPerfOverlay();
+    renderConsole();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
     }
+}
+
+void DebugUI::renderConsole() {
+    if (!m_showConsole) return;
+
+    ImGui::Begin("Console", &m_showConsole);
+
+    // Scrollback region, leaving room for the input line at the bottom.
+    const float footerHeight = ImGui::GetStyle().ItemSpacing.y + ImGui::GetFrameHeightWithSpacing();
+    ImGui::BeginChild("console_scroll", ImVec2(0.0f, -footerHeight), true,
+                      ImGuiWindowFlags_HorizontalScrollbar);
+    for (const std::string& line : m_console.lines()) {
+        ImGui::TextUnformatted(line.c_str());
+    }
+    if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f); // autoscroll
+    ImGui::EndChild();
+
+    ImGui::Separator();
+    const ImGuiInputTextFlags flags = ImGuiInputTextFlags_EnterReturnsTrue |
+                                      ImGuiInputTextFlags_CallbackCompletion |
+                                      ImGuiInputTextFlags_CallbackHistory;
+    if (ImGui::InputText("Input", m_consoleInput, sizeof(m_consoleInput), flags, &consoleTextEditStub,
+                         this)) {
+        m_console.execute(m_consoleInput);
+        m_consoleInput[0] = '\0';
+        ImGui::SetKeyboardFocusHere(-1); // keep focus on the input
+    }
+    ImGui::End();
+}
+
+int DebugUI::onConsoleTextEdit(void* callbackData) {
+    ImGuiInputTextCallbackData* data = static_cast<ImGuiInputTextCallbackData*>(callbackData);
+    if (data->EventFlag == ImGuiInputTextFlags_CallbackCompletion) {
+        const std::string current(data->Buf, data->Buf + data->BufTextLen);
+        const std::string completed = m_console.complete(current);
+        if (completed.size() > current.size()) {
+            data->DeleteChars(0, data->BufTextLen);
+            data->InsertChars(0, completed.c_str());
+        }
+    } else if (data->EventFlag == ImGuiInputTextFlags_CallbackHistory) {
+        std::string recalled;
+        if (data->EventKey == ImGuiKey_UpArrow) {
+            recalled = m_console.historyPrev();
+        } else if (data->EventKey == ImGuiKey_DownArrow) {
+            recalled = m_console.historyNext();
+        }
+        data->DeleteChars(0, data->BufTextLen);
+        if (!recalled.empty()) data->InsertChars(0, recalled.c_str());
+    }
+    return 0;
 }
 
 void DebugUI::renderPerfOverlay() {

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/DebugConsole.h"
 #include "core/PerfStats.h"
 
 struct GLFWwindow;
@@ -56,15 +57,28 @@ public:
     bool isVisible() const { return m_visible; }
     void toggle() { m_visible = !m_visible; }
 
+    /// Access the debug console so engine systems can register commands.
+    DebugConsole& console() { return m_console; }
+
+    /// Handle an ImGui InputText callback for the console (history/completion).
+    /// Takes a void* (an ImGuiInputTextCallbackData*) to keep this header free of
+    /// the ImGui headers; the implementation casts it. Public so the file-static
+    /// callback trampoline in DebugUI.cpp can dispatch to it.
+    int onConsoleTextEdit(void* callbackData);
+
 private:
     void buildUI(float deltaTimeSeconds);
     void renderPerfOverlay();
+    void renderConsole();
 
     bool m_initialized{false};
     bool m_visible{false};
     bool m_showDemoWindow{false};
     bool m_showPerf{true};
+    bool m_showConsole{true};
     PerfStats m_perf;
+    DebugConsole m_console;
+    char m_consoleInput[256]{};
 };
 
 } // namespace IKore

--- a/tests/test_debug_console.cpp
+++ b/tests/test_debug_console.cpp
@@ -1,0 +1,117 @@
+// Test for the in-engine debug console core - Milestone 9, #54.
+//
+// Verifies the headless model behind the ImGui console: command registration and
+// execution (with quoted args), scrollback, input history navigation, and
+// tab-completion. The ImGui text input / panel lives in DebugUI (engine build).
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_debug_console.cpp -o test_debug_console
+
+#include "core/DebugConsole.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool contains(const std::deque<std::string>& lines, const std::string& text) {
+    for (const std::string& l : lines) {
+        if (l.find(text) != std::string::npos) return true;
+    }
+    return false;
+}
+
+static void testExecuteAndScrollback() {
+    DebugConsole c;
+    c.registerCommand("echo", "echo args", [](const std::vector<std::string>& a) {
+        std::string s;
+        for (std::size_t i = 0; i < a.size(); ++i) s += (i ? " " : "") + a[i];
+        return s;
+    });
+    c.registerCommand("add", "add two ints", [](const std::vector<std::string>& a) {
+        if (a.size() < 2) return std::string("usage: add A B");
+        return std::to_string(std::stoi(a[0]) + std::stoi(a[1]));
+    });
+
+    CHECK(c.execute("echo hello world") == "hello world");
+    CHECK(c.execute("add 2 3") == "5");
+    // Quoted arguments stay together.
+    CHECK(c.execute("echo \"one two\" three") == "one two three");
+
+    CHECK(contains(c.lines(), "> echo hello world")); // input is echoed
+    CHECK(contains(c.lines(), "hello world"));         // output recorded
+
+    // Unknown command reports rather than throwing.
+    c.execute("bogus");
+    CHECK(contains(c.lines(), "unknown command: bogus"));
+
+    // Built-ins exist.
+    CHECK(c.hasCommand("help"));
+    CHECK(c.hasCommand("clear"));
+}
+
+static void testHistoryNavigation() {
+    DebugConsole c;
+    c.registerCommand("a", "", [](const std::vector<std::string>&) { return std::string(); });
+    c.registerCommand("b", "", [](const std::vector<std::string>&) { return std::string(); });
+    c.execute("a");
+    c.execute("b");
+    c.execute("a b"); // history: a, b, "a b"
+
+    CHECK(c.historyPrev() == "a b");
+    CHECK(c.historyPrev() == "b");
+    CHECK(c.historyPrev() == "a");
+    CHECK(c.historyPrev() == "a"); // clamps at the oldest
+    CHECK(c.historyNext() == "b");
+    CHECK(c.historyNext() == "a b");
+    CHECK(c.historyNext().empty()); // past the newest -> a fresh empty line
+}
+
+static void testAutocomplete() {
+    DebugConsole c;
+    c.registerCommand("physics_step", "", [](const std::vector<std::string>&) { return std::string(); });
+    c.registerCommand("physics_pause", "", [](const std::vector<std::string>&) { return std::string(); });
+    c.registerCommand("render", "", [](const std::vector<std::string>&) { return std::string(); });
+
+    const std::vector<std::string> phys = c.matches("phys");
+    CHECK(phys.size() == 2);
+    CHECK(phys[0] == "physics_pause" && phys[1] == "physics_step"); // sorted
+    CHECK(c.complete("phys") == "physics_"); // longest common prefix extends the input
+    CHECK(c.complete("physics_s") == "physics_step"); // unique -> full name
+    CHECK(c.complete("r") == "render");      // unique among r*
+    CHECK(c.matches("zzz").empty());
+    CHECK(c.complete("zzz") == "zzz");       // no match -> unchanged
+}
+
+static void testClearAndMirroredLogs() {
+    DebugConsole c;
+    c.print("[info] engine started"); // a mirrored log line
+    CHECK(contains(c.lines(), "engine started"));
+    c.execute("clear");
+    CHECK(c.lines().empty()); // clear command empties the scrollback
+}
+
+int main() {
+    testExecuteAndScrollback();
+    testHistoryNavigation();
+    testAutocomplete();
+    testClearAndMirroredLogs();
+
+    if (g_failures == 0) {
+        std::printf("All debug console tests passed.\n");
+        return 0;
+    }
+    std::printf("%d debug console test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Adds an interactive in-engine debug console on top of the Dear ImGui foundation (#144), following the same split proven by the FPS/performance overlay (#53): a headless, unit-tested core plus a thin ImGui panel wired into `DebugUI`.

Closes #54

## Core: `src/core/DebugConsole.h` (header-only, std only)

- Register commands (name, help, handler) from any engine system.
- `execute()`: trims input, echoes `"> line"`, records history, tokenizes with double-quoted-argument support, dispatches to the command, and appends its output. Unknown commands report `unknown command: NAME (type 'help')` instead of throwing.
- Bounded scrollback via `print()` / `clear()` / `lines()`; external log lines can be mirrored in (ties into the logging system, #63).
- Input history navigation (`historyPrev` / `historyNext`) and command-name tab-completion (`matches` / `complete`, longest common prefix). Built-in `help` and `clear` commands are auto-registered.

## Panel: `src/ui/DebugUI`

- A "Console" window with a scrolling, autoscrolling backlog and an `InputText` bound to the core.
- Tab triggers completion; Up/Down walk the input history, both via an ImGui input-text callback.
- The header stays ImGui-free: the callback data is taken as `void*` and cast in the `.cpp`, dispatched through a file-static trampoline.
- A `version` demo command is registered at init, and a "Show console" checkbox toggles the panel.

## Testing

- `tests/test_debug_console.cpp` covers command execution and scrollback (including quoted args and unknown commands), history navigation, and autocomplete. Passes locally under ASan/UBSan (`All debug console tests passed.`).
- New CMake target `test_debug_console`.
- The ImGui panel itself is compiled by CI (CodeQL c-cpp build), consistent with the rest of the ImGui-dependent engine code.

## Notes

- No behavior change to existing panels; the console is additive and starts visible under the debug UI (F1).