### PR TITLE
[M9] Add input remapping panel (#60)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -645,6 +645,11 @@ add_executable(test_scene_hierarchy
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_scene_hierarchy.cpp
 )
 
+# Input remapping core (Milestone 9 / #60) - header-only.
+add_executable(test_input_map
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_input_map.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/InputMap.h
+++ b/src/core/InputMap.h
@@ -1,0 +1,216 @@
+#pragma once
+
+#include <cstddef>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @file InputMap.h
+ * @brief Rebindable action -> input map with conflict detection (issue #60).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless core behind the input
+ * remapping panel: named game actions each bound to an input (a keyboard key, a
+ * mouse button, or a gamepad button, identified by device + integer code). Rebinding
+ * an action updates its binding in place so it takes effect immediately; bindings
+ * serialize to a simple text form and round-trip to disk so they persist across
+ * sessions; and conflicts (two actions on the same input) are detected so the panel
+ * can flag them.
+ *
+ * Codes are opaque integers (the engine uses ImGui key / mouse-button values), so
+ * the core needs no ImGui or GLFW and is unit-testable on its own. Header-only.
+ */
+namespace IKore {
+
+enum class InputDevice { None, Keyboard, Mouse, Gamepad };
+
+struct InputBinding {
+    InputDevice device{InputDevice::None};
+    int code{-1};
+
+    bool bound() const { return device != InputDevice::None; }
+    bool operator==(const InputBinding& o) const { return device == o.device && code == o.code; }
+    bool operator!=(const InputBinding& o) const { return !(*this == o); }
+};
+
+inline const char* deviceName(InputDevice device) {
+    switch (device) {
+        case InputDevice::Keyboard: return "keyboard";
+        case InputDevice::Mouse: return "mouse";
+        case InputDevice::Gamepad: return "gamepad";
+        case InputDevice::None: return "none";
+    }
+    return "none";
+}
+
+inline InputDevice deviceFromName(const std::string& name) {
+    if (name == "keyboard") return InputDevice::Keyboard;
+    if (name == "mouse") return InputDevice::Mouse;
+    if (name == "gamepad") return InputDevice::Gamepad;
+    return InputDevice::None;
+}
+
+/// Serialize a binding as "device:code", or "none" when unbound.
+inline std::string toString(const InputBinding& binding) {
+    if (!binding.bound()) return "none";
+    return std::string(deviceName(binding.device)) + ":" + std::to_string(binding.code);
+}
+
+/// Parse a "device:code" binding; returns an unbound binding on anything invalid.
+inline InputBinding bindingFromString(const std::string& text) {
+    const std::size_t colon = text.find(':');
+    if (colon == std::string::npos) return InputBinding{};
+    const InputDevice device = deviceFromName(text.substr(0, colon));
+    if (device == InputDevice::None) return InputBinding{};
+    try {
+        return InputBinding{device, std::stoi(text.substr(colon + 1))};
+    } catch (...) {
+        return InputBinding{};
+    }
+}
+
+class InputMap {
+public:
+    /// Register an action with a default binding. Duplicate names are ignored.
+    /// Registration order is preserved for the panel.
+    void addAction(const std::string& name, InputBinding defaultBinding = {}) {
+        if (m_index.count(name) != 0) return;
+        m_index.emplace(name, m_actions.size());
+        m_actions.push_back(Action{name, defaultBinding, defaultBinding});
+    }
+
+    bool hasAction(const std::string& name) const { return m_index.count(name) != 0; }
+    std::size_t actionCount() const { return m_actions.size(); }
+    const std::string& actionName(std::size_t i) const { return m_actions[i].name; }
+    InputBinding bindingAt(std::size_t i) const { return m_actions[i].binding; }
+
+    /// Current binding for @p action (unbound if the action is unknown).
+    InputBinding binding(const std::string& action) const {
+        const Action* a = find(action);
+        return a ? a->binding : InputBinding{};
+    }
+
+    /// Rebind @p action; takes effect immediately. No-op if the action is unknown.
+    void rebind(const std::string& action, InputBinding binding) {
+        if (Action* a = find(action)) a->binding = binding;
+    }
+
+    void unbind(const std::string& action) {
+        if (Action* a = find(action)) a->binding = InputBinding{};
+    }
+
+    /// The first action bound to @p binding, or "" (never matches unbound).
+    std::string actionFor(InputBinding binding) const {
+        if (!binding.bound()) return std::string();
+        for (const Action& a : m_actions) {
+            if (a.binding == binding) return a.name;
+        }
+        return std::string();
+    }
+
+    /// True if another action shares @p action's (bound) input.
+    bool hasConflict(const std::string& action) const {
+        const Action* self = find(action);
+        if (self == nullptr || !self->binding.bound()) return false;
+        for (const Action& a : m_actions) {
+            if (&a != self && a.binding.bound() && a.binding == self->binding) return true;
+        }
+        return false;
+    }
+
+    /// Names of other actions sharing @p action's binding.
+    std::vector<std::string> conflictsWith(const std::string& action) const {
+        std::vector<std::string> out;
+        const Action* self = find(action);
+        if (self == nullptr || !self->binding.bound()) return out;
+        for (const Action& a : m_actions) {
+            if (&a != self && a.binding.bound() && a.binding == self->binding) out.push_back(a.name);
+        }
+        return out;
+    }
+
+    /// True if any two actions share the same input.
+    bool anyConflicts() const {
+        for (std::size_t i = 0; i < m_actions.size(); ++i) {
+            if (!m_actions[i].binding.bound()) continue;
+            for (std::size_t j = i + 1; j < m_actions.size(); ++j) {
+                if (m_actions[j].binding.bound() && m_actions[j].binding == m_actions[i].binding) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /// Restore every action to the default it was registered with.
+    void resetToDefaults() {
+        for (Action& a : m_actions) a.binding = a.def;
+    }
+
+    /// Serialize as "action=device:code" lines, in registration order.
+    std::string serialize() const {
+        std::string out;
+        for (const Action& a : m_actions) out += a.name + "=" + toString(a.binding) + "\n";
+        return out;
+    }
+
+    /// Apply "action=device:code" lines to the registered actions. Unknown actions
+    /// and malformed lines are ignored; blank and '#'/';' lines are skipped.
+    void load(const std::string& text) {
+        std::istringstream in(text);
+        std::string line;
+        while (std::getline(in, line)) {
+            const std::string trimmed = trim(line);
+            if (trimmed.empty() || trimmed[0] == '#' || trimmed[0] == ';') continue;
+            const std::size_t eq = trimmed.find('=');
+            if (eq == std::string::npos) continue;
+            const std::string action = trim(trimmed.substr(0, eq));
+            if (hasAction(action)) rebind(action, bindingFromString(trim(trimmed.substr(eq + 1))));
+        }
+    }
+
+    bool saveToFile(const std::string& path) const {
+        std::ofstream out(path, std::ios::trunc);
+        if (!out) return false;
+        out << serialize();
+        return static_cast<bool>(out);
+    }
+
+    bool loadFromFile(const std::string& path) {
+        std::ifstream in(path);
+        if (!in) return false;
+        std::stringstream ss;
+        ss << in.rdbuf();
+        load(ss.str());
+        return true;
+    }
+
+private:
+    struct Action {
+        std::string name;
+        InputBinding binding;
+        InputBinding def;
+    };
+
+    Action* find(const std::string& name) {
+        auto it = m_index.find(name);
+        return it == m_index.end() ? nullptr : &m_actions[it->second];
+    }
+    const Action* find(const std::string& name) const {
+        auto it = m_index.find(name);
+        return it == m_index.end() ? nullptr : &m_actions[it->second];
+    }
+
+    static std::string trim(const std::string& s) {
+        const std::size_t a = s.find_first_not_of(" \t\r\n");
+        const std::size_t b = s.find_last_not_of(" \t\r\n");
+        return a == std::string::npos ? std::string() : s.substr(a, b - a + 1);
+    }
+
+    std::vector<Action> m_actions;
+    std::unordered_map<std::string, std::size_t> m_index;
+};
+
+} // namespace IKore

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -115,6 +115,65 @@ static void drawMenuItem(Menu& menu, int index, const MenuItem& item, bool focus
     ImGui::PopID();
 }
 
+// Gamepad buttons we let the user bind (an explicit list avoids depending on the
+// exact ImGuiKey gamepad range bounds).
+static const ImGuiKey kBindableGamepad[] = {
+    ImGuiKey_GamepadFaceDown,  ImGuiKey_GamepadFaceRight, ImGuiKey_GamepadFaceLeft,
+    ImGuiKey_GamepadFaceUp,    ImGuiKey_GamepadDpadUp,    ImGuiKey_GamepadDpadDown,
+    ImGuiKey_GamepadDpadLeft,  ImGuiKey_GamepadDpadRight, ImGuiKey_GamepadL1,
+    ImGuiKey_GamepadR1,        ImGuiKey_GamepadStart,     ImGuiKey_GamepadBack,
+};
+
+static bool isBindableGamepad(ImGuiKey key) {
+    for (ImGuiKey g : kBindableGamepad) {
+        if (g == key) return true;
+    }
+    return false;
+}
+
+// Poll for the next pressed input this frame, to capture a rebind. Mouse buttons
+// and gamepad buttons are checked explicitly; everything else is treated as a key.
+static InputBinding captureInput() {
+    for (int b = 0; b < 5; ++b) {
+        if (ImGui::IsMouseClicked(b)) return InputBinding{InputDevice::Mouse, b};
+    }
+    for (ImGuiKey g : kBindableGamepad) {
+        if (ImGui::IsKeyPressed(g, false)) return InputBinding{InputDevice::Gamepad, static_cast<int>(g)};
+    }
+    for (int k = ImGuiKey_NamedKey_BEGIN; k < ImGuiKey_NamedKey_END; ++k) {
+        const ImGuiKey key = static_cast<ImGuiKey>(k);
+        if (!ImGui::IsKeyPressed(key, false)) continue;
+        if (key >= ImGuiKey_MouseLeft && key <= ImGuiKey_MouseWheelY) continue; // handled above
+        if (isBindableGamepad(key)) continue;                                   // handled above
+        return InputBinding{InputDevice::Keyboard, static_cast<int>(key)};
+    }
+    return InputBinding{};
+}
+
+// Human-readable label for a binding, for the panel.
+static std::string bindingLabel(const InputBinding& binding) {
+    if (!binding.bound()) return "(unbound)";
+    if (binding.device == InputDevice::Mouse) {
+        switch (binding.code) {
+            case 0: return "Mouse Left";
+            case 1: return "Mouse Right";
+            case 2: return "Mouse Middle";
+            default: return "Mouse " + std::to_string(binding.code);
+        }
+    }
+    const char* name = ImGui::GetKeyName(static_cast<ImGuiKey>(binding.code)); // keys + gamepad
+    return (name != nullptr && name[0] != '\0') ? std::string(name) : std::string("code ") +
+                                                                          std::to_string(binding.code);
+}
+
+// Whether the input a binding refers to is currently held (shows rebinds taking
+// effect immediately).
+static bool bindingActive(const InputBinding& binding) {
+    if (!binding.bound()) return false;
+    if (binding.device == InputDevice::Mouse) return ImGui::IsMouseDown(binding.code);
+    return ImGui::IsKeyDown(static_cast<ImGuiKey>(binding.code));
+}
+
 bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     if (m_initialized) return true;
     if (window == nullptr) return false;
@@ -225,6 +284,18 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
 
     m_menuStack.open(&m_mainMenu);
 
+    // Input remapping (#60): register the default action bindings (ImGui key /
+    // mouse-button codes), then load any rebindings saved from a prior session.
+    m_inputMap.addAction("MoveForward", {InputDevice::Keyboard, static_cast<int>(ImGuiKey_W)});
+    m_inputMap.addAction("MoveBack", {InputDevice::Keyboard, static_cast<int>(ImGuiKey_S)});
+    m_inputMap.addAction("MoveLeft", {InputDevice::Keyboard, static_cast<int>(ImGuiKey_A)});
+    m_inputMap.addAction("MoveRight", {InputDevice::Keyboard, static_cast<int>(ImGuiKey_D)});
+    m_inputMap.addAction("Jump", {InputDevice::Keyboard, static_cast<int>(ImGuiKey_Space)});
+    m_inputMap.addAction("Interact", {InputDevice::Keyboard, static_cast<int>(ImGuiKey_E)});
+    m_inputMap.addAction("Fire", {InputDevice::Mouse, 0});
+    m_inputMap.addAction("AltFire", {InputDevice::Mouse, 1});
+    m_inputMap.loadFromFile("ikore_input.ini");
+
     m_initialized = true;
     LOG_INFO("DebugUI: Dear ImGui initialized (press F1 to toggle)");
     return true;
@@ -295,6 +366,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::Checkbox("Show scene view / picking (#57)", &m_showPicking);
     ImGui::Checkbox("Show menus (#58)", &m_showMenus);
     ImGui::Checkbox("Show scene hierarchy (#59)", &m_showHierarchy);
+    ImGui::Checkbox("Show input bindings (#60)", &m_showInput);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
@@ -305,6 +377,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     renderPicking();
     renderMenus();
     renderHierarchy();
+    renderInputBindings();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
@@ -593,6 +666,72 @@ void DebugUI::renderHierarchy() {
         if (ImGui::Selectable(m_hierarchy.name(id).c_str(), selected)) m_inspector.select(id);
         if (depth > 0) ImGui::Unindent(static_cast<float>(depth) * 16.0f);
         ImGui::PopID();
+    }
+
+    ImGui::End();
+}
+
+void DebugUI::renderInputBindings() {
+    if (!m_showInput) return;
+
+    ImGui::Begin("Input Bindings", &m_showInput);
+
+    // While capturing a rebind, watch for the next input (Esc cancels). Rebinding
+    // updates the map in place, so it takes effect immediately.
+    if (m_rebinding >= 0 && m_rebinding < static_cast<int>(m_inputMap.actionCount())) {
+        ImGui::TextColored(ImVec4(1.0f, 0.85f, 0.3f, 1.0f),
+                           "Press an input for '%s' (Esc to cancel)...",
+                           m_inputMap.actionName(static_cast<std::size_t>(m_rebinding)).c_str());
+        if (ImGui::IsKeyPressed(ImGuiKey_Escape, false)) {
+            m_rebinding = -1;
+        } else {
+            const InputBinding captured = captureInput();
+            if (captured.bound()) {
+                m_inputMap.rebind(m_inputMap.actionName(static_cast<std::size_t>(m_rebinding)), captured);
+                m_rebinding = -1;
+            }
+        }
+    }
+
+    for (int i = 0; i < static_cast<int>(m_inputMap.actionCount()); ++i) {
+        const std::string& name = m_inputMap.actionName(static_cast<std::size_t>(i));
+        const InputBinding binding = m_inputMap.bindingAt(static_cast<std::size_t>(i));
+        const bool conflict = m_inputMap.hasConflict(name);
+
+        ImGui::PushID(i);
+        ImGui::Text("%-14s", name.c_str());
+        ImGui::SameLine(150.0f);
+        if (conflict) ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(240, 90, 90, 255));
+        ImGui::TextUnformatted(bindingLabel(binding).c_str());
+        if (conflict) {
+            ImGui::PopStyleColor();
+            ImGui::SameLine();
+            ImGui::TextColored(ImVec4(0.95f, 0.35f, 0.35f, 1.0f), "(conflict)");
+        }
+        ImGui::SameLine(300.0f);
+        if (ImGui::SmallButton("Rebind")) m_rebinding = i;
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Clear")) m_inputMap.unbind(name);
+        ImGui::PopID();
+    }
+
+    ImGui::Separator();
+    if (ImGui::Button("Save")) m_inputMap.saveToFile("ikore_input.ini");
+    ImGui::SameLine();
+    if (ImGui::Button("Load")) m_inputMap.loadFromFile("ikore_input.ini");
+    ImGui::SameLine();
+    if (ImGui::Button("Reset to defaults")) m_inputMap.resetToDefaults();
+    if (m_inputMap.anyConflicts()) {
+        ImGui::TextColored(ImVec4(0.95f, 0.35f, 0.35f, 1.0f), "Some actions share the same input.");
+    }
+
+    // Live view: which actions are currently active, proving rebinds apply at once.
+    ImGui::Separator();
+    ImGui::TextDisabled("Active now:");
+    for (int i = 0; i < static_cast<int>(m_inputMap.actionCount()); ++i) {
+        if (bindingActive(m_inputMap.bindingAt(static_cast<std::size_t>(i)))) {
+            ImGui::BulletText("%s", m_inputMap.actionName(static_cast<std::size_t>(i)).c_str());
+        }
     }
 
     ImGui::End();

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/DebugConsole.h"
+#include "core/InputMap.h"
 #include "core/PerfStats.h"
 #include "core/Picking.h"
 #include "core/Settings.h"
@@ -95,6 +96,7 @@ private:
     void renderPicking();
     void renderMenus();
     void renderHierarchy();
+    void renderInputBindings();
 
     bool m_initialized{false};
     bool m_visible{false};
@@ -106,6 +108,7 @@ private:
     bool m_showPicking{true};
     bool m_showMenus{true};
     bool m_showHierarchy{true};
+    bool m_showInput{true};
     float m_hudScale{1.0f};
     PerfStats m_perf;
     DebugConsole m_console;
@@ -148,6 +151,12 @@ private:
     char m_renameBuffer[64]{};
     SceneHierarchy::NodeId m_renameFor{SceneHierarchy::kNoNode};
     int m_nextEntityLabel{1};
+
+    // Input remapping (#60): rebindable actions with conflict detection, persisted
+    // to disk. m_rebinding is the index of the action currently capturing input, or
+    // -1 when not listening.
+    InputMap m_inputMap;
+    int m_rebinding{-1};
 };
 
 } // namespace IKore

--- a/tests/test_input_map.cpp
+++ b/tests/test_input_map.cpp
@@ -1,0 +1,190 @@
+// Test for the input remapping core - Milestone 9, #60.
+//
+// Verifies the headless action/binding model behind the input panel: registration
+// and immediate rebinding, reverse lookup, conflict detection, reset to defaults,
+// the binding string round-trip, and persistence to disk (bindings surviving
+// across "sessions").
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_input_map.cpp -o test_input_map
+
+#include "core/InputMap.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// Arbitrary codes stand in for the engine's ImGui key / button values.
+static constexpr int KEY_W = 100;
+static constexpr int KEY_S = 101;
+static constexpr int KEY_SPACE = 200;
+
+static bool listHas(const std::vector<std::string>& v, const std::string& s) {
+    for (const std::string& x : v) {
+        if (x == s) return true;
+    }
+    return false;
+}
+
+static void testRegisterAndRebind() {
+    InputMap map;
+    map.addAction("MoveForward", {InputDevice::Keyboard, KEY_W});
+    map.addAction("Jump", {InputDevice::Keyboard, KEY_SPACE});
+    map.addAction("Fire", {InputDevice::Mouse, 0});
+
+    CHECK(map.actionCount() == 3);
+    CHECK(map.hasAction("Jump"));
+    CHECK(!map.hasAction("Nope"));
+    CHECK(map.actionName(0) == "MoveForward"); // registration order preserved
+
+    CHECK(map.binding("MoveForward") == (InputBinding{InputDevice::Keyboard, KEY_W}));
+
+    // Rebinding takes effect immediately.
+    map.rebind("MoveForward", {InputDevice::Keyboard, KEY_S});
+    CHECK(map.binding("MoveForward") == (InputBinding{InputDevice::Keyboard, KEY_S}));
+
+    // Unbind clears it; unbound never matches a reverse lookup.
+    map.unbind("Fire");
+    CHECK(!map.binding("Fire").bound());
+    CHECK(map.actionFor({InputDevice::Mouse, 0}).empty());
+
+    // Duplicate registration is ignored.
+    map.addAction("Jump", {InputDevice::Keyboard, 999});
+    CHECK(map.actionCount() == 3);
+    CHECK(map.binding("Jump") == (InputBinding{InputDevice::Keyboard, KEY_SPACE}));
+}
+
+static void testReverseLookup() {
+    InputMap map;
+    map.addAction("A", {InputDevice::Keyboard, KEY_W});
+    map.addAction("B", {InputDevice::Mouse, 1});
+    CHECK(map.actionFor({InputDevice::Keyboard, KEY_W}) == "A");
+    CHECK(map.actionFor({InputDevice::Mouse, 1}) == "B");
+    CHECK(map.actionFor({InputDevice::Gamepad, 3}).empty());
+}
+
+static void testConflictDetection() {
+    InputMap map;
+    map.addAction("MoveForward", {InputDevice::Keyboard, KEY_W});
+    map.addAction("Accelerate", {InputDevice::Keyboard, KEY_W}); // same as MoveForward
+    map.addAction("Jump", {InputDevice::Keyboard, KEY_SPACE});
+    map.addAction("Crouch"); // unbound
+
+    CHECK(map.anyConflicts());
+    CHECK(map.hasConflict("MoveForward"));
+    CHECK(map.hasConflict("Accelerate"));
+    CHECK(!map.hasConflict("Jump"));
+    CHECK(listHas(map.conflictsWith("MoveForward"), "Accelerate"));
+    CHECK(map.conflictsWith("Jump").empty());
+
+    // Two unbound actions do not conflict.
+    map.addAction("Extra"); // also unbound
+    CHECK(!map.hasConflict("Crouch"));
+    CHECK(!map.hasConflict("Extra"));
+
+    // Rebinding away resolves the conflict.
+    map.rebind("Accelerate", {InputDevice::Keyboard, 555});
+    CHECK(!map.hasConflict("MoveForward"));
+    CHECK(!map.anyConflicts());
+}
+
+static void testResetToDefaults() {
+    InputMap map;
+    map.addAction("Jump", {InputDevice::Keyboard, KEY_SPACE});
+    map.rebind("Jump", {InputDevice::Gamepad, 0});
+    CHECK(map.binding("Jump") == (InputBinding{InputDevice::Gamepad, 0}));
+    map.resetToDefaults();
+    CHECK(map.binding("Jump") == (InputBinding{InputDevice::Keyboard, KEY_SPACE}));
+}
+
+static void testBindingStringRoundTrip() {
+    const InputBinding key{InputDevice::Keyboard, 65};
+    const InputBinding mouse{InputDevice::Mouse, 2};
+    const InputBinding pad{InputDevice::Gamepad, 7};
+    const InputBinding none{};
+
+    CHECK(bindingFromString(toString(key)) == key);
+    CHECK(bindingFromString(toString(mouse)) == mouse);
+    CHECK(bindingFromString(toString(pad)) == pad);
+    CHECK(toString(none) == "none");
+    CHECK(!bindingFromString("none").bound());
+    CHECK(!bindingFromString("garbage").bound()); // malformed -> unbound
+}
+
+static void testSerializeRoundTrip() {
+    InputMap a;
+    a.addAction("MoveForward", {InputDevice::Keyboard, KEY_W});
+    a.addAction("Fire", {InputDevice::Mouse, 0});
+    a.addAction("Menu", {InputDevice::Gamepad, 4});
+    a.rebind("Fire", {InputDevice::Mouse, 1});
+
+    const std::string text = a.serialize();
+
+    // A fresh map with the same actions loads the saved bindings over its defaults.
+    InputMap b;
+    b.addAction("MoveForward");
+    b.addAction("Fire");
+    b.addAction("Menu");
+    b.load(text);
+    CHECK(b.binding("MoveForward") == (InputBinding{InputDevice::Keyboard, KEY_W}));
+    CHECK(b.binding("Fire") == (InputBinding{InputDevice::Mouse, 1}));
+    CHECK(b.binding("Menu") == (InputBinding{InputDevice::Gamepad, 4}));
+
+    // Unknown actions in the text are ignored.
+    InputMap c;
+    c.addAction("MoveForward");
+    c.load("MoveForward=keyboard:5\nUnknownAction=mouse:3\n");
+    CHECK(c.binding("MoveForward") == (InputBinding{InputDevice::Keyboard, 5}));
+    CHECK(!c.hasAction("UnknownAction"));
+}
+
+static void testPersistAcrossSessions() {
+    const std::string path = "ikore_input_test.ini";
+
+    InputMap first;
+    first.addAction("Jump", {InputDevice::Keyboard, KEY_SPACE});
+    first.addAction("Fire", {InputDevice::Mouse, 0});
+    first.rebind("Jump", {InputDevice::Gamepad, 1});
+    CHECK(first.saveToFile(path));
+
+    // A new "session" registers the same actions and loads the saved bindings.
+    InputMap second;
+    second.addAction("Jump", {InputDevice::Keyboard, KEY_SPACE});
+    second.addAction("Fire", {InputDevice::Mouse, 0});
+    CHECK(second.loadFromFile(path));
+    CHECK(second.binding("Jump") == (InputBinding{InputDevice::Gamepad, 1}));
+    CHECK(second.binding("Fire") == (InputBinding{InputDevice::Mouse, 0}));
+
+    CHECK(!second.loadFromFile("no_such_input_file_54321.ini"));
+
+    std::remove(path.c_str());
+}
+
+int main() {
+    testRegisterAndRebind();
+    testReverseLookup();
+    testConflictDetection();
+    testResetToDefaults();
+    testBindingStringRoundTrip();
+    testSerializeRoundTrip();
+    testPersistAcrossSessions();
+
+    if (g_failures == 0) {
+        std::printf("All input map tests passed.\n");
+        return 0;
+    }
+    std::printf("%d input map test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Adds an ImGui panel to rebind keyboard, mouse, and gamepad actions, with conflict detection and bindings that persist across sessions. Follows the same split proven by #53-#59: a headless, unit-tested core plus a thin ImGui panel wired into `DebugUI`.

Closes #60

## Core: `src/core/InputMap.h` (header-only, std only)

Codes are opaque integers (the engine uses ImGui key / mouse-button values), so the core needs no ImGui or GLFW and is unit-testable on its own.

- Named actions each bound to an `InputBinding` (device + integer code, where device is `Keyboard` / `Mouse` / `Gamepad`).
- `rebind()` updates the binding in place, so a change takes effect immediately; plus `unbind`, reverse lookup (`actionFor`), and conflict detection (`hasConflict`, `conflictsWith`, `anyConflicts`) - two actions sharing the same bound input, with unbound actions never counted as conflicts.
- `resetToDefaults()` restores each action's registered default; `serialize()` / `load()` use `action=device:code` text and `saveToFile` / `loadFromFile` round-trip to disk so bindings persist across sessions.

## Panel: `src/ui/DebugUI`

- An "Input Bindings" window listing each action, its current binding, and a red `(conflict)` flag when two actions share an input.
- A **Rebind** button captures the next key / mouse / gamepad press (Esc cancels) and applies it immediately; **Clear** unbinds; **Save** / **Load** / **Reset to defaults** persist or restore.
- A live "Active now" list shows which actions are currently held, demonstrating that a rebind takes effect at once.
- Defaults are registered with ImGui key codes and any saved rebindings load on init.

## Testing

- `tests/test_input_map.cpp` covers registration + immediate rebinding, reverse lookup, conflict detection (including that two unbound actions never conflict and that rebinding away resolves a conflict), reset to defaults, the `InputBinding` string round-trip (keyboard/mouse/gamepad/none and malformed input), `serialize`/`load` (ignoring unknown actions), and `saveToFile`/`loadFromFile` persistence across two "sessions".
- Passes locally under ASan/UBSan (`All input map tests passed.`).
- New CMake target `test_input_map`.
- The ImGui panel is compiled by CI (CodeQL c-cpp build).

## Acceptance criteria

- Rebinding takes effect immediately and persists across sessions: `rebind()` mutates the binding in place (the panel's "Active now" list reflects it at once), and `saveToFile`/`loadFromFile` round-trip bindings (verified by a two-session test); the panel loads `ikore_input.ini` on init and saves on demand.
- Conflicting bindings are flagged: `hasConflict`/`anyConflicts` detect shared inputs (verified in the unit test), and the panel shows a per-row `(conflict)` marker and a summary line.

## Notes

- Additive: no behavior change to existing panels. The map is self-contained in `DebugUI` (mirroring #55-#59); the real game reads action state via `InputMap::binding(action)` and translates engine input codes through it.