### PR TITLE
[M9] Add reusable UI/HUD framework (#55)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,6 +615,11 @@ add_executable(test_debug_console
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_debug_console.cpp
 )
 
+# Reusable UI/HUD framework core (Milestone 9 / #55) - header-only.
+add_executable(test_hud_framework
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_hud_framework.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -6,6 +6,8 @@
 
 #include "core/Logger.h"
 
+#include <cmath>
+#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -47,6 +49,19 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     });
     m_console.print("Console ready. Type 'help'.");
 
+    // Demo HUD wired through the reusable framework (#55). Each widget is anchored
+    // and bound to a live getter; in a real game these would read ECS component
+    // values. update() animates the demo state so the readouts visibly change.
+    m_demoInventory = {"Sword", "Shield", "Potion x3", "Map"};
+    m_hud.add(hudBar("Health", HudAnchor::TopLeft, {16.0f, 16.0f}, {220.0f, 20.0f},
+                     [this] { return m_demoHealth; }));
+    m_hud.add(hudText("Score", HudAnchor::TopRight, {16.0f, 16.0f}, {200.0f, 24.0f},
+                      [this] { return std::string("Score: ") + std::to_string(m_demoScore); }));
+    m_hud.add(hudValue("Ammo", HudAnchor::BottomRight, {16.0f, 16.0f}, {140.0f, 24.0f},
+                       [this] { return m_demoAmmo; }));
+    m_hud.add(hudList("Inventory", HudAnchor::BottomLeft, {16.0f, 16.0f}, {180.0f, 130.0f},
+                      [this] { return m_demoInventory; }));
+
     m_initialized = true;
     LOG_INFO("DebugUI: Dear ImGui initialized (press F1 to toggle)");
     return true;
@@ -64,6 +79,13 @@ void DebugUI::update(float deltaTimeSeconds) {
     // Cheap frame-time recording; runs even while the overlay is hidden so the
     // graph is populated when it is opened.
     m_perf.record(deltaTimeSeconds);
+
+    // Animate the demo HUD state so the data-bound widgets visibly update. In a
+    // real game these values come from ECS/game systems instead.
+    m_hudClock += deltaTimeSeconds;
+    m_demoHealth = 0.5f + 0.5f * std::sin(m_hudClock);       // oscillate across 0..1
+    m_demoScore = static_cast<int>(m_hudClock * 100.0f);     // climbs over time
+    m_demoAmmo = 30 - static_cast<int>(m_hudClock) % 31;     // counts down 30..0, loops
 }
 
 void DebugUI::render(float deltaTimeSeconds) {
@@ -104,11 +126,14 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::Separator();
     ImGui::Checkbox("Show performance overlay (#53)", &m_showPerf);
     ImGui::Checkbox("Show console (#54)", &m_showConsole);
+    ImGui::Checkbox("Show HUD (#55)", &m_showHud);
+    ImGui::SliderFloat("HUD scale (#61)", &m_hudScale, 0.5f, 2.0f, "%.2f");
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
     renderPerfOverlay();
     renderConsole();
+    renderHud();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
@@ -141,6 +166,56 @@ void DebugUI::renderConsole() {
         ImGui::SetKeyboardFocusHere(-1); // keep focus on the input
     }
     ImGui::End();
+}
+
+void DebugUI::renderHud() {
+    if (!m_showHud) return;
+
+    const ImGuiIO& io = ImGui::GetIO();
+    m_hud.setScreenSize(io.DisplaySize.x, io.DisplaySize.y); // resolution aware (#55)
+    m_hud.setScale(m_hudScale);                              // scale aware (#61)
+
+    // Borderless, click-through overlays so the HUD never obstructs gameplay input.
+    const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
+                                   ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing |
+                                   ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove;
+
+    int index = 0;
+    for (const HudElement& e : m_hud.elements()) {
+        if (!e.visible) continue;
+
+        const HudVec2 pos = m_hud.positionOf(e);
+        ImGui::SetNextWindowPos(ImVec2(pos.x, pos.y));
+        ImGui::SetNextWindowSize(ImVec2(e.size.x * m_hud.scale(), e.size.y * m_hud.scale()));
+        ImGui::SetNextWindowBgAlpha(0.35f);
+
+        char windowId[32];
+        std::snprintf(windowId, sizeof(windowId), "##hud_%d", index++);
+        if (ImGui::Begin(windowId, nullptr, flags)) {
+            switch (e.widget) {
+                case HudWidget::Text:
+                    ImGui::TextUnformatted(e.text().c_str());
+                    break;
+                case HudWidget::Value:
+                    ImGui::Text("%s: %d", e.name.c_str(), e.value());
+                    break;
+                case HudWidget::Bar: {
+                    char label[48];
+                    std::snprintf(label, sizeof(label), "%s %.0f%%", e.name.c_str(),
+                                  static_cast<double>(e.bar()) * 100.0);
+                    ImGui::ProgressBar(e.bar(), ImVec2(-1.0f, 0.0f), label);
+                    break;
+                }
+                case HudWidget::List:
+                    ImGui::TextUnformatted((e.name + ":").c_str());
+                    for (const std::string& item : e.list()) {
+                        ImGui::BulletText("%s", item.c_str());
+                    }
+                    break;
+            }
+        }
+        ImGui::End();
+    }
 }
 
 int DebugUI::onConsoleTextEdit(void* callbackData) {

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -2,6 +2,10 @@
 
 #include "core/DebugConsole.h"
 #include "core/PerfStats.h"
+#include "ui/HudFramework.h"
+
+#include <string>
+#include <vector>
 
 struct GLFWwindow;
 
@@ -60,6 +64,10 @@ public:
     /// Access the debug console so engine systems can register commands.
     DebugConsole& console() { return m_console; }
 
+    /// Access the in-game HUD so engine systems can add anchored, data-bound
+    /// widgets (issue #55). Menu screens (#58) reuse the same framework.
+    Hud& hud() { return m_hud; }
+
     /// Handle an ImGui InputText callback for the console (history/completion).
     /// Takes a void* (an ImGuiInputTextCallbackData*) to keep this header free of
     /// the ImGui headers; the implementation casts it. Public so the file-static
@@ -70,15 +78,27 @@ private:
     void buildUI(float deltaTimeSeconds);
     void renderPerfOverlay();
     void renderConsole();
+    void renderHud();
 
     bool m_initialized{false};
     bool m_visible{false};
     bool m_showDemoWindow{false};
     bool m_showPerf{true};
     bool m_showConsole{true};
+    bool m_showHud{true};
+    float m_hudScale{1.0f};
     PerfStats m_perf;
     DebugConsole m_console;
+    Hud m_hud;
     char m_consoleInput[256]{};
+
+    // Demo state bound into the HUD so the overlay visibly updates from "live"
+    // values, standing in for real ECS/game state. Animated in update().
+    float m_demoHealth{1.0f};
+    int m_demoAmmo{30};
+    int m_demoScore{0};
+    std::vector<std::string> m_demoInventory;
+    float m_hudClock{0.0f};
 };
 
 } // namespace IKore

--- a/src/ui/HudFramework.h
+++ b/src/ui/HudFramework.h
@@ -1,0 +1,266 @@
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * @file HudFramework.h
+ * @brief Reusable in-game UI/HUD framework: anchoring + live data binding (issue #55).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless, renderer-agnostic core
+ * behind the in-game HUD and menu screens (#58): a set of HUD elements, each
+ * anchored to a screen corner/edge/center with a pixel offset, bound to a live
+ * value source (a getter) so it reflects ECS/game state without any per-frame
+ * copying. Layout is resolution aware and scale aware, so the same HUD lays out
+ * correctly at any framebuffer size and honors the UI scaling work (#61).
+ *
+ * The ImGui panel in DebugUI walks elements() and draws each one at positionOf();
+ * keeping the anchoring math and the bindings here makes them unit-testable
+ * without a GL context. Header-only, std only (no ImGui, no glm, no ECS types).
+ */
+namespace IKore {
+
+/// Where an element is anchored within the screen rectangle (origin top-left).
+enum class HudAnchor {
+    TopLeft,
+    TopCenter,
+    TopRight,
+    MiddleLeft,
+    Center,
+    MiddleRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight
+};
+
+/// Which kind of readout an element draws.
+enum class HudWidget {
+    Text,  ///< a text label / string readout (e.g. a score line)
+    Value, ///< an integer readout (e.g. an ammo count)
+    Bar,   ///< a normalized 0..1 bar (e.g. a health fraction)
+    List   ///< a list of strings (e.g. an inventory)
+};
+
+struct HudVec2 {
+    float x{0.0f};
+    float y{0.0f};
+};
+
+inline const char* hudAnchorName(HudAnchor anchor) {
+    switch (anchor) {
+        case HudAnchor::TopLeft: return "TopLeft";
+        case HudAnchor::TopCenter: return "TopCenter";
+        case HudAnchor::TopRight: return "TopRight";
+        case HudAnchor::MiddleLeft: return "MiddleLeft";
+        case HudAnchor::Center: return "Center";
+        case HudAnchor::MiddleRight: return "MiddleRight";
+        case HudAnchor::BottomLeft: return "BottomLeft";
+        case HudAnchor::BottomCenter: return "BottomCenter";
+        case HudAnchor::BottomRight: return "BottomRight";
+    }
+    return "Unknown";
+}
+
+/**
+ * @brief Resolve the top-left pixel position of an anchored element.
+ * @param anchor       Which screen corner/edge/center to anchor to.
+ * @param screen       Screen (framebuffer) size in pixels.
+ * @param elementSize  Element size in pixels (used for center/right/bottom anchors).
+ * @param offset       Margin, in pixels, from the anchored edge (edge anchors) or a
+ *                     shift from center (center anchors). Positive values push inward.
+ * @return The element's top-left position in pixels.
+ *
+ * Pure layout math (no scale here; callers pre-scale size and offset). For edge
+ * anchors the offset is a margin from that edge, so a right/bottom offset moves the
+ * element inward, keeping HUD margins symmetric regardless of resolution.
+ */
+inline HudVec2 resolveAnchor(HudAnchor anchor, HudVec2 screen, HudVec2 elementSize, HudVec2 offset) {
+    float px = 0.0f;
+    switch (anchor) {
+        case HudAnchor::TopLeft:
+        case HudAnchor::MiddleLeft:
+        case HudAnchor::BottomLeft:
+            px = offset.x;
+            break;
+        case HudAnchor::TopCenter:
+        case HudAnchor::Center:
+        case HudAnchor::BottomCenter:
+            px = (screen.x - elementSize.x) * 0.5f + offset.x;
+            break;
+        case HudAnchor::TopRight:
+        case HudAnchor::MiddleRight:
+        case HudAnchor::BottomRight:
+            px = screen.x - elementSize.x - offset.x;
+            break;
+    }
+
+    float py = 0.0f;
+    switch (anchor) {
+        case HudAnchor::TopLeft:
+        case HudAnchor::TopCenter:
+        case HudAnchor::TopRight:
+            py = offset.y;
+            break;
+        case HudAnchor::MiddleLeft:
+        case HudAnchor::Center:
+        case HudAnchor::MiddleRight:
+            py = (screen.y - elementSize.y) * 0.5f + offset.y;
+            break;
+        case HudAnchor::BottomLeft:
+        case HudAnchor::BottomCenter:
+        case HudAnchor::BottomRight:
+            py = screen.y - elementSize.y - offset.y;
+            break;
+    }
+
+    return {px, py};
+}
+
+/**
+ * @brief A single HUD element: an anchored, live-bound widget.
+ *
+ * Only the data source matching @ref widget is consulted; the accessors return
+ * safe defaults when a source is unbound. Bind a source to a getter that reads
+ * live game/ECS state (see the hud* helper builders) so the readout updates every
+ * frame without the HUD owning or copying that state.
+ *
+ * A plain aggregate (public members, no user constructors) so callers can also
+ * build one field by field.
+ */
+struct HudElement {
+    std::string name;
+    HudAnchor anchor{HudAnchor::TopLeft};
+    HudVec2 offset{};        ///< pixels from the anchor, pre-scale
+    HudVec2 size{};          ///< element size in pixels, pre-scale
+    HudWidget widget{HudWidget::Text};
+    bool visible{true};
+
+    std::function<std::string()> textSource;
+    std::function<int()> valueSource;
+    std::function<float()> barSource;
+    std::function<std::vector<std::string>()> listSource;
+
+    /// Current string readout (empty if unbound).
+    std::string text() const { return textSource ? textSource() : std::string(); }
+
+    /// Current integer readout (0 if unbound).
+    int value() const { return valueSource ? valueSource() : 0; }
+
+    /// Current bar fraction, clamped to [0, 1] (0 if unbound).
+    float bar() const {
+        float v = barSource ? barSource() : 0.0f;
+        if (v < 0.0f) v = 0.0f;
+        if (v > 1.0f) v = 1.0f;
+        return v;
+    }
+
+    /// Current list contents (empty if unbound).
+    std::vector<std::string> list() const {
+        return listSource ? listSource() : std::vector<std::string>();
+    }
+};
+
+/// Build a text readout element bound to @p source.
+inline HudElement hudText(std::string name, HudAnchor anchor, HudVec2 offset, HudVec2 size,
+                          std::function<std::string()> source) {
+    HudElement e;
+    e.name = std::move(name);
+    e.anchor = anchor;
+    e.offset = offset;
+    e.size = size;
+    e.widget = HudWidget::Text;
+    e.textSource = std::move(source);
+    return e;
+}
+
+/// Build an integer readout element bound to @p source.
+inline HudElement hudValue(std::string name, HudAnchor anchor, HudVec2 offset, HudVec2 size,
+                           std::function<int()> source) {
+    HudElement e;
+    e.name = std::move(name);
+    e.anchor = anchor;
+    e.offset = offset;
+    e.size = size;
+    e.widget = HudWidget::Value;
+    e.valueSource = std::move(source);
+    return e;
+}
+
+/// Build a normalized (0..1) bar element bound to @p source.
+inline HudElement hudBar(std::string name, HudAnchor anchor, HudVec2 offset, HudVec2 size,
+                         std::function<float()> source) {
+    HudElement e;
+    e.name = std::move(name);
+    e.anchor = anchor;
+    e.offset = offset;
+    e.size = size;
+    e.widget = HudWidget::Bar;
+    e.barSource = std::move(source);
+    return e;
+}
+
+/// Build a string-list element (e.g. an inventory) bound to @p source.
+inline HudElement hudList(std::string name, HudAnchor anchor, HudVec2 offset, HudVec2 size,
+                          std::function<std::vector<std::string>()> source) {
+    HudElement e;
+    e.name = std::move(name);
+    e.anchor = anchor;
+    e.offset = offset;
+    e.size = size;
+    e.widget = HudWidget::List;
+    e.listSource = std::move(source);
+    return e;
+}
+
+/**
+ * @brief A collection of HUD elements laid out against a screen size and scale.
+ *
+ * The renderer sets the current screen (framebuffer) size and UI scale each frame,
+ * then walks elements() and draws each at positionOf(). Menu screens reuse the
+ * same container rather than hand-positioning per screen.
+ */
+class Hud {
+public:
+    void setScreenSize(float width, float height) {
+        m_screen.x = width;
+        m_screen.y = height;
+    }
+    HudVec2 screenSize() const { return m_screen; }
+
+    /// Set the UI scale factor (#61). Non-positive values are ignored.
+    void setScale(float scale) {
+        if (scale > 0.0f) m_scale = scale;
+    }
+    float scale() const { return m_scale; }
+
+    /// Append an element and return a reference to it. Elements are held in a deque
+    /// so this reference stays valid as more elements are added, letting callers keep
+    /// handles to bind or toggle later.
+    HudElement& add(HudElement element) {
+        m_elements.push_back(std::move(element));
+        return m_elements.back();
+    }
+
+    void clear() { m_elements.clear(); }
+    std::size_t count() const { return m_elements.size(); }
+    const std::deque<HudElement>& elements() const { return m_elements; }
+    std::deque<HudElement>& elements() { return m_elements; }
+
+    /// Top-left pixel position of @p element for the current screen size and scale.
+    HudVec2 positionOf(const HudElement& element) const {
+        const HudVec2 scaledSize{element.size.x * m_scale, element.size.y * m_scale};
+        const HudVec2 scaledOffset{element.offset.x * m_scale, element.offset.y * m_scale};
+        return resolveAnchor(element.anchor, m_screen, scaledSize, scaledOffset);
+    }
+
+private:
+    HudVec2 m_screen{1280.0f, 720.0f};
+    float m_scale{1.0f};
+    std::deque<HudElement> m_elements;
+};
+
+} // namespace IKore

--- a/tests/test_hud_framework.cpp
+++ b/tests/test_hud_framework.cpp
@@ -1,0 +1,179 @@
+// Test for the reusable UI/HUD framework core - Milestone 9, #55.
+//
+// Verifies the headless model behind the in-game HUD / menu screens: anchor
+// resolution (all nine anchors), resolution + scale aware layout, and live data
+// binding to game/ECS-style state. The ImGui panel that draws the elements lives
+// in DebugUI (engine build).
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_hud_framework.cpp -o test_hud_framework
+
+#include "ui/HudFramework.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b) { return std::fabs(a - b) < 1e-3f; }
+
+static bool posEq(HudVec2 p, float x, float y) { return approx(p.x, x) && approx(p.y, y); }
+
+static void testAnchorResolution() {
+    const HudVec2 screen{1000.0f, 600.0f};
+    const HudVec2 size{100.0f, 40.0f};
+    const HudVec2 off{10.0f, 20.0f};
+
+    // Horizontal: left -> margin, center -> centered + shift, right -> margin from right.
+    // Vertical:   top  -> margin, middle -> centered + shift, bottom -> margin from bottom.
+    CHECK(posEq(resolveAnchor(HudAnchor::TopLeft, screen, size, off), 10.0f, 20.0f));
+    CHECK(posEq(resolveAnchor(HudAnchor::TopCenter, screen, size, off), 460.0f, 20.0f));
+    CHECK(posEq(resolveAnchor(HudAnchor::TopRight, screen, size, off), 890.0f, 20.0f));
+    CHECK(posEq(resolveAnchor(HudAnchor::MiddleLeft, screen, size, off), 10.0f, 300.0f));
+    CHECK(posEq(resolveAnchor(HudAnchor::Center, screen, size, off), 460.0f, 300.0f));
+    CHECK(posEq(resolveAnchor(HudAnchor::MiddleRight, screen, size, off), 890.0f, 300.0f));
+    CHECK(posEq(resolveAnchor(HudAnchor::BottomLeft, screen, size, off), 10.0f, 540.0f));
+    CHECK(posEq(resolveAnchor(HudAnchor::BottomCenter, screen, size, off), 460.0f, 540.0f));
+    CHECK(posEq(resolveAnchor(HudAnchor::BottomRight, screen, size, off), 890.0f, 540.0f));
+}
+
+static void testResolutionAwareness() {
+    // The same right/bottom anchored element stays a fixed margin from the edge as
+    // the resolution changes - the hallmark of resolution-aware layout.
+    const HudVec2 size{80.0f, 30.0f};
+    const HudVec2 off{16.0f, 16.0f};
+    const HudVec2 small = resolveAnchor(HudAnchor::BottomRight, {800.0f, 600.0f}, size, off);
+    const HudVec2 big = resolveAnchor(HudAnchor::BottomRight, {1920.0f, 1080.0f}, size, off);
+    CHECK(approx(800.0f - small.x - size.x, 16.0f));   // margin from right edge preserved
+    CHECK(approx(1920.0f - big.x - size.x, 16.0f));
+    CHECK(approx(600.0f - small.y - size.y, 16.0f));   // margin from bottom edge preserved
+    CHECK(approx(1080.0f - big.y - size.y, 16.0f));
+}
+
+static void testScaleAffectsLayout() {
+    Hud hud;
+    hud.setScreenSize(1000.0f, 600.0f);
+    hud.setScale(2.0f);
+    CHECK(approx(hud.scale(), 2.0f));
+
+    HudElement& top = hud.add(hudText("tl", HudAnchor::TopLeft, {10.0f, 20.0f}, {100.0f, 40.0f},
+                                      [] { return std::string("x"); }));
+    HudElement& corner = hud.add(hudValue("br", HudAnchor::BottomRight, {10.0f, 20.0f}, {100.0f, 40.0f},
+                                          [] { return 0; }));
+    HudElement& mid = hud.add(hudText("c", HudAnchor::Center, {0.0f, 0.0f}, {100.0f, 40.0f},
+                                      [] { return std::string("x"); }));
+
+    // Offsets scale: top-left margin doubles from (10,20) to (20,40).
+    CHECK(posEq(hud.positionOf(top), 20.0f, 40.0f));
+    // Size and offset scale: 100x40 -> 200x80, offset 10/20 -> 20/40.
+    CHECK(posEq(hud.positionOf(corner), 1000.0f - 200.0f - 20.0f, 600.0f - 80.0f - 40.0f));
+    // Centering uses the scaled size: (1000-200)/2, (600-80)/2.
+    CHECK(posEq(hud.positionOf(mid), 400.0f, 260.0f));
+
+    // Non-positive scale is ignored (stays 2.0).
+    hud.setScale(0.0f);
+    CHECK(approx(hud.scale(), 2.0f));
+    hud.setScale(-1.0f);
+    CHECK(approx(hud.scale(), 2.0f));
+}
+
+// A stand-in for live ECS/game state the HUD binds to.
+struct PlayerState {
+    int health{100};
+    int maxHealth{100};
+    int ammo{30};
+    int score{0};
+    std::vector<std::string> inventory;
+};
+
+static void testLiveBinding() {
+    PlayerState player;
+    player.inventory = {"Sword", "Shield"};
+
+    Hud hud;
+    hud.setScreenSize(1920.0f, 1080.0f);
+
+    HudElement& health = hud.add(hudBar("Health", HudAnchor::TopLeft, {16.0f, 16.0f}, {220.0f, 22.0f},
+                                        [&player] {
+                                            return static_cast<float>(player.health) /
+                                                   static_cast<float>(player.maxHealth);
+                                        }));
+    HudElement& ammo = hud.add(hudValue("Ammo", HudAnchor::BottomRight, {16.0f, 16.0f}, {120.0f, 26.0f},
+                                        [&player] { return player.ammo; }));
+    HudElement& score = hud.add(hudText("Score", HudAnchor::TopRight, {16.0f, 16.0f}, {180.0f, 26.0f},
+                                        [&player] { return "Score: " + std::to_string(player.score); }));
+    HudElement& inv = hud.add(hudList("Inventory", HudAnchor::BottomLeft, {16.0f, 16.0f}, {180.0f, 120.0f},
+                                      [&player] { return player.inventory; }));
+
+    CHECK(hud.count() == 4);
+
+    // Initial reads reflect the bound state.
+    CHECK(approx(health.bar(), 1.0f));
+    CHECK(ammo.value() == 30);
+    CHECK(score.text() == "Score: 0");
+    CHECK(inv.list().size() == 2);
+
+    // Mutating the game state is reflected live on the next read - no re-binding.
+    player.health = 45;
+    player.ammo = 12;
+    player.score = 1500;
+    player.inventory.push_back("Potion");
+    CHECK(approx(health.bar(), 0.45f));
+    CHECK(ammo.value() == 12);
+    CHECK(score.text() == "Score: 1500");
+    CHECK(inv.list().size() == 3 && inv.list().back() == "Potion");
+
+    // The bar clamps to [0, 1] even when the raw ratio goes out of range.
+    player.health = 130; // overheal
+    CHECK(approx(health.bar(), 1.0f));
+    player.health = -20; // dead / negative
+    CHECK(approx(health.bar(), 0.0f));
+}
+
+static void testDefaultsAndVisibility() {
+    HudElement blank; // no sources bound
+    CHECK(blank.text().empty());
+    CHECK(blank.value() == 0);
+    CHECK(approx(blank.bar(), 0.0f));
+    CHECK(blank.list().empty());
+    CHECK(blank.visible);                       // visible by default
+    CHECK(blank.anchor == HudAnchor::TopLeft);  // sensible default anchor
+
+    Hud hud;
+    CHECK(hud.count() == 0);
+    hud.add(hudText("a", HudAnchor::Center, {}, {10.0f, 10.0f}, [] { return std::string("hi"); }));
+    CHECK(hud.count() == 1);
+    hud.clear();
+    CHECK(hud.count() == 0);
+
+    // Anchor names are stable for panel labels / debugging.
+    CHECK(std::string(hudAnchorName(HudAnchor::BottomRight)) == "BottomRight");
+    CHECK(std::string(hudAnchorName(HudAnchor::Center)) == "Center");
+}
+
+int main() {
+    testAnchorResolution();
+    testResolutionAwareness();
+    testScaleAffectsLayout();
+    testLiveBinding();
+    testDefaultsAndVisibility();
+
+    if (g_failures == 0) {
+        std::printf("All HUD framework tests passed.\n");
+        return 0;
+    }
+    std::printf("%d HUD framework test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Adds a reusable in-game UI/HUD layer on top of the Dear ImGui foundation (#144), following the same split proven by the FPS overlay (#53) and debug console (#54): a headless, unit-tested core plus a thin ImGui panel wired into `DebugUI`. This is the framework the menu screens (#58) reuse rather than laying out each screen by hand.

Closes #55

## Core: `src/ui/HudFramework.h` (header-only, std only)

No ImGui, glm, or ECS types, so it unit-tests without a GL context.

- `HudElement`: an anchored, live-bound widget. Bind a getter (text, int, a 0..1 bar, or a string list) that reads live game/ECS state, so the readout reflects current values every frame with no copying into the HUD. Bar values clamp to `[0, 1]`; unbound sources return safe defaults. `hudText` / `hudValue` / `hudBar` / `hudList` helpers build the common cases.
- `resolveAnchor()`: pure layout math for all nine anchors (corners, edges, center). Edge offsets act as margins from that edge, so HUD margins stay symmetric across resolutions (resolution aware).
- `Hud`: holds elements in a `std::deque` (references stay valid as more are added, so callers can keep handles), tracks the screen size and a UI scale factor (#61), and resolves each element's top-left pixel position via `positionOf()` with size and offset scaled - so the same HUD lays out correctly at any framebuffer size and scale.

## Panel: `src/ui/DebugUI`

- `renderHud()` walks `elements()` and draws each as a borderless, click-through overlay (flagged `NoInputs`, so the HUD never obstructs gameplay input) at its anchored, scaled position: text/value readouts, a progress bar, and a bulleted list.
- A demo HUD (health bar, score, ammo count, inventory list) is bound to animated state to demonstrate live updates, with a "Show HUD" toggle and a HUD-scale slider that exercises the #61 tie-in.
- A `hud()` accessor lets engine systems register their own widgets.

## Testing

- `tests/test_hud_framework.cpp` covers anchor resolution (all nine anchors), resolution awareness (margins preserved as resolution changes), scale-aware layout, live data binding (values update on the next read; bar clamping when out of range), and defaults/visibility. Passes locally under ASan/UBSan (`All HUD framework tests passed.`).
- New CMake target `test_hud_framework`.
- The ImGui panel is compiled by CI (CodeQL c-cpp build), consistent with the rest of the ImGui-dependent engine code.

## Acceptance criteria

- HUD widgets render and update from live (ECS-style) data without obstructing gameplay: overlays are click-through and pull values through bound getters each frame. Verified for binding/clamping in the unit test; the overlay itself is CodeQL-built.
- Menu screens (#58) can reuse this framework via the same `Hud` / `HudElement` types instead of duplicating per-screen layout.

## Notes

- Additive: no behavior change to the existing perf/console panels; the HUD starts visible under the debug UI (F1) and can be toggled off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_