### PR TITLE
[M9] Add entity inspector panel (#56)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,11 @@ add_executable(test_hud_framework
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_hud_framework.cpp
 )
 
+# Entity inspector core + archetype-ECS reflection (Milestone 9 / #56) - header-only.
+add_executable(test_entity_inspector
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_entity_inspector.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -19,6 +19,43 @@ static int consoleTextEditStub(ImGuiInputTextCallbackData* data) {
     return static_cast<DebugUI*>(data->UserData)->onConsoleTextEdit(data);
 }
 
+// Draw one reflected property with the widget matching its type; an edit writes
+// straight back through the setter, so it applies live to the component (#56).
+static void drawProperty(const Property& prop) {
+    const char* label = prop.name.c_str();
+    switch (prop.type) {
+        case PropertyType::Bool: {
+            bool v = prop.getBool();
+            if (ImGui::Checkbox(label, &v)) prop.setBool(v);
+            break;
+        }
+        case PropertyType::Int: {
+            int v = prop.getInt();
+            if (ImGui::DragInt(label, &v, prop.speed, static_cast<int>(prop.minValue),
+                               static_cast<int>(prop.maxValue)))
+                prop.setInt(v);
+            break;
+        }
+        case PropertyType::Float: {
+            float v = prop.getFloat();
+            if (ImGui::DragFloat(label, &v, prop.speed, prop.minValue, prop.maxValue)) prop.setFloat(v);
+            break;
+        }
+        case PropertyType::Float3: {
+            const Vec3f v = prop.getVec3();
+            float a[3] = {v.x, v.y, v.z};
+            if (ImGui::DragFloat3(label, a, prop.speed)) prop.setVec3(Vec3f{a[0], a[1], a[2]});
+            break;
+        }
+        case PropertyType::String: {
+            char buf[128];
+            std::snprintf(buf, sizeof(buf), "%s", prop.getString().c_str());
+            if (ImGui::InputText(label, buf, sizeof(buf))) prop.setString(std::string(buf));
+            break;
+        }
+    }
+}
+
 bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     if (m_initialized) return true;
     if (window == nullptr) return false;
@@ -61,6 +98,31 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
                        [this] { return m_demoAmmo; }));
     m_hud.add(hudList("Inventory", HudAnchor::BottomLeft, {16.0f, 16.0f}, {180.0f, 130.0f},
                       [this] { return m_demoInventory; }));
+
+    // Demo ECS scene for the entity inspector (#56). A few archetype-ECS entities
+    // with different component sets; the inspector reflects and live-edits them.
+    {
+        ecs::Entity player = m_demoRegistry.create();
+        m_demoRegistry.add<ecs::Transform>(player,
+                                           ecs::Transform{{0.0f, 1.0f, 0.0f}, {}, {1.0f, 1.0f, 1.0f}});
+        m_demoRegistry.add<ecs::Velocity>(player, ecs::Velocity{{1.0f, 0.0f, 0.0f}, {}});
+        m_demoRegistry.add<ecs::RigidBody>(player,
+                                           ecs::RigidBody{{0.0f, -9.8f, 0.0f}, 1.0f, 0.05f, false});
+        m_demoEntities.push_back(player);
+
+        ecs::Entity enemy = m_demoRegistry.create();
+        m_demoRegistry.add<ecs::Transform>(enemy,
+                                           ecs::Transform{{5.0f, 0.0f, 2.0f}, {}, {1.0f, 1.0f, 1.0f}});
+        m_demoRegistry.add<ecs::AIAgent>(enemy, ecs::AIAgent{{0.0f, 0.0f, 0.0f}, 2.0f, 0.1f, true});
+        m_demoEntities.push_back(enemy);
+
+        ecs::Entity prop = m_demoRegistry.create();
+        m_demoRegistry.add<ecs::Transform>(prop,
+                                           ecs::Transform{{-3.0f, 0.0f, -1.0f}, {}, {2.0f, 2.0f, 2.0f}});
+        m_demoEntities.push_back(prop);
+    }
+    installEcsBuilder(m_inspector, m_demoRegistry);
+    if (!m_demoEntities.empty()) m_inspector.select(packEntity(m_demoEntities.front()));
 
     m_initialized = true;
     LOG_INFO("DebugUI: Dear ImGui initialized (press F1 to toggle)");
@@ -128,12 +190,14 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::Checkbox("Show console (#54)", &m_showConsole);
     ImGui::Checkbox("Show HUD (#55)", &m_showHud);
     ImGui::SliderFloat("HUD scale (#61)", &m_hudScale, 0.5f, 2.0f, "%.2f");
+    ImGui::Checkbox("Show entity inspector (#56)", &m_showInspector);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
     renderPerfOverlay();
     renderConsole();
     renderHud();
+    renderInspector();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
@@ -165,6 +229,48 @@ void DebugUI::renderConsole() {
         m_consoleInput[0] = '\0';
         ImGui::SetKeyboardFocusHere(-1); // keep focus on the input
     }
+    ImGui::End();
+}
+
+void DebugUI::renderInspector() {
+    if (!m_showInspector) return;
+
+    ImGui::Begin("Entity Inspector", &m_showInspector);
+
+    // Entity picker. Selection will also be driven by viewport picking (#57) and
+    // the scene hierarchy (#59) once those land, via inspector().select(id).
+    ImGui::TextUnformatted("Entities");
+    if (ImGui::BeginListBox("##entities", ImVec2(-1.0f, 90.0f))) {
+        for (const ecs::Entity entity : m_demoEntities) {
+            const EntityInspector::EntityId id = packEntity(entity);
+            const bool selected = m_inspector.hasSelection() && m_inspector.selected() == id;
+            char label[32];
+            std::snprintf(label, sizeof(label), "Entity %u", entity.index);
+            if (ImGui::Selectable(label, selected)) m_inspector.select(id);
+        }
+        ImGui::EndListBox();
+    }
+
+    ImGui::Separator();
+
+    if (!m_inspector.hasSelection() || m_inspector.components().empty()) {
+        ImGui::TextDisabled("No entity selected, or it has no components.");
+        ImGui::End();
+        return;
+    }
+
+    // Cached component views: iterated every frame with no rebuild/allocation.
+    int componentIndex = 0;
+    for (const ComponentView& view : m_inspector.components()) {
+        ImGui::PushID(componentIndex++);
+        if (ImGui::CollapsingHeader(view.name.c_str(), ImGuiTreeNodeFlags_DefaultOpen)) {
+            for (const Property& prop : view.properties) {
+                drawProperty(prop);
+            }
+        }
+        ImGui::PopID();
+    }
+
     ImGui::End();
 }
 

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -2,6 +2,10 @@
 
 #include "core/DebugConsole.h"
 #include "core/PerfStats.h"
+#include "core/ecs/ECS.h"
+#include "core/ecs/components/Components.h"
+#include "ui/EcsInspector.h"
+#include "ui/EntityInspector.h"
 #include "ui/HudFramework.h"
 
 #include <string>
@@ -68,6 +72,10 @@ public:
     /// widgets (issue #55). Menu screens (#58) reuse the same framework.
     Hud& hud() { return m_hud; }
 
+    /// Access the entity inspector (issue #56) so viewport picking (#57) or the
+    /// scene hierarchy (#59) can drive selection via inspector().select(id).
+    EntityInspector& inspector() { return m_inspector; }
+
     /// Handle an ImGui InputText callback for the console (history/completion).
     /// Takes a void* (an ImGuiInputTextCallbackData*) to keep this header free of
     /// the ImGui headers; the implementation casts it. Public so the file-static
@@ -79,6 +87,7 @@ private:
     void renderPerfOverlay();
     void renderConsole();
     void renderHud();
+    void renderInspector();
 
     bool m_initialized{false};
     bool m_visible{false};
@@ -86,6 +95,7 @@ private:
     bool m_showPerf{true};
     bool m_showConsole{true};
     bool m_showHud{true};
+    bool m_showInspector{true};
     float m_hudScale{1.0f};
     PerfStats m_perf;
     DebugConsole m_console;
@@ -99,6 +109,13 @@ private:
     int m_demoScore{0};
     std::vector<std::string> m_demoInventory;
     float m_hudClock{0.0f};
+
+    // Demo ECS scene the entity inspector (#56) reflects. In the full engine the
+    // inspector points at the real registry; here it owns a small one so the panel
+    // is self-contained. m_demoRegistry must outlive m_inspector's builder.
+    ecs::Registry m_demoRegistry;
+    std::vector<ecs::Entity> m_demoEntities;
+    EntityInspector m_inspector;
 };
 
 } // namespace IKore

--- a/src/ui/EcsInspector.h
+++ b/src/ui/EcsInspector.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "core/ecs/ECS.h"
+#include "core/ecs/components/Components.h"
+#include "ui/EntityInspector.h"
+
+#include <cstdint>
+#include <vector>
+
+/**
+ * @file EcsInspector.h
+ * @brief Bridge the archetype ECS to the entity inspector's reflection (issue #56).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). Turns the archetype ECS components
+ * from Milestone 8 (Transform, Velocity, RigidBody, AIAgent) into the inspector's
+ * ComponentView / Property model, with each property's get/set reading and writing
+ * the live component through the Registry, so edits apply immediately in the
+ * running scene. Only the components an entity actually has are reflected.
+ *
+ * Header-only. Depends on the header-only, glm-free ECS and the (equally
+ * dependency-free) EntityInspector, so it is unit-testable against a real Registry
+ * without any GL context; the ImGui panel in DebugUI draws whatever this produces.
+ */
+namespace IKore {
+
+/// Pack an ECS entity handle into the inspector's opaque 64-bit id.
+inline EntityInspector::EntityId packEntity(ecs::Entity e) {
+    return (static_cast<std::uint64_t>(e.generation) << 32) | static_cast<std::uint64_t>(e.index);
+}
+
+/// Unpack an inspector id back into an ECS entity handle.
+inline ecs::Entity unpackEntity(EntityInspector::EntityId id) {
+    return ecs::Entity{static_cast<std::uint32_t>(id & 0xFFFFFFFFu),
+                       static_cast<std::uint32_t>(id >> 32)};
+}
+
+namespace detail {
+
+/// Bridge an ecs::Vec3 field of component T to a Float3 property.
+template <class T>
+inline Property vec3Property(const char* name, ecs::Registry& reg, ecs::Entity e,
+                             ecs::Vec3 T::*member) {
+    return propFloat3(
+        name,
+        [&reg, e, member] {
+            const ecs::Vec3& v = reg.get<T>(e).*member;
+            return Vec3f{v.x, v.y, v.z};
+        },
+        [&reg, e, member](Vec3f v) { reg.get<T>(e).*member = ecs::Vec3{v.x, v.y, v.z}; });
+}
+
+/// Bridge a float field of component T to a Float property.
+template <class T>
+inline Property floatProperty(const char* name, ecs::Registry& reg, ecs::Entity e, float T::*member,
+                              float speed = 0.05f, float minValue = 0.0f, float maxValue = 0.0f) {
+    return propFloat(
+        name, [&reg, e, member] { return reg.get<T>(e).*member; },
+        [&reg, e, member](float f) { reg.get<T>(e).*member = f; }, speed, minValue, maxValue);
+}
+
+/// Bridge a bool field of component T to a Bool property.
+template <class T>
+inline Property boolProperty(const char* name, ecs::Registry& reg, ecs::Entity e, bool T::*member) {
+    return propBool(
+        name, [&reg, e, member] { return reg.get<T>(e).*member; },
+        [&reg, e, member](bool b) { reg.get<T>(e).*member = b; });
+}
+
+} // namespace detail
+
+inline ComponentView reflectTransform(ecs::Registry& reg, ecs::Entity e) {
+    ComponentView cv;
+    cv.name = "Transform";
+    cv.properties.push_back(detail::vec3Property("position", reg, e, &ecs::Transform::position));
+    cv.properties.push_back(detail::vec3Property("rotation", reg, e, &ecs::Transform::rotation));
+    cv.properties.push_back(detail::vec3Property("scale", reg, e, &ecs::Transform::scale));
+    return cv;
+}
+
+inline ComponentView reflectVelocity(ecs::Registry& reg, ecs::Entity e) {
+    ComponentView cv;
+    cv.name = "Velocity";
+    cv.properties.push_back(detail::vec3Property("linear", reg, e, &ecs::Velocity::linear));
+    cv.properties.push_back(detail::vec3Property("angular", reg, e, &ecs::Velocity::angular));
+    return cv;
+}
+
+inline ComponentView reflectRigidBody(ecs::Registry& reg, ecs::Entity e) {
+    ComponentView cv;
+    cv.name = "RigidBody";
+    cv.properties.push_back(detail::vec3Property("acceleration", reg, e, &ecs::RigidBody::acceleration));
+    cv.properties.push_back(detail::floatProperty("mass", reg, e, &ecs::RigidBody::mass, 0.05f, 0.0f, 0.0f));
+    cv.properties.push_back(
+        detail::floatProperty("damping", reg, e, &ecs::RigidBody::damping, 0.01f, 0.0f, 1.0f));
+    cv.properties.push_back(detail::boolProperty("kinematic", reg, e, &ecs::RigidBody::kinematic));
+    return cv;
+}
+
+inline ComponentView reflectAIAgent(ecs::Registry& reg, ecs::Entity e) {
+    ComponentView cv;
+    cv.name = "AIAgent";
+    cv.properties.push_back(detail::vec3Property("target", reg, e, &ecs::AIAgent::target));
+    cv.properties.push_back(detail::floatProperty("speed", reg, e, &ecs::AIAgent::speed, 0.05f, 0.0f, 0.0f));
+    cv.properties.push_back(
+        detail::floatProperty("arriveRadius", reg, e, &ecs::AIAgent::arriveRadius, 0.01f, 0.0f, 0.0f));
+    cv.properties.push_back(detail::boolProperty("active", reg, e, &ecs::AIAgent::active));
+    return cv;
+}
+
+/// Reflect every known component an entity currently has, in a stable order.
+inline std::vector<ComponentView> reflectEntity(ecs::Registry& reg, ecs::Entity e) {
+    std::vector<ComponentView> views;
+    if (!reg.isValid(e)) return views;
+    if (reg.has<ecs::Transform>(e)) views.push_back(reflectTransform(reg, e));
+    if (reg.has<ecs::Velocity>(e)) views.push_back(reflectVelocity(reg, e));
+    if (reg.has<ecs::RigidBody>(e)) views.push_back(reflectRigidBody(reg, e));
+    if (reg.has<ecs::AIAgent>(e)) views.push_back(reflectAIAgent(reg, e));
+    return views;
+}
+
+/// Point an inspector at @p reg: selecting a packed entity id reflects its live
+/// components. The registry must outlive the inspector's use of the builder.
+inline void installEcsBuilder(EntityInspector& inspector, ecs::Registry& reg) {
+    inspector.setBuilder(
+        [&reg](EntityInspector::EntityId id) { return reflectEntity(reg, unpackEntity(id)); });
+}
+
+} // namespace IKore

--- a/src/ui/EntityInspector.h
+++ b/src/ui/EntityInspector.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * @file EntityInspector.h
+ * @brief Entity inspector model: component reflection + selection (issue #56).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless, renderer-agnostic core
+ * behind the ImGui entity inspector: a small reflection layer that describes a
+ * component's editable fields as typed get/set properties, plus a selection model
+ * that caches the selected entity's component views so the panel does no per-frame
+ * allocation - it rebuilds only when the selection changes (or on refresh()).
+ *
+ * The core is deliberately ECS-agnostic: it takes a Builder that maps an entity id
+ * to its component views, so it can reflect the archetype ECS (see EcsInspector.h)
+ * or any other object graph, and is unit-testable without a GL context. Editing a
+ * property calls its setter, which writes straight into the live component, so
+ * changes apply immediately in the running scene. Header-only, std only (no ImGui,
+ * no glm, no ECS types).
+ */
+namespace IKore {
+
+/// The value kind a property holds, so the panel can pick the right widget.
+enum class PropertyType { Bool, Int, Float, Float3, String };
+
+/// A glm-free 3-vector for reflecting position/rotation/scale style fields.
+struct Vec3f {
+    float x{0.0f};
+    float y{0.0f};
+    float z{0.0f};
+};
+
+/**
+ * @brief One editable field of a component: a name, a type, and typed accessors.
+ *
+ * Only the getter/setter pair matching @ref type is populated; the others stay
+ * empty. The getter reads the live value and the setter writes it straight back,
+ * so an edit in the panel is reflected in the running scene on the same frame.
+ * The min/max/speed hints drive numeric drag widgets (min == max means unbounded).
+ * A plain aggregate; use the prop* helpers to build the common cases.
+ */
+struct Property {
+    std::string name;
+    PropertyType type{PropertyType::Float};
+
+    std::function<bool()> getBool;
+    std::function<void(bool)> setBool;
+    std::function<int()> getInt;
+    std::function<void(int)> setInt;
+    std::function<float()> getFloat;
+    std::function<void(float)> setFloat;
+    std::function<Vec3f()> getVec3;
+    std::function<void(Vec3f)> setVec3;
+    std::function<std::string()> getString;
+    std::function<void(std::string)> setString;
+
+    float minValue{0.0f};
+    float maxValue{0.0f};
+    float speed{0.1f};
+};
+
+inline Property propBool(std::string name, std::function<bool()> get, std::function<void(bool)> set) {
+    Property p;
+    p.name = std::move(name);
+    p.type = PropertyType::Bool;
+    p.getBool = std::move(get);
+    p.setBool = std::move(set);
+    return p;
+}
+
+inline Property propInt(std::string name, std::function<int()> get, std::function<void(int)> set,
+                        float speed = 1.0f, float minValue = 0.0f, float maxValue = 0.0f) {
+    Property p;
+    p.name = std::move(name);
+    p.type = PropertyType::Int;
+    p.getInt = std::move(get);
+    p.setInt = std::move(set);
+    p.speed = speed;
+    p.minValue = minValue;
+    p.maxValue = maxValue;
+    return p;
+}
+
+inline Property propFloat(std::string name, std::function<float()> get, std::function<void(float)> set,
+                          float speed = 0.1f, float minValue = 0.0f, float maxValue = 0.0f) {
+    Property p;
+    p.name = std::move(name);
+    p.type = PropertyType::Float;
+    p.getFloat = std::move(get);
+    p.setFloat = std::move(set);
+    p.speed = speed;
+    p.minValue = minValue;
+    p.maxValue = maxValue;
+    return p;
+}
+
+inline Property propFloat3(std::string name, std::function<Vec3f()> get, std::function<void(Vec3f)> set,
+                           float speed = 0.1f) {
+    Property p;
+    p.name = std::move(name);
+    p.type = PropertyType::Float3;
+    p.getVec3 = std::move(get);
+    p.setVec3 = std::move(set);
+    p.speed = speed;
+    return p;
+}
+
+inline Property propString(std::string name, std::function<std::string()> get,
+                           std::function<void(std::string)> set) {
+    Property p;
+    p.name = std::move(name);
+    p.type = PropertyType::String;
+    p.getString = std::move(get);
+    p.setString = std::move(set);
+    return p;
+}
+
+/// A named group of properties, corresponding to one component on an entity.
+struct ComponentView {
+    std::string name;
+    std::vector<Property> properties;
+};
+
+/**
+ * @brief Selection model + cached component reflection for the inspector panel.
+ *
+ * Point it at a Builder (entity id -> component views), then drive selection from
+ * the scene hierarchy (#59) or viewport picking (#57) via select(). The selected
+ * entity's component views are built once on selection change and cached, so the
+ * panel iterates components() every frame with no rebuild or allocation; call
+ * refresh() when the entity's component set changes (e.g. a component is added).
+ */
+class EntityInspector {
+public:
+    using EntityId = std::uint64_t;
+    static constexpr EntityId kNoEntity = ~EntityId{0};
+
+    /// Maps an entity id to the component views to show for it.
+    using Builder = std::function<std::vector<ComponentView>(EntityId)>;
+
+    /// Set the reflection source. Rebuilds the current selection, if any.
+    void setBuilder(Builder builder) {
+        m_builder = std::move(builder);
+        if (m_hasSelection) rebuild();
+    }
+
+    /// Select an entity; rebuilds its component views only if the id changed.
+    void select(EntityId id) {
+        if (m_hasSelection && id == m_selected) return;
+        m_selected = id;
+        m_hasSelection = true;
+        rebuild();
+    }
+
+    /// Clear the selection and its cached views.
+    void deselect() {
+        m_hasSelection = false;
+        m_selected = kNoEntity;
+        m_components.clear();
+    }
+
+    /// Force a rebuild of the current selection (e.g. after components change).
+    void refresh() {
+        if (m_hasSelection) rebuild();
+    }
+
+    bool hasSelection() const { return m_hasSelection; }
+    EntityId selected() const { return m_selected; }
+
+    /// The selected entity's component views (empty if nothing is selected).
+    /// Cached: reading this does not allocate or rebuild.
+    const std::vector<ComponentView>& components() const { return m_components; }
+
+    /// How many times the views were rebuilt - for tests asserting the cache holds.
+    std::size_t rebuildCount() const { return m_rebuildCount; }
+
+private:
+    void rebuild() {
+        if (m_builder && m_hasSelection) {
+            m_components = m_builder(m_selected);
+        } else {
+            m_components.clear();
+        }
+        ++m_rebuildCount;
+    }
+
+    Builder m_builder;
+    std::vector<ComponentView> m_components;
+    EntityId m_selected{kNoEntity};
+    bool m_hasSelection{false};
+    std::size_t m_rebuildCount{0};
+};
+
+} // namespace IKore

--- a/tests/test_entity_inspector.cpp
+++ b/tests/test_entity_inspector.cpp
@@ -1,0 +1,269 @@
+// Test for the entity inspector core - Milestone 9, #56.
+//
+// Two surfaces:
+//   1. The generic reflection + selection model (EntityInspector): typed
+//      get/set properties round-trip, and the selection cache rebuilds only when
+//      the selection changes (the "no per-frame allocation" guarantee).
+//   2. The archetype-ECS bridge (EcsInspector): real Transform/Velocity/RigidBody/
+//      AIAgent components reflect with correct values and edits apply live to the
+//      running Registry.
+//
+// Pure std + header-only (the ECS is header-only and glm-free):
+//   g++ -std=c++17 -I src tests/test_entity_inspector.cpp -o test_entity_inspector
+
+#include "ui/EcsInspector.h"
+#include "ui/EntityInspector.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+namespace ecs = IKore::ecs;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b) { return std::fabs(a - b) < 1e-4f; }
+
+static const Property* findProp(const ComponentView& cv, const std::string& name) {
+    for (const Property& p : cv.properties) {
+        if (p.name == name) return &p;
+    }
+    return nullptr;
+}
+
+static const ComponentView* findView(const std::vector<ComponentView>& views, const std::string& name) {
+    for (const ComponentView& v : views) {
+        if (v.name == name) return &v;
+    }
+    return nullptr;
+}
+
+// ---- 1. Generic reflection + selection cache ------------------------------
+
+// Stands in for an arbitrary object with one field of each property type.
+struct Demo {
+    bool active{true};
+    int count{3};
+    float weight{2.5f};
+    Vec3f pos{1.0f, 2.0f, 3.0f};
+    std::string label{"hi"};
+};
+
+static ComponentView buildDemoView(Demo& d) {
+    ComponentView cv;
+    cv.name = "Demo";
+    cv.properties.push_back(propBool("active", [&d] { return d.active; },
+                                     [&d](bool b) { d.active = b; }));
+    cv.properties.push_back(propInt("count", [&d] { return d.count; }, [&d](int i) { d.count = i; }));
+    cv.properties.push_back(propFloat("weight", [&d] { return d.weight; },
+                                      [&d](float f) { d.weight = f; }));
+    cv.properties.push_back(propFloat3("pos", [&d] { return d.pos; }, [&d](Vec3f v) { d.pos = v; }));
+    cv.properties.push_back(propString("label", [&d] { return d.label; },
+                                       [&d](std::string s) { d.label = std::move(s); }));
+    return cv;
+}
+
+static void testGenericReflectionRoundTrip() {
+    Demo demo;
+    EntityInspector inspector;
+    inspector.setBuilder([&demo](EntityInspector::EntityId) {
+        return std::vector<ComponentView>{buildDemoView(demo)};
+    });
+
+    inspector.select(1);
+    CHECK(inspector.hasSelection());
+    CHECK(inspector.selected() == 1u);
+    CHECK(inspector.components().size() == 1);
+
+    const ComponentView& cv = inspector.components().front();
+    CHECK(cv.name == "Demo");
+    CHECK(cv.properties.size() == 5);
+
+    // Getters read the live values.
+    CHECK(findProp(cv, "active")->getBool() == true);
+    CHECK(findProp(cv, "count")->getInt() == 3);
+    CHECK(approx(findProp(cv, "weight")->getFloat(), 2.5f));
+    CHECK(approx(findProp(cv, "pos")->getVec3().y, 2.0f));
+    CHECK(findProp(cv, "label")->getString() == "hi");
+
+    // Setters write straight back into the object (edits apply live).
+    findProp(cv, "active")->setBool(false);
+    findProp(cv, "count")->setInt(42);
+    findProp(cv, "weight")->setFloat(9.75f);
+    findProp(cv, "pos")->setVec3(Vec3f{7.0f, 8.0f, 9.0f});
+    findProp(cv, "label")->setString("edited");
+
+    CHECK(demo.active == false);
+    CHECK(demo.count == 42);
+    CHECK(approx(demo.weight, 9.75f));
+    CHECK(approx(demo.pos.x, 7.0f) && approx(demo.pos.z, 9.0f));
+    CHECK(demo.label == "edited");
+}
+
+static void testSelectionCacheDoesNotRebuild() {
+    Demo demo;
+    EntityInspector inspector;
+    inspector.setBuilder([&demo](EntityInspector::EntityId) {
+        return std::vector<ComponentView>{buildDemoView(demo)};
+    });
+
+    inspector.select(1);
+    CHECK(inspector.rebuildCount() == 1);
+
+    // Re-selecting the same entity and reading components must not rebuild - this
+    // is what keeps the panel allocation-free per frame.
+    inspector.select(1);
+    for (int i = 0; i < 100; ++i) {
+        (void)inspector.components();
+        findProp(inspector.components().front(), "weight")->setFloat(static_cast<float>(i));
+    }
+    CHECK(inspector.rebuildCount() == 1);
+
+    // A different entity, and an explicit refresh, do rebuild.
+    inspector.select(2);
+    CHECK(inspector.rebuildCount() == 2);
+    inspector.refresh();
+    CHECK(inspector.rebuildCount() == 3);
+
+    inspector.deselect();
+    CHECK(!inspector.hasSelection());
+    CHECK(inspector.components().empty());
+    CHECK(inspector.rebuildCount() == 3); // deselect clears without rebuilding
+}
+
+// ---- 2. Archetype-ECS bridge ----------------------------------------------
+
+static void testEntityIdPacking() {
+    ecs::Entity e{7u, 3u};
+    const EntityInspector::EntityId id = packEntity(e);
+    const ecs::Entity back = unpackEntity(id);
+    CHECK(back == e);
+    CHECK(back.index == 7u && back.generation == 3u);
+}
+
+static void testEcsReflectionValuesAndLiveEdits() {
+    ecs::Registry reg;
+    ecs::Entity e = reg.create();
+    reg.add<ecs::Transform>(e, ecs::Transform{{1.0f, 2.0f, 3.0f}, {0.1f, 0.2f, 0.3f}, {2.0f, 2.0f, 2.0f}});
+    reg.add<ecs::Velocity>(e, ecs::Velocity{{5.0f, 0.0f, 0.0f}, {0.0f, 1.0f, 0.0f}});
+
+    const std::vector<ComponentView> views = reflectEntity(reg, e);
+    CHECK(views.size() == 2);
+
+    const ComponentView* transform = findView(views, "Transform");
+    CHECK(transform != nullptr);
+    const ComponentView* velocity = findView(views, "Velocity");
+    CHECK(velocity != nullptr);
+    if (transform == nullptr || velocity == nullptr) return;
+
+    // Values reflect the live component.
+    const Vec3f pos = findProp(*transform, "position")->getVec3();
+    CHECK(approx(pos.x, 1.0f) && approx(pos.y, 2.0f) && approx(pos.z, 3.0f));
+    const Vec3f scale = findProp(*transform, "scale")->getVec3();
+    CHECK(approx(scale.x, 2.0f));
+    CHECK(approx(findProp(*velocity, "linear")->getVec3().x, 5.0f));
+
+    // Editing a property writes straight into the ECS component.
+    findProp(*transform, "position")->setVec3(Vec3f{10.0f, 20.0f, 30.0f});
+    CHECK(approx(reg.get<ecs::Transform>(e).position.x, 10.0f));
+    CHECK(approx(reg.get<ecs::Transform>(e).position.z, 30.0f));
+
+    findProp(*velocity, "angular")->setVec3(Vec3f{0.0f, 0.0f, 9.0f});
+    CHECK(approx(reg.get<ecs::Velocity>(e).angular.z, 9.0f));
+}
+
+static void testEcsScalarAndBoolFields() {
+    ecs::Registry reg;
+    ecs::Entity e = reg.create();
+    reg.add<ecs::RigidBody>(e, ecs::RigidBody{{0.0f, -9.8f, 0.0f}, 2.0f, 0.1f, false});
+    reg.add<ecs::AIAgent>(e, ecs::AIAgent{{1.0f, 0.0f, 0.0f}, 3.0f, 0.5f, true});
+
+    const std::vector<ComponentView> views = reflectEntity(reg, e);
+    const ComponentView* body = findView(views, "RigidBody");
+    const ComponentView* ai = findView(views, "AIAgent");
+    CHECK(body != nullptr && ai != nullptr);
+    if (body == nullptr || ai == nullptr) return;
+
+    CHECK(approx(findProp(*body, "mass")->getFloat(), 2.0f));
+    CHECK(findProp(*body, "kinematic")->getBool() == false);
+
+    findProp(*body, "mass")->setFloat(5.5f);
+    findProp(*body, "kinematic")->setBool(true);
+    CHECK(approx(reg.get<ecs::RigidBody>(e).mass, 5.5f));
+    CHECK(reg.get<ecs::RigidBody>(e).kinematic == true);
+
+    CHECK(findProp(*ai, "active")->getBool() == true);
+    findProp(*ai, "speed")->setFloat(8.0f);
+    findProp(*ai, "active")->setBool(false);
+    CHECK(approx(reg.get<ecs::AIAgent>(e).speed, 8.0f));
+    CHECK(reg.get<ecs::AIAgent>(e).active == false);
+}
+
+static void testEcsReflectsOnlyPresentComponents() {
+    ecs::Registry reg;
+    ecs::Entity bare = reg.create(); // no components
+    CHECK(reflectEntity(reg, bare).empty());
+
+    ecs::Entity onlyTransform = reg.create();
+    reg.add<ecs::Transform>(onlyTransform, ecs::Transform{});
+    const std::vector<ComponentView> views = reflectEntity(reg, onlyTransform);
+    CHECK(views.size() == 1);
+    CHECK(findView(views, "Transform") != nullptr);
+    CHECK(findView(views, "Velocity") == nullptr);
+
+    // Invalid handles reflect to nothing rather than crashing.
+    CHECK(reflectEntity(reg, ecs::Entity::invalid()).empty());
+}
+
+static void testInspectorDrivenByEcsBuilder() {
+    ecs::Registry reg;
+    ecs::Entity a = reg.create();
+    reg.add<ecs::Transform>(a, ecs::Transform{{4.0f, 5.0f, 6.0f}, {}, {1.0f, 1.0f, 1.0f}});
+    ecs::Entity b = reg.create();
+    reg.add<ecs::Transform>(b, ecs::Transform{});
+    reg.add<ecs::AIAgent>(b, ecs::AIAgent{});
+
+    EntityInspector inspector;
+    installEcsBuilder(inspector, reg);
+
+    inspector.select(packEntity(a));
+    CHECK(inspector.hasSelection());
+    CHECK(inspector.components().size() == 1); // Transform only
+    const ComponentView& ta = inspector.components().front();
+    CHECK(approx(findProp(ta, "position")->getVec3().x, 4.0f));
+    // Edit through the cached property reaches the live component.
+    findProp(ta, "position")->setVec3(Vec3f{40.0f, 50.0f, 60.0f});
+    CHECK(approx(reg.get<ecs::Transform>(a).position.y, 50.0f));
+
+    // Switching selection reflects a different component set.
+    inspector.select(packEntity(b));
+    CHECK(inspector.components().size() == 2); // Transform + AIAgent
+    CHECK(findView(inspector.components(), "AIAgent") != nullptr);
+}
+
+int main() {
+    testGenericReflectionRoundTrip();
+    testSelectionCacheDoesNotRebuild();
+    testEntityIdPacking();
+    testEcsReflectionValuesAndLiveEdits();
+    testEcsScalarAndBoolFields();
+    testEcsReflectsOnlyPresentComponents();
+    testInspectorDrivenByEcsBuilder();
+
+    if (g_failures == 0) {
+        std::printf("All entity inspector tests passed.\n");
+        return 0;
+    }
+    std::printf("%d entity inspector test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Adds an ImGui entity inspector on top of the Dear ImGui foundation (#144), following the same split proven by #53/#54/#55: a headless, unit-tested core plus a thin ImGui panel wired into `DebugUI`. It reflects the archetype ECS (Milestone 8) and edits component fields live in the running scene.

Closes #56

## Core: `src/ui/EntityInspector.h` (header-only, std only)

No ImGui, glm, or ECS types, so it unit-tests without a GL context.

- `Property` describes one editable field as a name, a type (`Bool` / `Int` / `Float` / `Float3` / `String`), and a typed get/set pair. The getter reads the live value and the setter writes it straight back, so an edit in the panel applies immediately in the running scene. `prop*` helpers build the common cases; `ComponentView` groups a component's properties.
- `EntityInspector` is the selection model: point it at a `Builder` (entity id -> component views) and drive selection via `select()`, which caches the built views and rebuilds **only** when the selection changes (or `refresh()` is called). So the panel iterates `components()` every frame with no rebuild and no per-frame allocation. Selection is exposed so viewport picking (#57) and the scene hierarchy (#59) can drive it later.

## ECS bridge: `src/ui/EcsInspector.h` (header-only)

Reflects the real archetype components from Milestone 8 - `Transform`, `Velocity`, `RigidBody`, `AIAgent` - into `ComponentView`s whose get/set read and write the live component through the `Registry`. Only the components an entity actually has are shown. Entity handles pack into the inspector's opaque 64-bit id. Because the ECS is header-only and glm-free, this bridge is fully testable against a real `Registry`.

## Panel: `src/ui/DebugUI`

- `renderInspector()` lists a small demo ECS scene, lets you pick an entity, and draws each component view as a collapsing header with the widget matching each field (`Checkbox` / `DragInt` / `DragFloat` / `DragFloat3` / `InputText`). Edits write straight into the ECS component.
- A "Show entity inspector" toggle and an `inspector()` accessor are added. The demo entities have differing component sets to exercise the reflection.

## Testing

- `tests/test_entity_inspector.cpp` covers:
  - the generic reflection round-trip (every property type reads and edits live),
  - the selection cache (no rebuild on re-select or on repeated reads/writes; rebuild only on selection change or `refresh()`),
  - entity-id packing round-trip,
  - and, against a **real** `ecs::Registry`, correct reflected values and live edits for `Transform` / `Velocity` / `RigidBody` / `AIAgent`, plus reflecting only the components an entity has (and empty for bare/invalid entities).
- Passes locally under ASan/UBSan (`All entity inspector tests passed.`).
- New CMake target `test_entity_inspector`.
- The ImGui panel is compiled by CI (CodeQL c-cpp build), consistent with the rest of the ImGui-dependent engine code.

## Acceptance criteria

- The selected entity's components display with correct values and edits apply live: verified directly against a real `Registry` in the unit test (getters match; setters mutate the live component).
- No per-frame allocation spikes: component views are cached and rebuilt only on selection change; the ECS reflection uses only numeric/bool fields (no per-frame string copies), and the test asserts the cache does not rebuild on re-select or repeated reads.
- Selection is drivable from the scene hierarchy (#59) or viewport picking (#57) via the exposed `inspector().select(id)`.

## Notes

- Additive: no behavior change to the existing perf/console/HUD panels. The inspector currently reflects a self-contained demo registry owned by `DebugUI` (mirroring the #55 HUD demo); pointing it at the engine's real scene registry is a one-line `installEcsBuilder(...)` change once that registry is threaded into the debug UI.