### PR TITLE
[M9] Add scene hierarchy viewer (#59)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,6 +640,11 @@ add_executable(test_menu_system
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_menu_system.cpp
 )
 
+# Scene hierarchy core (Milestone 9 / #59) - header-only.
+add_executable(test_scene_hierarchy
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_scene_hierarchy.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -6,6 +6,7 @@
 
 #include "core/Logger.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <string>
@@ -183,6 +184,14 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     installEcsBuilder(m_inspector, m_demoRegistry);
     if (!m_demoEntities.empty()) m_inspector.select(packEntity(m_demoEntities.front()));
 
+    // Scene hierarchy (#59) mirroring the demo entities; Prop nests under Player to
+    // show a parent/child relationship. Selecting a node drives the inspector.
+    if (m_demoEntities.size() >= 3) {
+        m_hierarchy.add(packEntity(m_demoEntities[0]), "Player");
+        m_hierarchy.add(packEntity(m_demoEntities[1]), "Enemy");
+        m_hierarchy.add(packEntity(m_demoEntities[2]), "Prop", packEntity(m_demoEntities[0]));
+    }
+
     // Interactive menus + persisted settings (#58). Defaults first, then load any
     // saved values from disk (so a previous session's choices win), then build the
     // menus on the navigation core and open the main menu.
@@ -285,6 +294,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::Checkbox("Show entity inspector (#56)", &m_showInspector);
     ImGui::Checkbox("Show scene view / picking (#57)", &m_showPicking);
     ImGui::Checkbox("Show menus (#58)", &m_showMenus);
+    ImGui::Checkbox("Show scene hierarchy (#59)", &m_showHierarchy);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
@@ -294,6 +304,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     renderInspector();
     renderPicking();
     renderMenus();
+    renderHierarchy();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
@@ -505,6 +516,86 @@ void DebugUI::renderMenus() {
         m_menuQuitRequested = false;
         m_menuStack.closeAll();
     }
+}
+
+void DebugUI::renderHierarchy() {
+    if (!m_showHierarchy) return;
+
+    ImGui::Begin("Scene Hierarchy", &m_showHierarchy);
+
+    // Create/Delete stay in sync with the demo registry, so the tree reflects the
+    // live scene as entities are created and destroyed.
+    if (ImGui::Button("Create")) {
+        ecs::Entity created = m_demoRegistry.create();
+        m_demoRegistry.add<ecs::Transform>(created, ecs::Transform{});
+        m_demoEntities.push_back(created);
+        const SceneHierarchy::NodeId id = packEntity(created);
+        m_hierarchy.add(id, "Entity " + std::to_string(m_nextEntityLabel++));
+        m_inspector.select(id);
+    }
+    ImGui::SameLine();
+    const bool haveSelection = m_inspector.hasSelection() && m_hierarchy.exists(m_inspector.selected());
+    if (ImGui::Button("Delete") && haveSelection) {
+        const SceneHierarchy::NodeId id = m_inspector.selected();
+        for (const SceneHierarchy::NodeId gone : m_hierarchy.subtree(id)) {
+            const ecs::Entity entity = unpackEntity(gone);
+            if (m_demoRegistry.isValid(entity)) m_demoRegistry.destroy(entity);
+            m_demoEntities.erase(std::remove_if(m_demoEntities.begin(), m_demoEntities.end(),
+                                                [entity](ecs::Entity x) { return x == entity; }),
+                                 m_demoEntities.end());
+        }
+        m_hierarchy.remove(id, /*recursive=*/true);
+        m_inspector.deselect();
+    }
+
+    // Rename and reparent the current selection (re-checked after any delete above).
+    if (m_inspector.hasSelection() && m_hierarchy.exists(m_inspector.selected())) {
+        const SceneHierarchy::NodeId sel = m_inspector.selected();
+        if (sel != m_renameFor) {
+            std::snprintf(m_renameBuffer, sizeof(m_renameBuffer), "%s", m_hierarchy.name(sel).c_str());
+            m_renameFor = sel;
+        }
+        if (ImGui::InputText("Name", m_renameBuffer, sizeof(m_renameBuffer),
+                             ImGuiInputTextFlags_EnterReturnsTrue)) {
+            m_hierarchy.rename(sel, m_renameBuffer);
+        }
+
+        const SceneHierarchy::NodeId curParent = m_hierarchy.parent(sel);
+        const char* preview =
+            curParent == SceneHierarchy::kNoNode ? "(root)" : m_hierarchy.name(curParent).c_str();
+        if (ImGui::BeginCombo("Parent", preview)) {
+            if (ImGui::Selectable("(root)", curParent == SceneHierarchy::kNoNode)) {
+                m_hierarchy.reparent(sel, SceneHierarchy::kNoNode);
+            }
+            for (const auto& entry : m_hierarchy.flatten()) {
+                const SceneHierarchy::NodeId id = entry.first;
+                if (id == sel || m_hierarchy.isAncestor(sel, id)) continue; // no self / descendants
+                if (ImGui::Selectable(m_hierarchy.name(id).c_str(), id == curParent)) {
+                    m_hierarchy.reparent(sel, id); // guarded against cycles anyway
+                }
+            }
+            ImGui::EndCombo();
+        }
+    } else {
+        m_renameFor = SceneHierarchy::kNoNode;
+    }
+
+    ImGui::Separator();
+
+    // Flat, indented listing. flatten() returns a snapshot, so selecting mid-list
+    // never invalidates the iteration.
+    for (const auto& entry : m_hierarchy.flatten()) {
+        const SceneHierarchy::NodeId id = entry.first;
+        const int depth = entry.second;
+        ImGui::PushID(static_cast<int>(id & 0xFFFFFFFFu));
+        if (depth > 0) ImGui::Indent(static_cast<float>(depth) * 16.0f);
+        const bool selected = m_inspector.hasSelection() && m_inspector.selected() == id;
+        if (ImGui::Selectable(m_hierarchy.name(id).c_str(), selected)) m_inspector.select(id);
+        if (depth > 0) ImGui::Unindent(static_cast<float>(depth) * 16.0f);
+        ImGui::PopID();
+    }
+
+    ImGui::End();
 }
 
 void DebugUI::renderHud() {

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -10,6 +10,7 @@
 #include "ui/EntityInspector.h"
 #include "ui/HudFramework.h"
 #include "ui/MenuSystem.h"
+#include "ui/SceneHierarchy.h"
 
 #include <string>
 #include <vector>
@@ -93,6 +94,7 @@ private:
     void renderInspector();
     void renderPicking();
     void renderMenus();
+    void renderHierarchy();
 
     bool m_initialized{false};
     bool m_visible{false};
@@ -103,6 +105,7 @@ private:
     bool m_showInspector{true};
     bool m_showPicking{true};
     bool m_showMenus{true};
+    bool m_showHierarchy{true};
     float m_hudScale{1.0f};
     PerfStats m_perf;
     DebugConsole m_console;
@@ -138,6 +141,13 @@ private:
     MenuStack m_menuStack;
     bool m_menuQuitRequested{false};
     void saveSettings();
+
+    // Scene hierarchy (#59): a tree over the demo entities, kept in sync as they are
+    // created/destroyed; selecting a node drives the inspector (#56).
+    SceneHierarchy m_hierarchy;
+    char m_renameBuffer[64]{};
+    SceneHierarchy::NodeId m_renameFor{SceneHierarchy::kNoNode};
+    int m_nextEntityLabel{1};
 };
 
 } // namespace IKore

--- a/src/ui/SceneHierarchy.h
+++ b/src/ui/SceneHierarchy.h
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+/**
+ * @file SceneHierarchy.h
+ * @brief Scene hierarchy model: named entities and parent/child links (issue #59).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless core behind the ImGui
+ * scene hierarchy panel: track entities by id with a display name and parent/child
+ * relationships, and support the panel's edits - rename, reparent (with cycle
+ * prevention), and delete (recursive, or promoting children to the parent). The
+ * engine keeps this in sync with the live scene (add on create, remove on destroy)
+ * and uses the node ids - the same packed entity ids the inspector/picking use - to
+ * drive selection into the entity inspector (#56).
+ *
+ * Ids are opaque; the hierarchy stores only names and links, not component data, so
+ * it stays decoupled from the ECS and is unit-testable on its own. Header-only,
+ * std only.
+ */
+namespace IKore {
+
+class SceneHierarchy {
+public:
+    using NodeId = std::uint64_t;
+    /// Sentinel meaning "no node" / the virtual root that top-level entities hang off.
+    static constexpr NodeId kNoNode = ~NodeId{0};
+
+    /**
+     * @brief Add an entity with a display name under @p parent (kNoNode = top level).
+     * @return false if the id is the sentinel, already exists, or @p parent is unknown.
+     */
+    bool add(NodeId id, std::string name, NodeId parent = kNoNode) {
+        if (id == kNoNode || m_nodes.count(id) != 0) return false;
+        if (parent != kNoNode && !exists(parent)) return false;
+        Node node;
+        node.name = std::move(name);
+        node.parent = parent;
+        m_nodes.emplace(id, std::move(node));
+        childListOf(parent).push_back(id);
+        return true;
+    }
+
+    bool exists(NodeId id) const { return m_nodes.count(id) != 0; }
+    std::size_t size() const { return m_nodes.size(); }
+    void clear() {
+        m_nodes.clear();
+        m_roots.clear();
+    }
+
+    /**
+     * @brief Remove an entity.
+     * @param recursive true: delete the whole subtree; false: promote children to
+     *                  this node's parent before removing it.
+     * @return false if the id is unknown.
+     */
+    bool remove(NodeId id, bool recursive = true) {
+        auto it = m_nodes.find(id);
+        if (it == m_nodes.end()) return false;
+        const NodeId parent = it->second.parent;
+
+        if (recursive) {
+            for (const NodeId victim : subtree(id)) m_nodes.erase(victim);
+        } else {
+            const std::vector<NodeId> kids = it->second.children; // copy before edits
+            for (const NodeId child : kids) {
+                m_nodes[child].parent = parent;
+                childListOf(parent).push_back(child);
+            }
+            m_nodes.erase(id);
+        }
+        removeChildLink(parent, id);
+        return true;
+    }
+
+    bool rename(NodeId id, std::string name) {
+        auto it = m_nodes.find(id);
+        if (it == m_nodes.end()) return false;
+        it->second.name = std::move(name);
+        return true;
+    }
+
+    const std::string& name(NodeId id) const {
+        static const std::string empty;
+        auto it = m_nodes.find(id);
+        return it == m_nodes.end() ? empty : it->second.name;
+    }
+
+    /**
+     * @brief Move @p id under @p newParent (kNoNode = top level).
+     * @return false if either id is unknown, they are the same, or the move would
+     *         create a cycle (newParent is a descendant of id). A no-op move to the
+     *         current parent succeeds.
+     */
+    bool reparent(NodeId id, NodeId newParent) {
+        auto it = m_nodes.find(id);
+        if (it == m_nodes.end()) return false;
+        if (newParent != kNoNode && !exists(newParent)) return false;
+        if (newParent == id || isAncestor(id, newParent)) return false;
+
+        const NodeId old = it->second.parent;
+        if (old == newParent) return true;
+        removeChildLink(old, id);
+        it->second.parent = newParent;
+        childListOf(newParent).push_back(id);
+        return true;
+    }
+
+    NodeId parent(NodeId id) const {
+        auto it = m_nodes.find(id);
+        return it == m_nodes.end() ? kNoNode : it->second.parent;
+    }
+
+    /// Children of @p id (top-level entities for kNoNode); empty if @p id is unknown.
+    const std::vector<NodeId>& children(NodeId id) const {
+        if (id == kNoNode) return m_roots;
+        auto it = m_nodes.find(id);
+        return it == m_nodes.end() ? emptyList() : it->second.children;
+    }
+
+    const std::vector<NodeId>& roots() const { return m_roots; }
+
+    /// True if @p ancestor is a (strict) ancestor of @p of.
+    bool isAncestor(NodeId ancestor, NodeId of) const {
+        NodeId cur = parent(of);
+        while (cur != kNoNode) {
+            if (cur == ancestor) return true;
+            cur = parent(cur);
+        }
+        return false;
+    }
+
+    /// All ids in the subtree rooted at @p id (including @p id).
+    std::vector<NodeId> subtree(NodeId id) const {
+        std::vector<NodeId> out;
+        if (!exists(id)) return out;
+        std::vector<NodeId> stack{id};
+        while (!stack.empty()) {
+            const NodeId cur = stack.back();
+            stack.pop_back();
+            out.push_back(cur);
+            auto it = m_nodes.find(cur);
+            if (it != m_nodes.end()) {
+                for (const NodeId child : it->second.children) stack.push_back(child);
+            }
+        }
+        return out;
+    }
+
+    /// Depth-first preorder listing of (id, depth), for flat rendering.
+    std::vector<std::pair<NodeId, int>> flatten() const {
+        std::vector<std::pair<NodeId, int>> out;
+        for (const NodeId root : m_roots) flattenInto(root, 0, out);
+        return out;
+    }
+
+private:
+    struct Node {
+        std::string name;
+        NodeId parent{kNoNode};
+        std::vector<NodeId> children;
+    };
+
+    static const std::vector<NodeId>& emptyList() {
+        static const std::vector<NodeId> empty;
+        return empty;
+    }
+
+    std::vector<NodeId>& childListOf(NodeId parent) {
+        if (parent == kNoNode) return m_roots;
+        return m_nodes[parent].children; // callers guarantee parent exists
+    }
+
+    void removeChildLink(NodeId parent, NodeId child) {
+        std::vector<NodeId>& list = childListOf(parent);
+        list.erase(std::remove(list.begin(), list.end(), child), list.end());
+    }
+
+    void flattenInto(NodeId id, int depth, std::vector<std::pair<NodeId, int>>& out) const {
+        out.emplace_back(id, depth);
+        auto it = m_nodes.find(id);
+        if (it != m_nodes.end()) {
+            for (const NodeId child : it->second.children) flattenInto(child, depth + 1, out);
+        }
+    }
+
+    std::unordered_map<NodeId, Node> m_nodes;
+    std::vector<NodeId> m_roots;
+};
+
+} // namespace IKore

--- a/tests/test_scene_hierarchy.cpp
+++ b/tests/test_scene_hierarchy.cpp
@@ -1,0 +1,191 @@
+// Test for the scene hierarchy core - Milestone 9, #59.
+//
+// Verifies the headless tree model behind the ImGui hierarchy panel: add/remove
+// (recursive and promoting), rename, reparent with cycle prevention, ancestor
+// queries, preorder flattening, and that it tracks a live create/destroy sequence.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_scene_hierarchy.cpp -o test_scene_hierarchy
+
+#include "ui/SceneHierarchy.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using NodeId = SceneHierarchy::NodeId;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool contains(const std::vector<NodeId>& v, NodeId id) {
+    return std::find(v.begin(), v.end(), id) != v.end();
+}
+
+static void testAddAndQuery() {
+    SceneHierarchy h;
+    CHECK(h.add(1, "Root A"));
+    CHECK(h.add(2, "Root B"));
+    CHECK(h.add(3, "Child of A", 1));
+    CHECK(h.add(4, "Grandchild", 3));
+
+    CHECK(h.size() == 4);
+    CHECK(h.exists(1) && h.exists(4));
+    CHECK(!h.exists(99));
+
+    // Duplicate id and unknown parent are rejected.
+    CHECK(!h.add(1, "dup"));
+    CHECK(!h.add(5, "orphan", 42));
+    CHECK(!h.add(SceneHierarchy::kNoNode, "sentinel"));
+
+    CHECK(h.roots().size() == 2);
+    CHECK(contains(h.roots(), 1) && contains(h.roots(), 2));
+    CHECK(contains(h.children(1), 3));
+    CHECK(h.children(3).size() == 1 && contains(h.children(3), 4));
+    CHECK(h.parent(3) == 1);
+    CHECK(h.parent(1) == SceneHierarchy::kNoNode);
+    CHECK(h.name(3) == "Child of A");
+    CHECK(h.name(99).empty()); // unknown id -> empty name
+}
+
+static void testRename() {
+    SceneHierarchy h;
+    h.add(1, "Old");
+    CHECK(h.rename(1, "New"));
+    CHECK(h.name(1) == "New");
+    CHECK(!h.rename(99, "x"));
+}
+
+static void testAncestorAndReparent() {
+    SceneHierarchy h;
+    h.add(1, "A");
+    h.add(2, "B", 1);
+    h.add(3, "C", 2); // A > B > C
+
+    CHECK(h.isAncestor(1, 3));
+    CHECK(h.isAncestor(1, 2));
+    CHECK(!h.isAncestor(3, 1));
+
+    // Move C from under B to under A.
+    CHECK(h.reparent(3, 1));
+    CHECK(h.parent(3) == 1);
+    CHECK(!contains(h.children(2), 3));
+    CHECK(contains(h.children(1), 3));
+
+    // Reparent to top level.
+    CHECK(h.reparent(3, SceneHierarchy::kNoNode));
+    CHECK(h.parent(3) == SceneHierarchy::kNoNode);
+    CHECK(contains(h.roots(), 3));
+
+    // Cycle prevention: cannot move A under its descendant B, nor under itself, nor
+    // to an unknown parent. Structure must be unchanged after a rejected move.
+    CHECK(!h.reparent(1, 2));
+    CHECK(!h.reparent(1, 1));
+    CHECK(!h.reparent(1, 424242));
+    CHECK(h.parent(1) == SceneHierarchy::kNoNode);
+    CHECK(contains(h.children(1), 2));
+
+    // No-op reparent to the current parent succeeds.
+    CHECK(h.reparent(2, 1));
+}
+
+static void testRemoveRecursive() {
+    SceneHierarchy h;
+    h.add(1, "A");
+    h.add(2, "B", 1);
+    h.add(3, "C", 2);
+    h.add(4, "D", 1);
+
+    CHECK(h.subtree(1).size() == 4); // A, B, C, D
+    CHECK(h.subtree(2).size() == 2); // B, C (the subtree about to be removed)
+    CHECK(h.remove(2, /*recursive=*/true)); // removes B and C
+    CHECK(!h.exists(2));
+    CHECK(!h.exists(3));
+    CHECK(h.exists(1) && h.exists(4));
+    CHECK(!contains(h.children(1), 2));
+    CHECK(h.size() == 2);
+
+    CHECK(!h.remove(999));
+}
+
+static void testRemovePromotingChildren() {
+    SceneHierarchy h;
+    h.add(1, "A");
+    h.add(2, "B", 1);
+    h.add(3, "C", 2);
+    h.add(4, "D", 2);
+
+    // Remove B without recursion: its children move up to A.
+    CHECK(h.remove(2, /*recursive=*/false));
+    CHECK(!h.exists(2));
+    CHECK(h.exists(3) && h.exists(4));
+    CHECK(h.parent(3) == 1);
+    CHECK(h.parent(4) == 1);
+    CHECK(contains(h.children(1), 3) && contains(h.children(1), 4));
+    CHECK(!contains(h.children(1), 2));
+}
+
+static void testFlattenPreorder() {
+    SceneHierarchy h;
+    h.add(1, "A");
+    h.add(2, "B", 1);
+    h.add(3, "C", 1);
+    h.add(4, "B1", 2);
+    // A(0) > [ B(1) > B1(2), C(1) ]
+    const std::vector<std::pair<NodeId, int>> flat = h.flatten();
+    CHECK(flat.size() == 4);
+    CHECK(flat[0].first == 1u && flat[0].second == 0);
+    CHECK(flat[1].first == 2u && flat[1].second == 1);
+    CHECK(flat[2].first == 4u && flat[2].second == 2);
+    CHECK(flat[3].first == 3u && flat[3].second == 1);
+}
+
+static void testTracksLiveSceneChanges() {
+    // Mirrors the engine adding on create and removing on destroy: the hierarchy
+    // reflects the live set of entities as it changes.
+    SceneHierarchy h;
+    CHECK(h.size() == 0);
+    for (NodeId id = 1; id <= 5; ++id) h.add(id, "E" + std::to_string(id));
+    CHECK(h.size() == 5);
+    CHECK(h.roots().size() == 5);
+
+    h.remove(3);
+    h.remove(5);
+    CHECK(h.size() == 3);
+    CHECK(!h.exists(3) && !h.exists(5));
+    CHECK(h.exists(1) && h.exists(2) && h.exists(4));
+
+    h.add(6, "E6");
+    CHECK(h.size() == 4);
+    CHECK(contains(h.roots(), 6));
+
+    h.clear();
+    CHECK(h.size() == 0);
+    CHECK(h.roots().empty());
+}
+
+int main() {
+    testAddAndQuery();
+    testRename();
+    testAncestorAndReparent();
+    testRemoveRecursive();
+    testRemovePromotingChildren();
+    testFlattenPreorder();
+    testTracksLiveSceneChanges();
+
+    if (g_failures == 0) {
+        std::printf("All scene hierarchy tests passed.\n");
+        return 0;
+    }
+    std::printf("%d scene hierarchy test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Adds a scene hierarchy panel that lists entities and their parent/child relationships and drives the entity inspector (#56), following the same split proven by #53-#58: a headless, unit-tested core plus a thin ImGui panel wired into `DebugUI`.

Closes #59

## Core: `src/ui/SceneHierarchy.h` (header-only, std only)

Stores only names and links (not component data), so it stays decoupled from the ECS and is unit-testable on its own.

- Track entities by opaque id (the same packed entity ids the inspector and picking use) with a display name and parent/child links.
- `add()` under a parent or at top level; `remove()` either recursively (delete the subtree) or promoting children to the parent; `rename()`; and `reparent()` with cycle prevention (rejects moving a node under itself or a descendant, and unknown parents).
- Queries: `exists`/`size`, `parent`/`children`/`roots`, `isAncestor`, `subtree` (all ids under a node), and `flatten()` for a preorder `(id, depth)` listing.

## Panel: `src/ui/DebugUI`

- A "Scene Hierarchy" window with **Create**/**Delete** that stay in sync with the demo registry, so the tree reflects the live scene as entities are created and destroyed. Delete removes the whole subtree from both the registry and the hierarchy and clears the selection.
- A rename field and a reparent combo (listing only valid, non-descendant parents) for the current selection.
- A flat, indented listing where selecting a node feeds the inspector via `inspector().select(...)`. Structural edits happen before the snapshot-based (`flatten()`) listing is drawn, so navigation never invalidates iteration or crashes.

## Testing

- `tests/test_scene_hierarchy.cpp` covers add/query (including duplicate-id and unknown-parent rejection), rename, ancestor checks and reparent (with cycle prevention and no-op moves), recursive delete and delete-promoting-children, preorder flattening with depths, and tracking a live create/destroy/clear sequence.
- Passes locally under ASan/UBSan (`All scene hierarchy tests passed.`).
- New CMake target `test_scene_hierarchy`.
- The ImGui panel is compiled by CI (CodeQL c-cpp build).

## Acceptance criteria

- The hierarchy reflects the live scene, updating as entities are created or destroyed: the core tracks the live id set (verified by the create/destroy test), and the panel's Create/Delete drive the demo registry and hierarchy together.
- Selection drives the inspector and edits apply without crashes: selecting a node calls `inspector().select(id)`; rename/reparent/delete are guarded (cycle prevention, safe handling of unknown/stale ids, deferred structural edits), and the whole core passes under ASan/UBSan.

## Notes

- Additive: no behavior change to existing panels. The tree runs over the self-contained demo scene owned by `DebugUI` (mirroring #55-#58); pointing it at the real scene is a matter of mirroring the game's entity create/destroy into `add`/`remove`.