### PR TITLE
[M9] Add DPI and resolution UI scaling (#61)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,6 +650,11 @@ add_executable(test_input_map
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_input_map.cpp
 )
 
+# DPI / resolution UI scaling core (Milestone 9 / #61) - header-only.
+add_executable(test_ui_scaling
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ui_scaling.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -14,6 +14,11 @@
 
 namespace IKore {
 
+// Unscaled base style, captured once at init. Each frame applyScaling() copies it
+// back and re-applies ScaleAllSizes(scale), so scaling is not cumulative (#61).
+static ImGuiStyle s_baseStyle;
+static bool s_baseStyleCaptured = false;
+
 // File-static trampoline: ImGui's InputText callback dispatches here, then into
 // the DebugUI instance passed as user data.
 static int consoleTextEditStub(ImGuiInputTextCallbackData* data) {
@@ -187,6 +192,8 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;    // allow panels to be docked together
 
     ImGui::StyleColorsDark();
+    s_baseStyle = ImGui::GetStyle(); // remember the unscaled style for #61
+    s_baseStyleCaptured = true;
 
     if (!ImGui_ImplGlfw_InitForOpenGL(window, /*install_callbacks=*/true)) {
         LOG_ERROR("DebugUI: ImGui GLFW backend init failed");
@@ -256,8 +263,10 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     // menus on the navigation core and open the main menu.
     m_settings.setBool("vsync", true);
     m_settings.setFloat("volume", 0.8f);
-    m_settings.setInt("quality", 2); // index into {Low, Medium, High}
+    m_settings.setInt("quality", 2);       // index into {Low, Medium, High}
+    m_settings.setFloat("ui.scale", 1.0f); // user-facing UI scale (#61)
     m_settings.loadFromFile("ikore_settings.ini");
+    m_uiScale.userScale = m_settings.getFloat("ui.scale", 1.0f); // persisted scale
 
     m_settingsMenu.add(menuToggle("VSync", [this] { return m_settings.getBool("vsync"); },
                                   [this](bool b) { m_settings.setBool("vsync", b); }));
@@ -330,6 +339,7 @@ void DebugUI::render(float deltaTimeSeconds) {
     ImGui_ImplGlfw_NewFrame();
     ImGui::NewFrame();
 
+    applyScaling(); // DPI / resolution aware scaling (#61), before any widgets
     buildUI(deltaTimeSeconds);
 
     ImGui::Render();
@@ -361,12 +371,12 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::Checkbox("Show performance overlay (#53)", &m_showPerf);
     ImGui::Checkbox("Show console (#54)", &m_showConsole);
     ImGui::Checkbox("Show HUD (#55)", &m_showHud);
-    ImGui::SliderFloat("HUD scale (#61)", &m_hudScale, 0.5f, 2.0f, "%.2f");
     ImGui::Checkbox("Show entity inspector (#56)", &m_showInspector);
     ImGui::Checkbox("Show scene view / picking (#57)", &m_showPicking);
     ImGui::Checkbox("Show menus (#58)", &m_showMenus);
     ImGui::Checkbox("Show scene hierarchy (#59)", &m_showHierarchy);
     ImGui::Checkbox("Show input bindings (#60)", &m_showInput);
+    ImGui::Checkbox("Show UI scaling (#61)", &m_showScaling);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
@@ -378,6 +388,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     renderMenus();
     renderHierarchy();
     renderInputBindings();
+    renderScaling();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
@@ -565,9 +576,10 @@ void DebugUI::renderMenus() {
     Menu* menu = m_menuStack.current();
     if (menu == nullptr) return;
 
-    // Center the menu window using the HUD framework's anchoring (#55).
+    // Center the menu window using the HUD framework's anchoring (#55), sizing it by
+    // the effective UI scale (#61) so it stays proportionate across resolutions.
     const ImGuiIO& io = ImGui::GetIO();
-    const HudVec2 size{340.0f, 320.0f};
+    const HudVec2 size{340.0f * m_effectiveScale, 320.0f * m_effectiveScale};
     const HudVec2 pos =
         resolveAnchor(HudAnchor::Center, {io.DisplaySize.x, io.DisplaySize.y}, size, {0.0f, 0.0f});
     ImGui::SetNextWindowPos(ImVec2(pos.x, pos.y), ImGuiCond_Always);
@@ -737,12 +749,58 @@ void DebugUI::renderInputBindings() {
     ImGui::End();
 }
 
+void DebugUI::applyScaling() {
+    ImGuiIO& io = ImGui::GetIO();
+    const float dpi = io.DisplayFramebufferScale.y > 0.0f ? io.DisplayFramebufferScale.y : 1.0f;
+    m_effectiveScale = computeUiScale(m_uiScale, io.DisplaySize.y, dpi);
+
+    // Re-apply the unscaled base style, then scale it - cheap (a struct copy plus
+    // ScaleAllSizes), with no font-atlas rebuild, so the cost is negligible (#61).
+    if (s_baseStyleCaptured) {
+        ImGui::GetStyle() = s_baseStyle;
+        ImGui::GetStyle().ScaleAllSizes(m_effectiveScale);
+    }
+    io.FontGlobalScale = m_effectiveScale;
+    m_hud.setScale(m_effectiveScale);
+}
+
+void DebugUI::renderScaling() {
+    if (!m_showScaling) return;
+
+    ImGui::Begin("UI Scaling", &m_showScaling);
+
+    const ImGuiIO& io = ImGui::GetIO();
+    const float w = io.DisplaySize.x;
+    const float h = io.DisplaySize.y;
+    ImGui::Text("Resolution: %.0f x %.0f", w, h);
+    ImGui::Text("DPI / framebuffer scale: %.2f", io.DisplayFramebufferScale.y);
+    ImGui::Text("Aspect: %.3f (%s)", aspectRatio(w, h), aspectCategoryName(classifyAspect(w, h)));
+    ImGui::Text("Effective UI scale: %.2f", m_effectiveScale);
+
+    ImGui::Separator();
+    float userScale = m_uiScale.userScale;
+    if (ImGui::SliderFloat("User scale", &userScale, m_uiScale.minScale, m_uiScale.maxScale, "%.2f")) {
+        m_uiScale.userScale = userScale;
+        m_settings.setFloat("ui.scale", userScale);
+    }
+    if (ImGui::IsItemDeactivatedAfterEdit()) saveSettings(); // persist once, on release
+    ImGui::Checkbox("Auto-scale with resolution", &m_uiScale.autoResolutionScale);
+
+    if (ImGui::Button("Reset")) {
+        m_uiScale.userScale = 1.0f;
+        m_settings.setFloat("ui.scale", 1.0f);
+        saveSettings();
+    }
+
+    ImGui::End();
+}
+
 void DebugUI::renderHud() {
     if (!m_showHud) return;
 
     const ImGuiIO& io = ImGui::GetIO();
     m_hud.setScreenSize(io.DisplaySize.x, io.DisplaySize.y); // resolution aware (#55)
-    m_hud.setScale(m_hudScale);                              // scale aware (#61)
+    // HUD scale is set globally by applyScaling() (#61).
 
     // Borderless, click-through overlays so the HUD never obstructs gameplay input.
     const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -12,6 +12,7 @@
 #include "ui/HudFramework.h"
 #include "ui/MenuSystem.h"
 #include "ui/SceneHierarchy.h"
+#include "ui/UiScaling.h"
 
 #include <string>
 #include <vector>
@@ -97,6 +98,8 @@ private:
     void renderMenus();
     void renderHierarchy();
     void renderInputBindings();
+    void renderScaling();
+    void applyScaling();
 
     bool m_initialized{false};
     bool m_visible{false};
@@ -109,7 +112,7 @@ private:
     bool m_showMenus{true};
     bool m_showHierarchy{true};
     bool m_showInput{true};
-    float m_hudScale{1.0f};
+    bool m_showScaling{true};
     PerfStats m_perf;
     DebugConsole m_console;
     Hud m_hud;
@@ -157,6 +160,12 @@ private:
     // -1 when not listening.
     InputMap m_inputMap;
     int m_rebinding{-1};
+
+    // DPI / resolution UI scaling (#61). applyScaling() computes the effective
+    // scale each frame from the framebuffer size and DPI and applies it cheaply to
+    // ImGui (font + style) and the HUD; the user scale persists in settings.
+    UiScaleConfig m_uiScale;
+    float m_effectiveScale{1.0f};
 };
 
 } // namespace IKore

--- a/src/ui/UiScaling.h
+++ b/src/ui/UiScaling.h
@@ -1,0 +1,72 @@
+#pragma once
+
+/**
+ * @file UiScaling.h
+ * @brief DPI / resolution aware UI scaling math (issue #61).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless core behind DPI- and
+ * resolution-aware UI: combine a user-facing scale multiplier, the monitor DPI /
+ * content scale, and an optional resolution auto-scale (relative to the resolution
+ * the UI is authored at) into a single effective scale, clamped to a readable range.
+ * Plus aspect-ratio classification so the layout can adapt across aspect ratios.
+ *
+ * The engine applies the returned scale cheaply (ImGui FontGlobalScale +
+ * ScaleAllSizes and the HUD scale), so there is no font-atlas rebuild and the cost
+ * is negligible. Pure math, no ImGui - unit-testable on its own. Header-only.
+ */
+namespace IKore {
+
+/// Broad aspect-ratio buckets the layout can adapt to.
+enum class AspectCategory { Tall, Standard, Wide, UltraWide };
+
+/// Configuration for the effective UI scale. userScale is the user-facing setting.
+struct UiScaleConfig {
+    float referenceHeight{1080.0f}; ///< Resolution height the UI is authored at.
+    float userScale{1.0f};          ///< User-facing multiplier.
+    float minScale{0.5f};
+    float maxScale{3.0f};
+    bool autoResolutionScale{true}; ///< Scale with framebuffer height vs referenceHeight.
+};
+
+/**
+ * @brief Effective UI scale for the given framebuffer height and DPI.
+ * @param cfg               Scale configuration (user setting, reference, clamps).
+ * @param framebufferHeight Current framebuffer/logical height in the same units as
+ *                          cfg.referenceHeight.
+ * @param dpiScale          Monitor DPI / content scale (1.0 at 96 DPI). Values <= 0
+ *                          are treated as 1.0.
+ * @return userScale * dpiScale * (auto-resolution factor), clamped to [min, max].
+ */
+inline float computeUiScale(const UiScaleConfig& cfg, float framebufferHeight, float dpiScale) {
+    float scale = cfg.userScale * (dpiScale > 0.0f ? dpiScale : 1.0f);
+    if (cfg.autoResolutionScale && cfg.referenceHeight > 0.0f && framebufferHeight > 0.0f) {
+        scale *= framebufferHeight / cfg.referenceHeight;
+    }
+    if (scale < cfg.minScale) scale = cfg.minScale;
+    if (scale > cfg.maxScale) scale = cfg.maxScale;
+    return scale;
+}
+
+/// Aspect ratio (width / height); 0 if height is non-positive.
+inline float aspectRatio(float width, float height) { return height > 0.0f ? width / height : 0.0f; }
+
+/// Classify an aspect ratio into a broad bucket for adaptive layout.
+inline AspectCategory classifyAspect(float width, float height) {
+    const float r = aspectRatio(width, height);
+    if (r < 1.0f) return AspectCategory::Tall;      // portrait
+    if (r < 1.55f) return AspectCategory::Standard; // 4:3, 3:2
+    if (r < 2.0f) return AspectCategory::Wide;      // 16:10, 16:9
+    return AspectCategory::UltraWide;               // 21:9 and wider
+}
+
+inline const char* aspectCategoryName(AspectCategory category) {
+    switch (category) {
+        case AspectCategory::Tall: return "Tall";
+        case AspectCategory::Standard: return "Standard";
+        case AspectCategory::Wide: return "Wide";
+        case AspectCategory::UltraWide: return "UltraWide";
+    }
+    return "Unknown";
+}
+
+} // namespace IKore

--- a/tests/test_ui_scaling.cpp
+++ b/tests/test_ui_scaling.cpp
@@ -1,0 +1,117 @@
+// Test for the DPI / resolution UI scaling core - Milestone 9, #61.
+//
+// Verifies the effective-scale formula (user * DPI * resolution auto-scale, with
+// clamping and DPI-fallback) and aspect-ratio classification used for adaptive
+// layout. The application of the scale (ImGui font/style, HUD) lives in DebugUI.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_ui_scaling.cpp -o test_ui_scaling
+
+#include "ui/UiScaling.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b) { return std::fabs(a - b) < 1e-3f; }
+
+static void testBaselineAndResolutionAutoScale() {
+    UiScaleConfig cfg; // reference 1080, user 1, auto on, clamp [0.5, 3]
+
+    // At the reference resolution with DPI 1, the scale is 1.
+    CHECK(approx(computeUiScale(cfg, 1080.0f, 1.0f), 1.0f));
+
+    // 1440p and 4K scale up proportionally.
+    CHECK(approx(computeUiScale(cfg, 1440.0f, 1.0f), 1440.0f / 1080.0f));
+    CHECK(approx(computeUiScale(cfg, 2160.0f, 1.0f), 2.0f));
+
+    // 720p scales down.
+    CHECK(approx(computeUiScale(cfg, 720.0f, 1.0f), 720.0f / 1080.0f));
+}
+
+static void testUserScaleAndDpi() {
+    UiScaleConfig cfg;
+
+    // User scale multiplies through at the reference resolution.
+    cfg.userScale = 1.5f;
+    CHECK(approx(computeUiScale(cfg, 1080.0f, 1.0f), 1.5f));
+
+    // DPI multiplies too.
+    cfg.userScale = 1.0f;
+    CHECK(approx(computeUiScale(cfg, 1080.0f, 2.0f), 2.0f));
+
+    // DPI <= 0 is treated as 1.0.
+    CHECK(approx(computeUiScale(cfg, 1080.0f, 0.0f), 1.0f));
+    CHECK(approx(computeUiScale(cfg, 1080.0f, -3.0f), 1.0f));
+}
+
+static void testClamping() {
+    UiScaleConfig cfg; // clamp [0.5, 3]
+
+    // Combined factors exceed the max -> clamped.
+    cfg.userScale = 1.5f;
+    CHECK(approx(computeUiScale(cfg, 2160.0f, 2.0f), 3.0f)); // 1.5 * 2 * 2 = 6 -> 3
+
+    // Tiny resolution with a small user scale clamps to the min.
+    cfg.userScale = 0.5f;
+    CHECK(approx(computeUiScale(cfg, 720.0f, 1.0f), 0.5f)); // 0.5 * 0.667 = 0.333 -> 0.5
+
+    // Custom clamps are honored.
+    UiScaleConfig tight;
+    tight.minScale = 1.0f;
+    tight.maxScale = 1.25f;
+    CHECK(approx(computeUiScale(tight, 480.0f, 1.0f), 1.0f));  // would be < 1 -> min
+    CHECK(approx(computeUiScale(tight, 2160.0f, 1.0f), 1.25f)); // would be 2 -> max
+}
+
+static void testAutoResolutionScaleToggle() {
+    UiScaleConfig cfg;
+    cfg.autoResolutionScale = false;
+
+    // With auto-scale off, resolution height is ignored: only user * DPI.
+    CHECK(approx(computeUiScale(cfg, 2160.0f, 1.0f), 1.0f));
+    CHECK(approx(computeUiScale(cfg, 720.0f, 1.0f), 1.0f));
+    cfg.userScale = 1.25f;
+    CHECK(approx(computeUiScale(cfg, 4320.0f, 1.0f), 1.25f));
+}
+
+static void testAspectRatioAndClassification() {
+    CHECK(approx(aspectRatio(1920.0f, 1080.0f), 16.0f / 9.0f));
+    CHECK(approx(aspectRatio(800.0f, 600.0f), 4.0f / 3.0f));
+    CHECK(approx(aspectRatio(100.0f, 0.0f), 0.0f)); // guard against divide-by-zero
+
+    CHECK(classifyAspect(1080.0f, 1920.0f) == AspectCategory::Tall);     // portrait
+    CHECK(classifyAspect(1024.0f, 768.0f) == AspectCategory::Standard);  // 4:3
+    CHECK(classifyAspect(1920.0f, 1080.0f) == AspectCategory::Wide);     // 16:9
+    CHECK(classifyAspect(3440.0f, 1440.0f) == AspectCategory::UltraWide); // 21:9
+
+    CHECK(std::string(aspectCategoryName(AspectCategory::UltraWide)) == "UltraWide");
+    CHECK(std::string(aspectCategoryName(AspectCategory::Standard)) == "Standard");
+}
+
+int main() {
+    testBaselineAndResolutionAutoScale();
+    testUserScaleAndDpi();
+    testClamping();
+    testAutoResolutionScaleToggle();
+    testAspectRatioAndClassification();
+
+    if (g_failures == 0) {
+        std::printf("All UI scaling tests passed.\n");
+        return 0;
+    }
+    std::printf("%d UI scaling test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Makes the ImGui panels and HUD DPI- and resolution-aware, with an adaptive layout across aspect ratios and a persisted, user-facing scale setting. Follows the same split proven by #53-#60: a headless, unit-tested core plus a thin ImGui panel wired into `DebugUI`.

Closes #61

## Core: `src/ui/UiScaling.h` (header-only, std only)

Pure math, no ImGui, so it unit-tests on its own.

- `computeUiScale()` combines the user scale, the monitor DPI / content scale, and an optional resolution auto-scale (framebuffer height vs the reference height the UI is authored at), clamped to a readable range. A DPI value `<= 0` is treated as `1.0`.
- `aspectRatio()` / `classifyAspect()` bucket the viewport into `Tall` / `Standard` / `Wide` / `UltraWide` so the layout can adapt across aspect ratios.

## Application + panel: `src/ui/DebugUI`

- `applyScaling()` runs each frame: it computes the effective scale from the framebuffer size and `DisplayFramebufferScale` and applies it to ImGui (`FontGlobalScale` plus a re-applied, scaled copy of the base style) and to the HUD. This unifies scaling under one global UI scale, replacing the earlier per-HUD demo slider.
- A "UI Scaling" panel shows the resolution, DPI, aspect ratio + category, and effective scale, and exposes the user-scale slider and an auto-scale toggle. The user scale persists in settings (`ui.scale`) and is saved on release.
- Menu windows are sized by the effective scale so they stay proportionate and unclipped across resolutions.

## Testing

- `tests/test_ui_scaling.cpp` covers the baseline and resolution auto-scale, user-scale and DPI multiplication (including the DPI `<= 0` fallback), clamping to the default and to custom ranges, the auto-scale toggle, and aspect-ratio computation/classification.
- Passes locally under ASan/UBSan (`All UI scaling tests passed.`).
- New CMake target `test_ui_scaling`.
- The ImGui integration is compiled by CI (CodeQL c-cpp build).

## Acceptance criteria

- UI stays readable and unclipped across resolutions and aspect ratios: the scale grows/shrinks with resolution (with DPI) and clamps to a readable range; menus size by the effective scale; the aspect classifier is available for adaptive layout. The math is verified in the unit test; the visual application is CodeQL-built.
- The scale setting persists and has negligible performance impact: the user scale round-trips through `Settings` (`ui.scale`, saved on release); scaling uses `FontGlobalScale` + `ScaleAllSizes` on a cached base style with no font-atlas rebuild, so per-frame cost is a struct copy.

## Notes

- Additive: the change consolidates the scattered HUD-scale demo slider into a single, persisted UI scale that drives fonts, widget metrics, the HUD, and menu sizing.