### PR TITLE
[M9] Add ray-based viewport picking (#57)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,6 +625,11 @@ add_executable(test_entity_inspector
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_entity_inspector.cpp
 )
 
+# Ray-based viewport picking core (Milestone 9 / #57) - header-only.
+add_executable(test_picking
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_picking.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/Picking.h
+++ b/src/core/Picking.h
@@ -1,0 +1,225 @@
+#pragma once
+
+#include "core/ecs/components/Components.h" // for ecs::Vec3
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <utility>
+#include <vector>
+
+/**
+ * @file Picking.h
+ * @brief Ray-based viewport picking core (issue #57).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless, renderer-agnostic math
+ * behind mouse picking: turn a cursor position into a world-space ray, intersect
+ * that ray with entity bounding volumes (AABB / sphere), and pick the nearest hit.
+ * A small Picker state machine tracks hover and selection and gates on whether the
+ * UI wants the mouse, so a click over an ImGui panel is consumed by the UI and
+ * never reaches the scene. The engine feeds the resulting selection to the entity
+ * inspector (#56).
+ *
+ * Vectors reuse the glm-free ecs::Vec3, so the whole thing is unit-testable without
+ * glm or a GL context. Matrices are column-major (matching glm), so the engine can
+ * pass glm::value_ptr(glm::inverse(proj * view)) straight into screenToRay().
+ * Header-only, std only.
+ */
+namespace IKore {
+namespace pick {
+
+using Vec3 = ecs::Vec3;
+using Id = std::uint64_t;
+
+/// A world-space ray. @c dir is expected to be normalized.
+struct Ray {
+    Vec3 origin;
+    Vec3 dir;
+};
+
+/// An axis-aligned bounding box.
+struct Aabb {
+    Vec3 min;
+    Vec3 max;
+
+    static Aabb fromCenterHalf(Vec3 center, Vec3 half) {
+        return Aabb{center - half, center + half};
+    }
+};
+
+/// A column-major 4x4 matrix (same layout as glm::mat4).
+struct Mat4 {
+    float m[16];
+
+    static Mat4 identity() {
+        Mat4 r{};
+        r.m[0] = r.m[5] = r.m[10] = r.m[15] = 1.0f;
+        return r;
+    }
+};
+
+/// A scene item that can be picked: an id plus its world-space bounds.
+struct Pickable {
+    Id id;
+    Aabb bounds;
+};
+
+/// Result of a pick query.
+struct PickResult {
+    bool hit{false};
+    Id id{0};
+    float distance{0.0f};
+};
+
+/// Unproject a clip-space point (NDC x,y,z with w=1) through an inverse
+/// view-projection matrix, applying the perspective divide, to world space.
+inline Vec3 unproject(const Mat4& invViewProj, float ndcX, float ndcY, float ndcZ) {
+    const float* m = invViewProj.m;
+    float x = m[0] * ndcX + m[4] * ndcY + m[8] * ndcZ + m[12];
+    float y = m[1] * ndcX + m[5] * ndcY + m[9] * ndcZ + m[13];
+    float z = m[2] * ndcX + m[6] * ndcY + m[10] * ndcZ + m[14];
+    float w = m[3] * ndcX + m[7] * ndcY + m[11] * ndcZ + m[15];
+    if (w != 0.0f) {
+        x /= w;
+        y /= w;
+        z /= w;
+    }
+    return Vec3{x, y, z};
+}
+
+/**
+ * @brief Build a world-space pick ray from a cursor position in pixels.
+ * @param mouseX,mouseY     Cursor position, pixels, origin at the top-left.
+ * @param viewportW,viewportH Viewport size in pixels.
+ * @param invViewProj       Inverse of (projection * view).
+ *
+ * Unprojects the near and far plane points under the cursor and returns the ray
+ * from near toward far. Assumes the OpenGL NDC z range [-1, 1].
+ */
+inline Ray screenToRay(float mouseX, float mouseY, float viewportW, float viewportH,
+                       const Mat4& invViewProj) {
+    const float ndcX = 2.0f * (mouseX / viewportW) - 1.0f;
+    const float ndcY = 1.0f - 2.0f * (mouseY / viewportH); // screen y is top-down
+    const Vec3 nearPoint = unproject(invViewProj, ndcX, ndcY, -1.0f);
+    const Vec3 farPoint = unproject(invViewProj, ndcX, ndcY, 1.0f);
+    return Ray{nearPoint, (farPoint - nearPoint).normalized()};
+}
+
+/**
+ * @brief Ray vs AABB (slab method). Only hits in front of the origin count.
+ * @param[out] tHit Distance along the ray to the entry point, if hit.
+ * @return true if the ray hits the box at t >= 0.
+ */
+inline bool rayAabb(const Ray& ray, const Aabb& box, float& tHit) {
+    float tmin = 0.0f;
+    float tmax = std::numeric_limits<float>::max();
+    const float o[3] = {ray.origin.x, ray.origin.y, ray.origin.z};
+    const float d[3] = {ray.dir.x, ray.dir.y, ray.dir.z};
+    const float lo[3] = {box.min.x, box.min.y, box.min.z};
+    const float hi[3] = {box.max.x, box.max.y, box.max.z};
+    for (int i = 0; i < 3; ++i) {
+        if (std::fabs(d[i]) < 1e-8f) {
+            if (o[i] < lo[i] || o[i] > hi[i]) return false; // parallel and outside the slab
+        } else {
+            const float inv = 1.0f / d[i];
+            float t1 = (lo[i] - o[i]) * inv;
+            float t2 = (hi[i] - o[i]) * inv;
+            if (t1 > t2) std::swap(t1, t2);
+            if (t1 > tmin) tmin = t1;
+            if (t2 < tmax) tmax = t2;
+            if (tmin > tmax) return false;
+        }
+    }
+    tHit = tmin;
+    return true;
+}
+
+/**
+ * @brief Ray vs sphere. Only hits in front of the origin count.
+ * @param[out] tHit Distance along the ray to the nearest hit, if any.
+ */
+inline bool raySphere(const Ray& ray, Vec3 center, float radius, float& tHit) {
+    const Vec3 oc = ray.origin - center;
+    const float b = oc.x * ray.dir.x + oc.y * ray.dir.y + oc.z * ray.dir.z; // dot(oc, dir)
+    const float c = oc.lengthSquared() - radius * radius;
+    const float disc = b * b - c; // dir is normalized, so a == 1
+    if (disc < 0.0f) return false;
+    const float sq = std::sqrt(disc);
+    float t = -b - sq;      // near root
+    if (t < 0.0f) t = -b + sq; // origin inside / near root behind: try the far root
+    if (t < 0.0f) return false;
+    tHit = t;
+    return true;
+}
+
+/// Pick the nearest item whose AABB the ray hits.
+inline PickResult pickNearest(const Ray& ray, const std::vector<Pickable>& items) {
+    PickResult best;
+    float bestT = std::numeric_limits<float>::max();
+    for (const Pickable& item : items) {
+        float t = 0.0f;
+        if (rayAabb(ray, item.bounds, t) && t < bestT) {
+            bestT = t;
+            best.hit = true;
+            best.id = item.id;
+            best.distance = t;
+        }
+    }
+    return best;
+}
+
+/// Whether a viewport pointer event should reach the scene. When the UI wants the
+/// mouse (ImGui io.WantCaptureMouse), clicks are consumed by the UI, not the scene.
+inline bool sceneShouldReceiveMouse(bool imguiWantsMouse) { return !imguiWantsMouse; }
+
+/**
+ * @brief Hover + selection state driven by per-frame viewport interaction.
+ *
+ * Call update() each frame with the pick ray, the scene's pickables, whether the
+ * UI wants the mouse, and whether a select click happened. When the UI wants the
+ * mouse the scene is left untouched (hover clears, the click is ignored), so UI
+ * clicks never fall through to picking. Otherwise the nearest hit becomes the
+ * hover; a click commits it as the selection, and clicking empty space clears it.
+ */
+class Picker {
+public:
+    void update(const Ray& ray, const std::vector<Pickable>& items, bool pointerOverUI, bool clicked) {
+        if (pointerOverUI) {
+            m_hasHover = false; // UI consumed the pointer; leave the selection as-is
+            m_hoverId = 0;
+            return;
+        }
+        const PickResult result = pickNearest(ray, items);
+        m_hasHover = result.hit;
+        m_hoverId = result.id;
+        if (clicked) {
+            m_hasSelection = result.hit;
+            m_selectedId = result.hit ? result.id : 0;
+        }
+    }
+
+    bool hasHover() const { return m_hasHover; }
+    Id hovered() const { return m_hoverId; }
+
+    bool hasSelection() const { return m_hasSelection; }
+    Id selected() const { return m_selectedId; }
+
+    /// Selection can also be driven externally (e.g. from the scene hierarchy #59).
+    void select(Id id) {
+        m_hasSelection = true;
+        m_selectedId = id;
+    }
+    void clearSelection() {
+        m_hasSelection = false;
+        m_selectedId = 0;
+    }
+
+private:
+    bool m_hasHover{false};
+    Id m_hoverId{0};
+    bool m_hasSelection{false};
+    Id m_selectedId{0};
+};
+
+} // namespace pick
+} // namespace IKore

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -191,6 +191,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::Checkbox("Show HUD (#55)", &m_showHud);
     ImGui::SliderFloat("HUD scale (#61)", &m_hudScale, 0.5f, 2.0f, "%.2f");
     ImGui::Checkbox("Show entity inspector (#56)", &m_showInspector);
+    ImGui::Checkbox("Show scene view / picking (#57)", &m_showPicking);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
@@ -198,6 +199,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     renderConsole();
     renderHud();
     renderInspector();
+    renderPicking();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
@@ -269,6 +271,89 @@ void DebugUI::renderInspector() {
             }
         }
         ImGui::PopID();
+    }
+
+    ImGui::End();
+}
+
+void DebugUI::renderPicking() {
+    if (!m_showPicking) return;
+
+    ImGui::Begin("Scene View (picking)", &m_showPicking);
+    ImGui::TextUnformatted("Top-down pick view: hover to highlight, click to select.");
+    const ImGuiIO& io = ImGui::GetIO();
+    ImGui::Text("ImGui WantCaptureMouse: %s", io.WantCaptureMouse ? "yes" : "no");
+
+    // Reserve the viewport rectangle. The InvisibleButton is what makes ImGui
+    // consume clicks: only a click that lands on it (and not on another panel)
+    // counts as a scene click - clicks elsewhere on the UI never pick (#57).
+    const ImVec2 topLeft = ImGui::GetCursorScreenPos();
+    const float viewW = ImGui::GetContentRegionAvail().x;
+    const float viewH = 240.0f;
+    ImGui::InvisibleButton("##viewport", ImVec2(viewW, viewH));
+    const bool overViewport = ImGui::IsItemHovered();
+    const bool clicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
+
+    // World window (x -> horizontal, z -> vertical) mapped onto the rectangle.
+    const float worldMinX = -6.0f, worldMaxX = 6.0f, worldMinZ = -6.0f, worldMaxZ = 6.0f;
+    auto worldToScreen = [&](float wx, float wz) {
+        return ImVec2(topLeft.x + (wx - worldMinX) / (worldMaxX - worldMinX) * viewW,
+                      topLeft.y + (wz - worldMinZ) / (worldMaxZ - worldMinZ) * viewH);
+    };
+
+    // Pickable bounds from the demo entities' transforms; ids match the inspector.
+    std::vector<pick::Pickable> pickables;
+    pickables.reserve(m_demoEntities.size());
+    for (const ecs::Entity entity : m_demoEntities) {
+        if (!m_demoRegistry.has<ecs::Transform>(entity)) continue;
+        const ecs::Transform& t = m_demoRegistry.get<ecs::Transform>(entity);
+        const pick::Vec3 half{0.5f * t.scale.x + 0.25f, 0.5f * t.scale.y + 0.25f, 0.5f * t.scale.z + 0.25f};
+        pickables.push_back({packEntity(entity),
+                             pick::Aabb::fromCenterHalf(
+                                 pick::Vec3{t.position.x, t.position.y, t.position.z}, half)});
+    }
+
+    // Cursor -> top-down world ray (straight down onto the x/z plane).
+    const float worldX = worldMinX + (io.MousePos.x - topLeft.x) / viewW * (worldMaxX - worldMinX);
+    const float worldZ = worldMinZ + (io.MousePos.y - topLeft.y) / viewH * (worldMaxZ - worldMinZ);
+    const pick::Ray ray{pick::Vec3{worldX, 100.0f, worldZ}, pick::Vec3{0.0f, -1.0f, 0.0f}};
+
+    m_picker.update(ray, pickables, /*pointerOverUI=*/!overViewport, clicked);
+
+    // A click in the viewport feeds the entity inspector (#56).
+    if (clicked) {
+        if (m_picker.hasSelection()) {
+            m_inspector.select(m_picker.selected());
+        } else {
+            m_inspector.deselect();
+        }
+    }
+
+    // Draw the scene: white dots, a yellow ring on hover, green fill when selected.
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
+    drawList->AddRectFilled(topLeft, ImVec2(topLeft.x + viewW, topLeft.y + viewH), IM_COL32(28, 28, 32, 255));
+    drawList->AddRect(topLeft, ImVec2(topLeft.x + viewW, topLeft.y + viewH), IM_COL32(80, 80, 90, 255));
+    for (const pick::Pickable& p : pickables) {
+        const float cx = 0.5f * (p.bounds.min.x + p.bounds.max.x);
+        const float cz = 0.5f * (p.bounds.min.z + p.bounds.max.z);
+        const ImVec2 dot = worldToScreen(cx, cz);
+        ImU32 color = IM_COL32(220, 220, 220, 255);
+        if (m_picker.hasSelection() && m_picker.selected() == p.id) color = IM_COL32(80, 220, 120, 255);
+        drawList->AddCircleFilled(dot, 6.0f, color);
+        if (m_picker.hasHover() && m_picker.hovered() == p.id) {
+            drawList->AddCircle(dot, 10.0f, IM_COL32(240, 220, 80, 255), 0, 2.0f);
+        }
+    }
+
+    if (m_picker.hasHover()) {
+        ImGui::Text("Hover: Entity %u", unpackEntity(m_picker.hovered()).index);
+    } else {
+        ImGui::TextDisabled("Hover: none");
+    }
+    if (m_picker.hasSelection()) {
+        ImGui::Text("Selected: Entity %u", unpackEntity(m_picker.selected()).index);
+    } else {
+        ImGui::TextDisabled("Selected: none");
     }
 
     ImGui::End();

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -2,6 +2,7 @@
 
 #include "core/DebugConsole.h"
 #include "core/PerfStats.h"
+#include "core/Picking.h"
 #include "core/ecs/ECS.h"
 #include "core/ecs/components/Components.h"
 #include "ui/EcsInspector.h"
@@ -88,6 +89,7 @@ private:
     void renderConsole();
     void renderHud();
     void renderInspector();
+    void renderPicking();
 
     bool m_initialized{false};
     bool m_visible{false};
@@ -96,6 +98,7 @@ private:
     bool m_showConsole{true};
     bool m_showHud{true};
     bool m_showInspector{true};
+    bool m_showPicking{true};
     float m_hudScale{1.0f};
     PerfStats m_perf;
     DebugConsole m_console;
@@ -116,6 +119,10 @@ private:
     ecs::Registry m_demoRegistry;
     std::vector<ecs::Entity> m_demoEntities;
     EntityInspector m_inspector;
+
+    // Viewport picking (#57): a top-down pick view over the demo scene that feeds
+    // the inspector on click. The core math/state lives in core/Picking.h.
+    pick::Picker m_picker;
 };
 
 } // namespace IKore

--- a/tests/test_picking.cpp
+++ b/tests/test_picking.cpp
@@ -1,0 +1,175 @@
+// Test for the ray-based viewport picking core - Milestone 9, #57.
+//
+// Verifies the headless picking math and state machine: screen-to-ray
+// unprojection, ray/AABB and ray/sphere intersection, nearest-hit selection, and
+// the Picker's hover/select behavior including the "UI consumes the click" gate.
+// The cursor drawing and camera live in the engine (DebugUI / main).
+//
+// Pure std + header-only (reuses the glm-free ecs::Vec3):
+//   g++ -std=c++17 -I src tests/test_picking.cpp -o test_picking
+
+#include "core/Picking.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::pick;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b) { return std::fabs(a - b) < 1e-3f; }
+
+static Ray downRay(float x, float z) { return Ray{Vec3{x, 100.0f, z}, Vec3{0.0f, -1.0f, 0.0f}}; }
+
+static void testScreenToRayIdentity() {
+    const Mat4 id = Mat4::identity();
+
+    // Center of an 800x600 viewport -> NDC (0,0). With an identity inverse VP the
+    // near plane sits at z=-1 and the ray points down +Z.
+    const Ray center = screenToRay(400.0f, 300.0f, 800.0f, 600.0f, id);
+    CHECK(approx(center.origin.x, 0.0f) && approx(center.origin.y, 0.0f) && approx(center.origin.z, -1.0f));
+    CHECK(approx(center.dir.x, 0.0f) && approx(center.dir.y, 0.0f) && approx(center.dir.z, 1.0f));
+
+    // Top-right pixel -> NDC (+1, +1) (screen y flips).
+    const Ray corner = screenToRay(800.0f, 0.0f, 800.0f, 600.0f, id);
+    CHECK(approx(corner.origin.x, 1.0f) && approx(corner.origin.y, 1.0f));
+
+    // Bottom-left pixel -> NDC (-1, -1).
+    const Ray bl = screenToRay(0.0f, 600.0f, 800.0f, 600.0f, id);
+    CHECK(approx(bl.origin.x, -1.0f) && approx(bl.origin.y, -1.0f));
+}
+
+static void testScreenToRayTranslation() {
+    // Inverse VP that translates by (5, -2, 10): the unprojected points shift, so
+    // the ray origin moves with the camera while the direction stays +Z.
+    Mat4 t = Mat4::identity();
+    t.m[12] = 5.0f;
+    t.m[13] = -2.0f;
+    t.m[14] = 10.0f;
+
+    const Ray r = screenToRay(400.0f, 300.0f, 800.0f, 600.0f, t);
+    CHECK(approx(r.origin.x, 5.0f) && approx(r.origin.y, -2.0f) && approx(r.origin.z, 9.0f));
+    CHECK(approx(r.dir.z, 1.0f));
+}
+
+static void testRayAabb() {
+    const Ray r{Vec3{0.0f, 0.0f, -5.0f}, Vec3{0.0f, 0.0f, 1.0f}};
+
+    float t = 0.0f;
+    const Aabb atOrigin = Aabb::fromCenterHalf(Vec3{0.0f, 0.0f, 0.0f}, Vec3{1.0f, 1.0f, 1.0f});
+    CHECK(rayAabb(r, atOrigin, t));
+    CHECK(approx(t, 4.0f)); // enters the box at z = -1
+
+    // Offset in X so the +Z ray misses.
+    const Aabb offset = Aabb::fromCenterHalf(Vec3{5.0f, 0.0f, 0.0f}, Vec3{1.0f, 1.0f, 1.0f});
+    CHECK(!rayAabb(r, offset, t));
+
+    // A box entirely behind the origin is not hit (only t >= 0 counts).
+    const Ray away{Vec3{0.0f, 0.0f, 5.0f}, Vec3{0.0f, 0.0f, 1.0f}};
+    CHECK(!rayAabb(away, atOrigin, t));
+
+    // Ray parallel to a slab and outside it: miss.
+    const Ray parallel{Vec3{5.0f, 0.0f, -5.0f}, Vec3{0.0f, 0.0f, 1.0f}};
+    CHECK(!rayAabb(parallel, atOrigin, t));
+}
+
+static void testRaySphere() {
+    const Ray r{Vec3{0.0f, 0.0f, -5.0f}, Vec3{0.0f, 0.0f, 1.0f}};
+    float t = 0.0f;
+    CHECK(raySphere(r, Vec3{0.0f, 0.0f, 0.0f}, 1.0f, t));
+    CHECK(approx(t, 4.0f));
+
+    CHECK(!raySphere(r, Vec3{5.0f, 0.0f, 0.0f}, 1.0f, t)); // off to the side, misses
+}
+
+static void testPickNearest() {
+    // Two boxes straight ahead; the nearer one wins.
+    std::vector<Pickable> items = {
+        {1, Aabb::fromCenterHalf(Vec3{0.0f, 0.0f, 0.0f}, Vec3{1.0f, 1.0f, 1.0f})},
+        {2, Aabb::fromCenterHalf(Vec3{0.0f, 0.0f, -5.0f}, Vec3{1.0f, 1.0f, 1.0f})},
+    };
+    const Ray r{Vec3{0.0f, 0.0f, -10.0f}, Vec3{0.0f, 0.0f, 1.0f}};
+    const PickResult res = pickNearest(r, items);
+    CHECK(res.hit);
+    CHECK(res.id == 2); // the box at z=-5 is closer to the origin at z=-10
+    CHECK(approx(res.distance, 4.0f));
+
+    // A ray that hits nothing.
+    const Ray miss{Vec3{0.0f, 50.0f, -10.0f}, Vec3{0.0f, 0.0f, 1.0f}};
+    CHECK(!pickNearest(miss, items).hit);
+}
+
+static void testPickerHoverAndSelect() {
+    std::vector<Pickable> items = {
+        {10, Aabb::fromCenterHalf(Vec3{0.0f, 0.0f, 0.0f}, Vec3{0.5f, 0.5f, 0.5f})},
+        {20, Aabb::fromCenterHalf(Vec3{3.0f, 0.0f, 0.0f}, Vec3{0.5f, 0.5f, 0.5f})},
+    };
+    Picker picker;
+
+    // Hover over the first box (top-down ray at x=0), no click yet.
+    picker.update(downRay(0.0f, 0.0f), items, /*pointerOverUI=*/false, /*clicked=*/false);
+    CHECK(picker.hasHover());
+    CHECK(picker.hovered() == 10);
+    CHECK(!picker.hasSelection());
+
+    // Click selects the hovered entity (feeds the inspector).
+    picker.update(downRay(0.0f, 0.0f), items, false, true);
+    CHECK(picker.hasSelection());
+    CHECK(picker.selected() == 10);
+
+    // Move over the second box and click: selection follows.
+    picker.update(downRay(3.0f, 0.0f), items, false, true);
+    CHECK(picker.selected() == 20);
+
+    // Click on empty space clears the selection.
+    picker.update(downRay(50.0f, 0.0f), items, false, true);
+    CHECK(!picker.hasHover());
+    CHECK(!picker.hasSelection());
+}
+
+static void testPickerUIConsumesClick() {
+    std::vector<Pickable> items = {
+        {10, Aabb::fromCenterHalf(Vec3{0.0f, 0.0f, 0.0f}, Vec3{0.5f, 0.5f, 0.5f})},
+    };
+    Picker picker;
+
+    // Establish a selection via the scene.
+    picker.update(downRay(0.0f, 0.0f), items, false, true);
+    CHECK(picker.selected() == 10);
+
+    // Now the pointer is over the UI: even a click that geometrically hits the box
+    // must not reach the scene - hover clears and the selection is untouched.
+    picker.update(downRay(0.0f, 0.0f), items, /*pointerOverUI=*/true, /*clicked=*/true);
+    CHECK(!picker.hasHover());
+    CHECK(picker.hasSelection());
+    CHECK(picker.selected() == 10);
+
+    CHECK(sceneShouldReceiveMouse(false) == true);
+    CHECK(sceneShouldReceiveMouse(true) == false);
+}
+
+int main() {
+    testScreenToRayIdentity();
+    testScreenToRayTranslation();
+    testRayAabb();
+    testRaySphere();
+    testPickNearest();
+    testPickerHoverAndSelect();
+    testPickerUIConsumesClick();
+
+    if (g_failures == 0) {
+        std::printf("All picking tests passed.\n");
+        return 0;
+    }
+    std::printf("%d picking test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Adds mouse ray picking to select scene entities and feed the entity inspector (#56), following the same split proven by #53-#56: a headless, unit-tested core plus a thin ImGui panel wired into `DebugUI`.

Closes #57

## Core: `src/core/Picking.h` (header-only, std only)

Reuses the glm-free `ecs::Vec3`, so the whole thing is unit-testable without glm or a GL context.

- `screenToRay()` unprojects a cursor position through an inverse view-projection matrix into a world-space ray. Matrices are column-major (glm layout), so the engine can pass `glm::value_ptr(glm::inverse(proj * view))` straight in.
- `rayAabb()` (slab method) and `raySphere()` intersection, counting only hits in front of the ray origin.
- `pickNearest()` returns the closest AABB hit among the scene's pickables.
- `sceneShouldReceiveMouse()` is the UI-capture gate (`io.WantCaptureMouse`).
- `Picker` holds per-frame hover + selection state. When the pointer is over the UI the scene is left untouched (hover clears, the click is ignored), so UI clicks never fall through to picking; otherwise the nearest hit becomes the hover and a click commits it as the selection (clicking empty space clears it). Selection can also be driven externally (e.g. from the scene hierarchy #59).

## Panel: `src/ui/DebugUI`

- A "Scene View" top-down pick view over the demo ECS scene. An `InvisibleButton` reserves the viewport rectangle, which is what makes ImGui consume clicks: only a click that lands on the viewport (not on another panel) counts as a scene click.
- The cursor casts a top-down ray; entities highlight with a ring on hover and fill green when selected; a click feeds the selection to the inspector via `inspector().select(...)`. Pickable ids are the same packed entity ids the inspector uses, so picking and inspection stay in sync.
- The panel also shows the live `WantCaptureMouse` flag and the hovered/selected entity.

## Testing

- `tests/test_picking.cpp` covers:
  - screen-to-ray unprojection (identity and translated inverse VP; NDC corners),
  - ray/AABB (hit, side miss, behind-origin, parallel-slab) and ray/sphere intersection,
  - nearest-of-overlapping selection,
  - and the `Picker` hover/select flow, including that a click over the UI does **not** reach the scene (selection untouched) and `sceneShouldReceiveMouse` gating.
- Passes locally under ASan/UBSan (`All picking tests passed.`).
- New CMake target `test_picking`.
- The ImGui panel is compiled by CI (CodeQL c-cpp build), consistent with the rest of the ImGui-dependent engine code.

## Acceptance criteria

- Ray picking selects the correct entity under the cursor: verified by `pickNearest` choosing the nearest of overlapping boxes and by the `Picker` hover/click tests.
- Clicks on UI are consumed by ImGui and do not reach the scene: the core gates on "pointer over UI" (a click over the UI leaves the scene selection untouched), and the panel uses an `InvisibleButton` so only viewport clicks pick.

## Notes

- Additive: no behavior change to existing panels. The pick view runs against the self-contained demo scene owned by `DebugUI` (mirroring #55/#56); the same core plugs into the real viewport by building the ray from the engine camera's `inverse(proj*view)` and gating on `!io.WantCaptureMouse`.