### PR TITLE
[M9] Add interactive menus and persistent settings (#58)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,16 @@ add_executable(test_picking
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_picking.cpp
 )
 
+# Persistent settings store (Milestone 9 / #58) - header-only.
+add_executable(test_settings
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_settings.cpp
+)
+
+# Interactive menu navigation core (Milestone 9 / #58) - header-only.
+add_executable(test_menu_system
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_menu_system.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/Settings.h
+++ b/src/core/Settings.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <cstddef>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+
+/**
+ * @file Settings.h
+ * @brief Persistent key/value settings store (issue #58).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). A small, typed settings store behind
+ * the settings menu: set/get bool/int/float/string values, serialize them to a
+ * simple "key=value" text form, and load them back, so settings persist across
+ * sessions. saveToFile()/loadFromFile() do the round trip to disk; serialize()/
+ * load() are the pure string form, unit-testable without touching the filesystem.
+ *
+ * Header-only, std only. Values are stored as strings and coerced on read, with a
+ * caller-supplied default for missing or unparyable keys.
+ */
+namespace IKore {
+
+class Settings {
+public:
+    void setBool(const std::string& key, bool value) { m_values[key] = value ? "true" : "false"; }
+    void setInt(const std::string& key, int value) { m_values[key] = std::to_string(value); }
+    void setFloat(const std::string& key, float value) { m_values[key] = floatToString(value); }
+    void setString(const std::string& key, const std::string& value) { m_values[key] = value; }
+
+    bool has(const std::string& key) const { return m_values.count(key) > 0; }
+    void clear() { m_values.clear(); }
+    std::size_t size() const { return m_values.size(); }
+
+    bool getBool(const std::string& key, bool defaultValue = false) const {
+        auto it = m_values.find(key);
+        if (it == m_values.end()) return defaultValue;
+        const std::string& v = it->second;
+        return v == "true" || v == "1" || v == "on" || v == "yes";
+    }
+
+    int getInt(const std::string& key, int defaultValue = 0) const {
+        auto it = m_values.find(key);
+        if (it == m_values.end()) return defaultValue;
+        try {
+            return std::stoi(it->second);
+        } catch (...) {
+            return defaultValue;
+        }
+    }
+
+    float getFloat(const std::string& key, float defaultValue = 0.0f) const {
+        auto it = m_values.find(key);
+        if (it == m_values.end()) return defaultValue;
+        try {
+            return std::stof(it->second);
+        } catch (...) {
+            return defaultValue;
+        }
+    }
+
+    std::string getString(const std::string& key, const std::string& defaultValue = "") const {
+        auto it = m_values.find(key);
+        return it == m_values.end() ? defaultValue : it->second;
+    }
+
+    /// Serialize to "key=value" lines, one per key, in sorted key order.
+    std::string serialize() const {
+        std::string out;
+        for (const auto& kv : m_values) out += kv.first + "=" + kv.second + "\n";
+        return out;
+    }
+
+    /**
+     * @brief Parse "key=value" lines, merging into the current values.
+     *
+     * Blank lines and lines beginning with '#' or ';' are ignored. Whitespace
+     * around the key and value is trimmed. Existing keys are overwritten; keys not
+     * present in @p text are left as-is, so defaults set beforehand survive.
+     */
+    void load(const std::string& text) {
+        std::istringstream in(text);
+        std::string line;
+        while (std::getline(in, line)) {
+            const std::string trimmed = trim(line);
+            if (trimmed.empty() || trimmed[0] == '#' || trimmed[0] == ';') continue;
+            const std::size_t eq = trimmed.find('=');
+            if (eq == std::string::npos) continue;
+            const std::string key = trim(trimmed.substr(0, eq));
+            const std::string value = trim(trimmed.substr(eq + 1));
+            if (!key.empty()) m_values[key] = value;
+        }
+    }
+
+    /// Write the serialized settings to @p path (truncating). Returns success.
+    bool saveToFile(const std::string& path) const {
+        std::ofstream out(path, std::ios::trunc);
+        if (!out) return false;
+        out << serialize();
+        return static_cast<bool>(out);
+    }
+
+    /// Load and merge settings from @p path. Returns false if the file is absent.
+    bool loadFromFile(const std::string& path) {
+        std::ifstream in(path);
+        if (!in) return false;
+        std::stringstream ss;
+        ss << in.rdbuf();
+        load(ss.str());
+        return true;
+    }
+
+private:
+    static std::string floatToString(float value) {
+        std::ostringstream os;
+        os << value;
+        return os.str();
+    }
+
+    static std::string trim(const std::string& s) {
+        const std::size_t a = s.find_first_not_of(" \t\r\n");
+        const std::size_t b = s.find_last_not_of(" \t\r\n");
+        return a == std::string::npos ? std::string() : s.substr(a, b - a + 1);
+    }
+
+    std::map<std::string, std::string> m_values;
+};
+
+} // namespace IKore

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -56,6 +56,64 @@ static void drawProperty(const Property& prop) {
     }
 }
 
+// Draw one menu row with the widget matching its type. Mouse hover moves the menu
+// focus and mouse edits route through the same setters keyboard/gamepad use (#58).
+static void drawMenuItem(Menu& menu, int index, const MenuItem& item, bool focused) {
+    ImGui::PushID(index);
+    if (focused) {
+        ImGui::Bullet(); // focus marker
+        ImGui::SameLine();
+    }
+
+    switch (item.type) {
+        case MenuItemType::Label:
+            ImGui::TextDisabled("%s", item.label.c_str());
+            break;
+        case MenuItemType::Button:
+            if (ImGui::Selectable(item.label.c_str(), focused)) {
+                menu.setFocus(index);
+                menu.activate();
+            }
+            if (ImGui::IsItemHovered()) menu.setFocus(index);
+            break;
+        case MenuItemType::Toggle: {
+            bool v = item.getBool ? item.getBool() : false;
+            if (ImGui::Checkbox(item.label.c_str(), &v)) {
+                menu.setFocus(index);
+                if (item.setBool) item.setBool(v);
+            }
+            if (ImGui::IsItemHovered()) menu.setFocus(index);
+            break;
+        }
+        case MenuItemType::Slider: {
+            float v = item.getFloat ? item.getFloat() : 0.0f;
+            if (ImGui::SliderFloat(item.label.c_str(), &v, item.minValue, item.maxValue)) {
+                menu.setFocus(index);
+                if (item.setFloat) item.setFloat(v);
+            }
+            if (ImGui::IsItemHovered()) menu.setFocus(index);
+            break;
+        }
+        case MenuItemType::Choice: {
+            const int cur = item.getChoice ? item.getChoice() : 0;
+            const char* preview =
+                (cur >= 0 && cur < static_cast<int>(item.options.size())) ? item.options[cur].c_str() : "";
+            if (ImGui::BeginCombo(item.label.c_str(), preview)) {
+                for (int k = 0; k < static_cast<int>(item.options.size()); ++k) {
+                    if (ImGui::Selectable(item.options[k].c_str(), k == cur)) {
+                        menu.setFocus(index);
+                        if (item.setChoice) item.setChoice(k);
+                    }
+                }
+                ImGui::EndCombo();
+            }
+            if (ImGui::IsItemHovered()) menu.setFocus(index);
+            break;
+        }
+    }
+    ImGui::PopID();
+}
+
 bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     if (m_initialized) return true;
     if (window == nullptr) return false;
@@ -65,7 +123,8 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
 
     ImGuiIO& io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
-    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable; // allow panels to be docked together
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad; // menus (#58) support gamepad
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;    // allow panels to be docked together
 
     ImGui::StyleColorsDark();
 
@@ -123,6 +182,39 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     }
     installEcsBuilder(m_inspector, m_demoRegistry);
     if (!m_demoEntities.empty()) m_inspector.select(packEntity(m_demoEntities.front()));
+
+    // Interactive menus + persisted settings (#58). Defaults first, then load any
+    // saved values from disk (so a previous session's choices win), then build the
+    // menus on the navigation core and open the main menu.
+    m_settings.setBool("vsync", true);
+    m_settings.setFloat("volume", 0.8f);
+    m_settings.setInt("quality", 2); // index into {Low, Medium, High}
+    m_settings.loadFromFile("ikore_settings.ini");
+
+    m_settingsMenu.add(menuToggle("VSync", [this] { return m_settings.getBool("vsync"); },
+                                  [this](bool b) { m_settings.setBool("vsync", b); }));
+    m_settingsMenu.add(menuSlider("Master Volume", [this] { return m_settings.getFloat("volume"); },
+                                  [this](float v) { m_settings.setFloat("volume", v); }, 0.0f, 1.0f, 0.05f));
+    m_settingsMenu.add(menuChoice("Quality", {"Low", "Medium", "High"},
+                                  [this] { return m_settings.getInt("quality"); },
+                                  [this](int i) { m_settings.setInt("quality", i); }));
+    m_settingsMenu.add(menuButton("Back", [this] {
+        saveSettings();
+        m_menuStack.back();
+    }));
+
+    m_pauseMenu.add(menuButton("Resume", [this] { m_menuStack.closeAll(); }));
+    m_pauseMenu.add(menuButton("Settings", [this] { m_menuStack.open(&m_settingsMenu); }));
+    m_pauseMenu.add(menuButton("Main Menu", [this] {
+        m_menuStack.closeAll();
+        m_menuStack.open(&m_mainMenu);
+    }));
+
+    m_mainMenu.add(menuButton("Play", [this] { m_menuStack.closeAll(); }));
+    m_mainMenu.add(menuButton("Settings", [this] { m_menuStack.open(&m_settingsMenu); }));
+    m_mainMenu.add(menuButton("Quit", [this] { m_menuQuitRequested = true; }));
+
+    m_menuStack.open(&m_mainMenu);
 
     m_initialized = true;
     LOG_INFO("DebugUI: Dear ImGui initialized (press F1 to toggle)");
@@ -192,6 +284,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::SliderFloat("HUD scale (#61)", &m_hudScale, 0.5f, 2.0f, "%.2f");
     ImGui::Checkbox("Show entity inspector (#56)", &m_showInspector);
     ImGui::Checkbox("Show scene view / picking (#57)", &m_showPicking);
+    ImGui::Checkbox("Show menus (#58)", &m_showMenus);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
@@ -200,6 +293,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     renderHud();
     renderInspector();
     renderPicking();
+    renderMenus();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
@@ -357,6 +451,60 @@ void DebugUI::renderPicking() {
     }
 
     ImGui::End();
+}
+
+void DebugUI::saveSettings() { m_settings.saveToFile("ikore_settings.ini"); }
+
+void DebugUI::renderMenus() {
+    if (!m_showMenus) return;
+
+    // Map keyboard and gamepad input to menu actions. All input sources funnel
+    // through the same MenuAction stream, so navigation is identical for each; the
+    // mouse is handled per-item below (hover to focus, click to activate).
+    if (m_menuStack.isOpen()) {
+        if (ImGui::IsKeyPressed(ImGuiKey_UpArrow) || ImGui::IsKeyPressed(ImGuiKey_GamepadDpadUp))
+            m_menuStack.handle(MenuAction::Up);
+        if (ImGui::IsKeyPressed(ImGuiKey_DownArrow) || ImGui::IsKeyPressed(ImGuiKey_GamepadDpadDown))
+            m_menuStack.handle(MenuAction::Down);
+        if (ImGui::IsKeyPressed(ImGuiKey_LeftArrow) || ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft))
+            m_menuStack.handle(MenuAction::Left);
+        if (ImGui::IsKeyPressed(ImGuiKey_RightArrow) || ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight))
+            m_menuStack.handle(MenuAction::Right);
+        if (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_GamepadFaceDown))
+            m_menuStack.handle(MenuAction::Activate);
+        if (ImGui::IsKeyPressed(ImGuiKey_Escape) || ImGui::IsKeyPressed(ImGuiKey_GamepadFaceRight))
+            m_menuStack.handle(MenuAction::Back);
+    } else if (ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+        m_menuStack.open(&m_pauseMenu); // Escape opens the pause menu when idle
+    }
+
+    Menu* menu = m_menuStack.current();
+    if (menu == nullptr) return;
+
+    // Center the menu window using the HUD framework's anchoring (#55).
+    const ImGuiIO& io = ImGui::GetIO();
+    const HudVec2 size{340.0f, 320.0f};
+    const HudVec2 pos =
+        resolveAnchor(HudAnchor::Center, {io.DisplaySize.x, io.DisplaySize.y}, size, {0.0f, 0.0f});
+    ImGui::SetNextWindowPos(ImVec2(pos.x, pos.y), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(size.x, size.y), ImGuiCond_Always);
+
+    ImGui::Begin(menu->title().c_str(), nullptr,
+                 ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse |
+                     ImGuiWindowFlags_NoSavedSettings);
+    const std::vector<MenuItem>& items = menu->items();
+    for (int i = 0; i < static_cast<int>(items.size()); ++i) {
+        drawMenuItem(*menu, i, items[i], menu->focus() == i);
+    }
+    ImGui::End();
+
+    if (m_menuQuitRequested) {
+        // In the full engine this would signal the main loop to exit; here we just
+        // note it and drop back so the demo stays interactive.
+        LOG_INFO("DebugUI: menu Quit selected");
+        m_menuQuitRequested = false;
+        m_menuStack.closeAll();
+    }
 }
 
 void DebugUI::renderHud() {

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -3,11 +3,13 @@
 #include "core/DebugConsole.h"
 #include "core/PerfStats.h"
 #include "core/Picking.h"
+#include "core/Settings.h"
 #include "core/ecs/ECS.h"
 #include "core/ecs/components/Components.h"
 #include "ui/EcsInspector.h"
 #include "ui/EntityInspector.h"
 #include "ui/HudFramework.h"
+#include "ui/MenuSystem.h"
 
 #include <string>
 #include <vector>
@@ -90,6 +92,7 @@ private:
     void renderHud();
     void renderInspector();
     void renderPicking();
+    void renderMenus();
 
     bool m_initialized{false};
     bool m_visible{false};
@@ -99,6 +102,7 @@ private:
     bool m_showHud{true};
     bool m_showInspector{true};
     bool m_showPicking{true};
+    bool m_showMenus{true};
     float m_hudScale{1.0f};
     PerfStats m_perf;
     DebugConsole m_console;
@@ -123,6 +127,17 @@ private:
     // Viewport picking (#57): a top-down pick view over the demo scene that feeds
     // the inspector on click. The core math/state lives in core/Picking.h.
     pick::Picker m_picker;
+
+    // Interactive menus + persisted settings (#58). The menus are built on the
+    // navigation core and drawn centered via the HUD framework (#55); settings
+    // persist to disk. Menus are owned here; the stack holds pointers to them.
+    Settings m_settings;
+    Menu m_mainMenu{"Main Menu"};
+    Menu m_pauseMenu{"Paused"};
+    Menu m_settingsMenu{"Settings"};
+    MenuStack m_menuStack;
+    bool m_menuQuitRequested{false};
+    void saveSettings();
 };
 
 } // namespace IKore

--- a/src/ui/MenuSystem.h
+++ b/src/ui/MenuSystem.h
@@ -1,0 +1,288 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * @file MenuSystem.h
+ * @brief Interactive menu model: items, navigation, and a screen stack (issue #58).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless, renderer- and
+ * input-agnostic core behind the main / pause / settings menus: a Menu is a titled
+ * list of MenuItems (buttons, toggles, sliders, choices, labels) with a focus
+ * cursor; a MenuStack pushes and pops menus so submenus (Settings) layer over their
+ * parent. All input is funnelled through a single MenuAction enum, so keyboard,
+ * mouse, and gamepad produce the same actions and navigation is identical for each.
+ * Item values bind to live getters/setters (e.g. into the Settings store), so a
+ * toggle or slider edits the backing value directly.
+ *
+ * The ImGui panel in DebugUI draws the current menu (centered via the HUD framework
+ * #55) and maps key / pad / mouse events to MenuAction. Keeping the navigation and
+ * item logic here makes it unit-testable without a GL context. Header-only, std only.
+ */
+namespace IKore {
+
+/// A source-agnostic navigation action. The engine maps keys, gamepad buttons, and
+/// mouse events onto these, so all input types drive the menus identically.
+enum class MenuAction { Up, Down, Left, Right, Activate, Back };
+
+enum class MenuItemType { Button, Toggle, Slider, Choice, Label };
+
+/**
+ * @brief One row of a menu. Only the accessors matching @ref type are used.
+ *
+ * A plain aggregate; use the menu* helpers to build the common cases. Buttons run
+ * onActivate; toggles/sliders/choices read and write their bound value live.
+ */
+struct MenuItem {
+    std::string label;
+    MenuItemType type{MenuItemType::Button};
+    bool enabled{true};
+
+    std::function<void()> onActivate; // Button
+
+    std::function<bool()> getBool; // Toggle
+    std::function<void(bool)> setBool;
+
+    std::function<float()> getFloat; // Slider
+    std::function<void(float)> setFloat;
+    float minValue{0.0f};
+    float maxValue{1.0f};
+    float step{0.1f};
+
+    std::function<int()> getChoice; // Choice (index into options)
+    std::function<void(int)> setChoice;
+    std::vector<std::string> options;
+
+    /// Labels and disabled rows cannot take focus.
+    bool selectable() const { return enabled && type != MenuItemType::Label; }
+};
+
+inline MenuItem menuLabel(std::string text) {
+    MenuItem item;
+    item.label = std::move(text);
+    item.type = MenuItemType::Label;
+    return item;
+}
+
+inline MenuItem menuButton(std::string label, std::function<void()> onActivate) {
+    MenuItem item;
+    item.label = std::move(label);
+    item.type = MenuItemType::Button;
+    item.onActivate = std::move(onActivate);
+    return item;
+}
+
+inline MenuItem menuToggle(std::string label, std::function<bool()> get, std::function<void(bool)> set) {
+    MenuItem item;
+    item.label = std::move(label);
+    item.type = MenuItemType::Toggle;
+    item.getBool = std::move(get);
+    item.setBool = std::move(set);
+    return item;
+}
+
+inline MenuItem menuSlider(std::string label, std::function<float()> get, std::function<void(float)> set,
+                           float minValue, float maxValue, float step) {
+    MenuItem item;
+    item.label = std::move(label);
+    item.type = MenuItemType::Slider;
+    item.getFloat = std::move(get);
+    item.setFloat = std::move(set);
+    item.minValue = minValue;
+    item.maxValue = maxValue;
+    item.step = step;
+    return item;
+}
+
+inline MenuItem menuChoice(std::string label, std::vector<std::string> options,
+                           std::function<int()> get, std::function<void(int)> set) {
+    MenuItem item;
+    item.label = std::move(label);
+    item.type = MenuItemType::Choice;
+    item.options = std::move(options);
+    item.getChoice = std::move(get);
+    item.setChoice = std::move(set);
+    return item;
+}
+
+/**
+ * @brief A titled menu screen: a list of items with a focus cursor.
+ *
+ * Focus starts on the first selectable item and skips labels/disabled rows as it
+ * moves (wrapping at the ends). activate() triggers the focused item; adjustLeft/
+ * adjustRight change sliders, choices, and toggles.
+ */
+class Menu {
+public:
+    explicit Menu(std::string title = std::string()) : m_title(std::move(title)) {}
+
+    const std::string& title() const { return m_title; }
+    void setTitle(std::string title) { m_title = std::move(title); }
+
+    void add(MenuItem item) {
+        m_items.push_back(std::move(item));
+        if (m_focus < 0 && m_items.back().selectable()) {
+            m_focus = static_cast<int>(m_items.size()) - 1;
+        }
+    }
+
+    const std::vector<MenuItem>& items() const { return m_items; }
+    std::size_t count() const { return m_items.size(); }
+
+    int focus() const { return m_focus; }
+    bool hasFocus() const { return m_focus >= 0 && m_focus < static_cast<int>(m_items.size()); }
+
+    /// Set focus directly (e.g. mouse hover). Ignored if the row is not selectable.
+    void setFocus(int index) {
+        if (index >= 0 && index < static_cast<int>(m_items.size()) && m_items[index].selectable()) {
+            m_focus = index;
+        }
+    }
+
+    void focusNext() { moveFocus(+1); }
+    void focusPrev() { moveFocus(-1); }
+
+    /// Trigger the focused item: run a button, flip a toggle, cycle a choice.
+    bool activate() {
+        if (!hasFocus()) return false;
+        const MenuItem& item = m_items[static_cast<std::size_t>(m_focus)];
+        switch (item.type) {
+            case MenuItemType::Button:
+                if (item.onActivate) {
+                    item.onActivate();
+                    return true;
+                }
+                return false;
+            case MenuItemType::Toggle:
+                if (item.getBool && item.setBool) {
+                    item.setBool(!item.getBool());
+                    return true;
+                }
+                return false;
+            case MenuItemType::Choice:
+                return cycleChoice(item, +1, /*wrap=*/true);
+            case MenuItemType::Slider: // sliders are changed with left/right
+            case MenuItemType::Label:
+                return false;
+        }
+        return false;
+    }
+
+    bool adjustRight() { return adjust(+1); }
+    bool adjustLeft() { return adjust(-1); }
+
+private:
+    void moveFocus(int dir) {
+        const int n = static_cast<int>(m_items.size());
+        if (n == 0 || m_focus < 0) return;
+        int idx = m_focus;
+        for (int step = 0; step < n; ++step) {
+            idx = (idx + dir + n) % n;
+            if (m_items[static_cast<std::size_t>(idx)].selectable()) {
+                m_focus = idx;
+                return;
+            }
+        }
+    }
+
+    bool adjust(int dir) {
+        if (!hasFocus()) return false;
+        const MenuItem& item = m_items[static_cast<std::size_t>(m_focus)];
+        switch (item.type) {
+            case MenuItemType::Slider:
+                if (item.getFloat && item.setFloat) {
+                    float v = item.getFloat() + static_cast<float>(dir) * item.step;
+                    if (v < item.minValue) v = item.minValue;
+                    if (v > item.maxValue) v = item.maxValue;
+                    item.setFloat(v);
+                    return true;
+                }
+                return false;
+            case MenuItemType::Choice:
+                return cycleChoice(item, dir, /*wrap=*/false);
+            case MenuItemType::Toggle:
+                if (item.setBool) {
+                    item.setBool(dir > 0);
+                    return true;
+                }
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    static bool cycleChoice(const MenuItem& item, int dir, bool wrap) {
+        if (!item.getChoice || !item.setChoice || item.options.empty()) return false;
+        const int n = static_cast<int>(item.options.size());
+        int next = item.getChoice() + dir;
+        if (wrap) {
+            next = (next % n + n) % n;
+        } else {
+            if (next < 0) next = 0;
+            if (next >= n) next = n - 1;
+        }
+        item.setChoice(next);
+        return true;
+    }
+
+    std::string m_title;
+    std::vector<MenuItem> m_items;
+    int m_focus{-1};
+};
+
+/**
+ * @brief A stack of open menus. The top menu receives navigation; Back pops it.
+ *
+ * Menus are owned elsewhere (the stack holds non-owning pointers), so a button can
+ * push a submenu (open(&settings)) or return to the parent (back()). handle()
+ * routes a MenuAction to the current menu, which is all the engine needs to drive
+ * menus from any input source.
+ */
+class MenuStack {
+public:
+    void open(Menu* menu) {
+        if (menu != nullptr) m_stack.push_back(menu);
+    }
+    void back() {
+        if (!m_stack.empty()) m_stack.pop_back();
+    }
+    void closeAll() { m_stack.clear(); }
+
+    bool isOpen() const { return !m_stack.empty(); }
+    std::size_t depth() const { return m_stack.size(); }
+    Menu* current() const { return m_stack.empty() ? nullptr : m_stack.back(); }
+
+    void handle(MenuAction action) {
+        Menu* cur = current();
+        if (cur == nullptr) return;
+        switch (action) {
+            case MenuAction::Up:
+                cur->focusPrev();
+                break;
+            case MenuAction::Down:
+                cur->focusNext();
+                break;
+            case MenuAction::Left:
+                cur->adjustLeft();
+                break;
+            case MenuAction::Right:
+                cur->adjustRight();
+                break;
+            case MenuAction::Activate:
+                cur->activate();
+                break;
+            case MenuAction::Back:
+                back();
+                break;
+        }
+    }
+
+private:
+    std::vector<Menu*> m_stack;
+};
+
+} // namespace IKore

--- a/tests/test_menu_system.cpp
+++ b/tests/test_menu_system.cpp
@@ -1,0 +1,219 @@
+// Test for the interactive menu core - Milestone 9, #58.
+//
+// Verifies the headless menu model: focus navigation (skipping labels/disabled,
+// wrapping), item activation and adjustment (button/toggle/slider/choice), direct
+// focus (mouse hover), the menu stack (open/back/close, action routing), and that
+// the same MenuAction stream drives everything (so keyboard/mouse/gamepad behave
+// identically). Also checks menu items bound to the Settings store persist.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_menu_system.cpp -o test_menu_system
+
+#include "core/Settings.h"
+#include "ui/MenuSystem.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b) { return std::fabs(a - b) < 1e-4f; }
+
+static void testFocusNavigation() {
+    Menu menu("Main");
+    menu.add(menuLabel("== Title =="));                    // 0: not selectable
+    menu.add(menuButton("Play", [] {}));                   // 1
+    MenuItem disabled = menuButton("Locked", [] {});
+    disabled.enabled = false;
+    menu.add(disabled);                                    // 2: not selectable
+    menu.add(menuButton("Settings", [] {}));               // 3
+    menu.add(menuButton("Quit", [] {}));                   // 4
+
+    // Focus starts on the first selectable item (skips the label).
+    CHECK(menu.focus() == 1);
+
+    // Down skips the disabled row.
+    menu.focusNext();
+    CHECK(menu.focus() == 3);
+    menu.focusNext();
+    CHECK(menu.focus() == 4);
+    menu.focusNext(); // wraps past the end back to the first selectable
+    CHECK(menu.focus() == 1);
+
+    // Up wraps the other way, still skipping non-selectable rows.
+    menu.focusPrev();
+    CHECK(menu.focus() == 4);
+    menu.focusPrev();
+    CHECK(menu.focus() == 3);
+
+    // Direct focus (mouse hover) lands only on selectable rows.
+    menu.setFocus(1);
+    CHECK(menu.focus() == 1);
+    menu.setFocus(0); // label -> ignored
+    CHECK(menu.focus() == 1);
+    menu.setFocus(2); // disabled -> ignored
+    CHECK(menu.focus() == 1);
+}
+
+static void testButtonActivate() {
+    int plays = 0;
+    Menu menu("Main");
+    menu.add(menuButton("Play", [&plays] { ++plays; }));
+    menu.add(menuButton("Quit", [] {}));
+
+    CHECK(menu.focus() == 0);
+    CHECK(menu.activate());
+    CHECK(plays == 1);
+    menu.focusNext();
+    CHECK(menu.activate()); // Quit has an (empty) action, still handled
+    CHECK(plays == 1);
+}
+
+static void testToggleSliderChoice() {
+    bool fullscreen = false;
+    float volume = 0.5f;
+    int quality = 1; // index into {Low, Medium, High}
+
+    Menu menu("Settings");
+    menu.add(menuToggle("Fullscreen", [&fullscreen] { return fullscreen; },
+                        [&fullscreen](bool b) { fullscreen = b; }));
+    menu.add(menuSlider("Volume", [&volume] { return volume; }, [&volume](float v) { volume = v; }, 0.0f,
+                        1.0f, 0.1f));
+    menu.add(menuChoice("Quality", {"Low", "Medium", "High"}, [&quality] { return quality; },
+                        [&quality](int i) { quality = i; }));
+
+    // Toggle: activate flips; left/right force off/on.
+    CHECK(menu.focus() == 0);
+    menu.activate();
+    CHECK(fullscreen == true);
+    menu.adjustLeft();
+    CHECK(fullscreen == false);
+    menu.adjustRight();
+    CHECK(fullscreen == true);
+
+    // Slider: right/left step and clamp to [min, max].
+    menu.focusNext();
+    CHECK(menu.focus() == 1);
+    menu.adjustRight();
+    CHECK(approx(volume, 0.6f));
+    for (int i = 0; i < 10; ++i) menu.adjustRight();
+    CHECK(approx(volume, 1.0f)); // clamped at max
+    for (int i = 0; i < 20; ++i) menu.adjustLeft();
+    CHECK(approx(volume, 0.0f)); // clamped at min
+    CHECK(!menu.activate());     // Activate is a no-op on sliders
+
+    // Choice: right/left clamp; activate cycles with wrap.
+    menu.focusNext();
+    CHECK(menu.focus() == 2);
+    menu.adjustRight();
+    CHECK(quality == 2);
+    menu.adjustRight();
+    CHECK(quality == 2); // clamped at last
+    menu.adjustLeft();
+    menu.adjustLeft();
+    CHECK(quality == 0); // clamped at first
+    menu.activate();     // wrap cycle: 0 -> 1
+    CHECK(quality == 1);
+}
+
+static void testMenuStackNavigation() {
+    Menu mainMenu("Main");
+    Menu settingsMenu("Settings");
+    MenuStack stack;
+
+    // A "Settings" button opens the submenu; a "Back" button pops it.
+    mainMenu.add(menuButton("Settings", [&] { stack.open(&settingsMenu); }));
+    mainMenu.add(menuButton("Quit", [] {}));
+    settingsMenu.add(menuButton("Back", [&] { stack.back(); }));
+
+    CHECK(!stack.isOpen());
+    stack.open(&mainMenu);
+    CHECK(stack.isOpen());
+    CHECK(stack.depth() == 1);
+    CHECK(stack.current() == &mainMenu);
+
+    // Route actions through the stack (this is what all input sources call).
+    stack.handle(MenuAction::Activate); // focused item is "Settings" -> opens submenu
+    CHECK(stack.depth() == 2);
+    CHECK(stack.current() == &settingsMenu);
+
+    stack.handle(MenuAction::Activate); // "Back" -> pops back to main
+    CHECK(stack.depth() == 1);
+    CHECK(stack.current() == &mainMenu);
+
+    stack.handle(MenuAction::Back); // Back on the root pops it
+    CHECK(!stack.isOpen());
+    CHECK(stack.current() == nullptr);
+    stack.handle(MenuAction::Down); // routing to an empty stack is safe
+    CHECK(!stack.isOpen());
+
+    stack.open(&mainMenu);
+    stack.open(&settingsMenu);
+    stack.closeAll();
+    CHECK(!stack.isOpen());
+}
+
+static void testActionRoutingMovesFocus() {
+    // The same MenuAction stream (whatever the source) drives navigation.
+    Menu menu("Main");
+    menu.add(menuButton("A", [] {}));
+    menu.add(menuButton("B", [] {}));
+    menu.add(menuButton("C", [] {}));
+    MenuStack stack;
+    stack.open(&menu);
+
+    CHECK(menu.focus() == 0);
+    stack.handle(MenuAction::Down);
+    CHECK(menu.focus() == 1);
+    stack.handle(MenuAction::Down);
+    CHECK(menu.focus() == 2);
+    stack.handle(MenuAction::Up);
+    CHECK(menu.focus() == 1);
+}
+
+static void testSettingsBoundMenuPersists() {
+    // A settings menu bound to the Settings store: toggling a menu item changes the
+    // stored value, which then serializes - i.e. the change persists.
+    Settings settings;
+    settings.setBool("vsync", false);
+
+    Menu menu("Settings");
+    menu.add(menuToggle("VSync", [&settings] { return settings.getBool("vsync"); },
+                        [&settings](bool b) { settings.setBool("vsync", b); }));
+
+    CHECK(settings.getBool("vsync") == false);
+    menu.activate(); // flips the toggle -> writes into the store
+    CHECK(settings.getBool("vsync") == true);
+
+    const std::string serialized = settings.serialize();
+    Settings reloaded;
+    reloaded.load(serialized);
+    CHECK(reloaded.getBool("vsync") == true); // survived the round trip
+}
+
+int main() {
+    testFocusNavigation();
+    testButtonActivate();
+    testToggleSliderChoice();
+    testMenuStackNavigation();
+    testActionRoutingMovesFocus();
+    testSettingsBoundMenuPersists();
+
+    if (g_failures == 0) {
+        std::printf("All menu system tests passed.\n");
+        return 0;
+    }
+    std::printf("%d menu system test(s) failed.\n", g_failures);
+    return 1;
+}

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -1,0 +1,147 @@
+// Test for the persistent settings store - Milestone 9, #58.
+//
+// Verifies typed get/set with defaults, the "key=value" serialize/load round trip
+// (including comments, blank lines, and whitespace trimming), and persistence to
+// disk via saveToFile/loadFromFile (settings surviving across "sessions").
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_settings.cpp -o test_settings
+
+#include "core/Settings.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b) { return std::fabs(a - b) < 1e-4f; }
+
+static void testTypedGetSetAndDefaults() {
+    Settings s;
+    s.setBool("vsync", true);
+    s.setInt("width", 1920);
+    s.setFloat("volume", 0.75f);
+    s.setString("profile", "player1");
+
+    CHECK(s.getBool("vsync") == true);
+    CHECK(s.getInt("width") == 1920);
+    CHECK(approx(s.getFloat("volume"), 0.75f));
+    CHECK(s.getString("profile") == "player1");
+
+    // Missing keys fall back to the supplied default.
+    CHECK(s.getBool("missing", true) == true);
+    CHECK(s.getInt("missing", 42) == 42);
+    CHECK(approx(s.getFloat("missing", 1.5f), 1.5f));
+    CHECK(s.getString("missing", "def") == "def");
+
+    CHECK(s.has("vsync"));
+    CHECK(!s.has("nope"));
+    CHECK(s.size() == 4);
+}
+
+static void testBoolParsingVariants() {
+    Settings s;
+    s.load("a=true\nb=1\nc=on\nd=yes\ne=false\nf=0\ng=nonsense\n");
+    CHECK(s.getBool("a"));
+    CHECK(s.getBool("b"));
+    CHECK(s.getBool("c"));
+    CHECK(s.getBool("d"));
+    CHECK(!s.getBool("e"));
+    CHECK(!s.getBool("f"));
+    CHECK(!s.getBool("g")); // unrecognized -> false
+}
+
+static void testInvalidNumbersFallBack() {
+    Settings s;
+    s.setString("notnum", "abc");
+    CHECK(s.getInt("notnum", -1) == -1);
+    CHECK(approx(s.getFloat("notnum", -2.0f), -2.0f));
+}
+
+static void testSerializeRoundTrip() {
+    Settings a;
+    a.setBool("vsync", false);
+    a.setInt("quality", 2);
+    a.setFloat("volume", 0.5f);
+    a.setString("name", "IKore");
+
+    const std::string text = a.serialize();
+
+    Settings b;
+    b.load(text);
+    CHECK(b.getBool("vsync") == false);
+    CHECK(b.getInt("quality") == 2);
+    CHECK(approx(b.getFloat("volume"), 0.5f));
+    CHECK(b.getString("name") == "IKore");
+    CHECK(b.size() == a.size());
+}
+
+static void testLoadMergesAndIgnoresJunk() {
+    Settings s;
+    s.setInt("keep", 7);       // pre-existing default that should survive
+    s.setInt("quality", 0);    // will be overwritten by load
+    s.load("# a comment\n"
+           "; another comment\n"
+           "\n"
+           "  quality = 3  \n"  // whitespace around key and value is trimmed
+           "volume=0.9\n"
+           "malformed line without equals\n");
+
+    CHECK(s.getInt("keep") == 7);       // untouched key survives (merge)
+    CHECK(s.getInt("quality") == 3);    // overwritten, trimmed
+    CHECK(approx(s.getFloat("volume"), 0.9f));
+    CHECK(!s.has("malformed line without equals"));
+}
+
+static void testPersistAcrossSessions() {
+    const std::string path = "ikore_settings_test.ini";
+
+    // "Session 1" writes settings to disk.
+    Settings first;
+    first.setBool("fullscreen", true);
+    first.setInt("width", 2560);
+    first.setFloat("gamma", 1.2f);
+    CHECK(first.saveToFile(path));
+
+    // "Session 2" starts fresh and loads them back.
+    Settings second;
+    CHECK(second.loadFromFile(path));
+    CHECK(second.getBool("fullscreen") == true);
+    CHECK(second.getInt("width") == 2560);
+    CHECK(approx(second.getFloat("gamma"), 1.2f));
+
+    // Loading a non-existent file reports failure and leaves values untouched.
+    Settings third;
+    third.setInt("x", 5);
+    CHECK(!third.loadFromFile("this_file_does_not_exist_98765.ini"));
+    CHECK(third.getInt("x") == 5);
+
+    std::remove(path.c_str());
+}
+
+int main() {
+    testTypedGetSetAndDefaults();
+    testBoolParsingVariants();
+    testInvalidNumbersFallBack();
+    testSerializeRoundTrip();
+    testLoadMergesAndIgnoresJunk();
+    testPersistAcrossSessions();
+
+    if (g_failures == 0) {
+        std::printf("All settings tests passed.\n");
+        return 0;
+    }
+    std::printf("%d settings test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Adds main / pause / settings menus built on a navigation core, drawn centered via the HUD framework (#55), with settings that persist across sessions. Follows the same split proven by #53-#57: headless, unit-tested cores plus a thin ImGui panel wired into `DebugUI`.

Closes #58

## Menu core: `src/ui/MenuSystem.h` (header-only, std only)

- `MenuItem`: button / toggle / slider / choice / label, each with live get/set bindings; `menu*` helpers build the common cases.
- `Menu`: a titled item list with a focus cursor that skips labels/disabled rows and wraps at the ends. `activate()` runs a button, flips a toggle, or cycles a choice; `adjustLeft` / `adjustRight` change sliders/choices/toggles; `setFocus` is used by mouse hover.
- `MenuStack`: a stack of open menus so submenus (Settings) layer over their parent; `handle(MenuAction)` routes to the current menu and `Back` pops it. All input is funnelled through one source-agnostic `MenuAction` enum, so keyboard, mouse, and gamepad drive navigation identically.

## Settings core: `src/core/Settings.h` (header-only, std only)

- Typed get/set (`bool` / `int` / `float` / `string`) with caller-supplied defaults for missing/unparsable keys.
- `serialize()` to `key=value` lines and `load()` back (ignoring `#`/`;` comments and blank lines, trimming whitespace, merging over existing keys so pre-set defaults survive).
- `saveToFile()` / `loadFromFile()` round-trip to disk, so settings persist across sessions.

## Panel: `src/ui/DebugUI`

- Main / pause / settings menus wired on the cores. The settings menu binds directly to the `Settings` store (VSync toggle, master-volume slider, quality choice) and saves on `Back`; `Escape` opens the pause menu and backs out of open menus.
- Keyboard and gamepad map to `MenuAction` (gamepad nav flag enabled); the mouse drives focus on hover and activation on click, per item. Persisted values load on init and the main menu opens.
- The menu window is centered using the HUD framework's `resolveAnchor(HudAnchor::Center, ...)` (#55 reuse).

## Testing

- `tests/test_settings.cpp`: typed get/set + defaults, bool parsing variants, `serialize`/`load` round-trip, merge + comment + whitespace handling, invalid-number fallback, and `saveToFile`/`loadFromFile` persistence across two "sessions".
- `tests/test_menu_system.cpp`: focus navigation (skipping labels/disabled, wrapping), button/toggle/slider/choice behavior (including clamping and choice wrap), mouse-style direct focus, the menu stack (open/back/close and action routing, including safe routing to an empty stack), and a settings-bound menu item whose change survives a serialize round-trip.
- Both pass locally under ASan/UBSan.
- New CMake targets `test_settings` and `test_menu_system`.
- The ImGui panel is compiled by CI (CodeQL c-cpp build).

## Acceptance criteria

- Menus open, close, and navigate correctly with all input types: navigation, activation, and stack transitions are covered in the unit tests via the shared `MenuAction` stream that keyboard, mouse, and gamepad all feed; the panel maps each input source onto it.
- Settings changes persist across sessions: verified by `saveToFile` then `loadFromFile` into a fresh `Settings` (and a menu-bound toggle surviving a serialize round-trip); the panel loads `ikore_settings.ini` on init and saves on leaving the settings menu.

## Notes

- Additive: no behavior change to existing panels. The menus/settings run self-contained in `DebugUI` (mirroring the #55-#57 demos); the same cores drop into the real game loop by mapping engine input to `MenuAction` and pointing `Settings` at the game's config path.