### PR TITLE
[M9] Add performance benchmarking panel (#62)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,6 +655,11 @@ add_executable(test_ui_scaling
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ui_scaling.cpp
 )
 
+# Performance benchmark recorder + export (Milestone 9 / #62) - header-only.
+add_executable(test_benchmark
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_benchmark.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/Benchmark.h
+++ b/src/core/Benchmark.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "core/sim/DataExport.h"
+
+#include <cstddef>
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <vector>
+
+/**
+ * @file Benchmark.h
+ * @brief Performance benchmark recorder with data export (issue #62).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). Captures FPS, frame time, and memory
+ * over a run and exports the samples to a structured, parseable file. It reuses the
+ * same frame-time values the perf overlay uses (PerfStats, #53) - the engine feeds
+ * each frame's duration and resident memory - and the deterministic data-export
+ * format (DataExporter, #155) for the exported CSV/JSON.
+ *
+ * Capture is explicit: record() is a no-op on a single branch unless a run is
+ * active, so it costs nothing when idle or disabled. Header-only, std only.
+ */
+namespace IKore {
+
+struct BenchmarkSample {
+    double timeSeconds{0.0}; ///< Accumulated time since the run started.
+    double frameMs{0.0};
+    double fps{0.0};
+    long memoryBytes{0};
+};
+
+class Benchmark {
+public:
+    /// Begin a fresh run: clears prior samples and starts capturing.
+    void start() {
+        reset();
+        m_capturing = true;
+    }
+
+    /// Stop capturing (samples are kept for inspection/export).
+    void stop() { m_capturing = false; }
+
+    /// Clear all samples and state.
+    void reset() {
+        m_samples.clear();
+        m_elapsed = 0.0;
+        m_peakMemory = 0;
+        m_capturing = false;
+    }
+
+    bool capturing() const { return m_capturing; }
+
+    /**
+     * @brief Record one frame while capturing; a no-op otherwise.
+     * @param frameSeconds This frame's duration in seconds.
+     * @param memoryBytes  Resident memory this frame (e.g. PerfStats::residentBytes()).
+     */
+    void record(double frameSeconds, long memoryBytes = 0) {
+        if (!m_capturing) return;
+        m_elapsed += frameSeconds;
+        const double ms = frameSeconds * 1000.0;
+        BenchmarkSample sample;
+        sample.timeSeconds = m_elapsed;
+        sample.frameMs = ms;
+        sample.fps = ms > 0.0 ? 1000.0 / ms : 0.0;
+        sample.memoryBytes = memoryBytes;
+        m_samples.push_back(sample);
+        if (memoryBytes > m_peakMemory) m_peakMemory = memoryBytes;
+    }
+
+    std::size_t sampleCount() const { return m_samples.size(); }
+    const std::vector<BenchmarkSample>& samples() const { return m_samples; }
+
+    double durationSeconds() const { return m_elapsed; }
+
+    double avgFrameMs() const {
+        if (m_samples.empty()) return 0.0;
+        double sum = 0.0;
+        for (const BenchmarkSample& s : m_samples) sum += s.frameMs;
+        return sum / static_cast<double>(m_samples.size());
+    }
+    double minFrameMs() const {
+        if (m_samples.empty()) return 0.0;
+        double m = m_samples.front().frameMs;
+        for (const BenchmarkSample& s : m_samples) {
+            if (s.frameMs < m) m = s.frameMs;
+        }
+        return m;
+    }
+    double maxFrameMs() const {
+        if (m_samples.empty()) return 0.0;
+        double m = m_samples.front().frameMs;
+        for (const BenchmarkSample& s : m_samples) {
+            if (s.frameMs > m) m = s.frameMs;
+        }
+        return m;
+    }
+
+    double avgFps() const {
+        const double a = avgFrameMs();
+        return a > 0.0 ? 1000.0 / a : 0.0;
+    }
+    double minFps() const {
+        const double m = maxFrameMs(); // slowest frame -> lowest FPS
+        return m > 0.0 ? 1000.0 / m : 0.0;
+    }
+    double maxFps() const {
+        const double m = minFrameMs(); // fastest frame -> highest FPS
+        return m > 0.0 ? 1000.0 / m : 0.0;
+    }
+
+    long peakMemoryBytes() const { return m_peakMemory; }
+
+    /// Export all samples via the deterministic DataExporter format (#155).
+    void exportTo(std::ostream& out, sim::ExportFormat format = sim::ExportFormat::Csv) const {
+        sim::DataExporter exporter;
+        exporter.begin(out, format, {"frame", "time_s", "frame_ms", "fps", "memory_bytes"});
+        for (std::size_t i = 0; i < m_samples.size(); ++i) {
+            const BenchmarkSample& s = m_samples[i];
+            exporter.record({static_cast<double>(i), s.timeSeconds, s.frameMs, s.fps,
+                             static_cast<double>(s.memoryBytes)});
+        }
+        exporter.end();
+    }
+
+    /// Export to @p path. Returns false if the file cannot be opened.
+    bool exportToFile(const std::string& path, sim::ExportFormat format = sim::ExportFormat::Csv) const {
+        std::ofstream out(path, std::ios::trunc);
+        if (!out) return false;
+        exportTo(out, format);
+        return static_cast<bool>(out);
+    }
+
+private:
+    std::vector<BenchmarkSample> m_samples;
+    double m_elapsed{0.0};
+    long m_peakMemory{0};
+    bool m_capturing{false};
+};
+
+} // namespace IKore

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -323,6 +323,12 @@ void DebugUI::update(float deltaTimeSeconds) {
     // graph is populated when it is opened.
     m_perf.record(deltaTimeSeconds);
 
+    // Benchmark capture (#62) runs regardless of panel visibility. When not
+    // capturing this is a single branch, so it costs nothing when idle/disabled.
+    if (m_benchmark.capturing()) {
+        m_benchmark.record(static_cast<double>(deltaTimeSeconds), PerfStats::residentBytes());
+    }
+
     // Animate the demo HUD state so the data-bound widgets visibly update. In a
     // real game these values come from ECS/game systems instead.
     m_hudClock += deltaTimeSeconds;
@@ -377,6 +383,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::Checkbox("Show scene hierarchy (#59)", &m_showHierarchy);
     ImGui::Checkbox("Show input bindings (#60)", &m_showInput);
     ImGui::Checkbox("Show UI scaling (#61)", &m_showScaling);
+    ImGui::Checkbox("Show benchmark (#62)", &m_showBenchmark);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
@@ -389,6 +396,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     renderHierarchy();
     renderInputBindings();
     renderScaling();
+    renderBenchmark();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
@@ -791,6 +799,56 @@ void DebugUI::renderScaling() {
         m_settings.setFloat("ui.scale", 1.0f);
         saveSettings();
     }
+
+    ImGui::End();
+}
+
+void DebugUI::renderBenchmark() {
+    if (!m_showBenchmark) return;
+
+    ImGui::Begin("Benchmark", &m_showBenchmark);
+
+    const bool capturing = m_benchmark.capturing();
+    if (capturing) {
+        if (ImGui::Button("Stop")) m_benchmark.stop();
+    } else {
+        if (ImGui::Button("Start")) m_benchmark.start();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Reset")) {
+        m_benchmark.reset();
+        m_benchmarkStatus.clear();
+    }
+
+    ImGui::Text("Capturing: %s", capturing ? "yes" : "no");
+    ImGui::Text("Samples: %zu    Duration: %.2f s", m_benchmark.sampleCount(),
+                m_benchmark.durationSeconds());
+
+    if (m_benchmark.sampleCount() > 0) {
+        ImGui::Text("FPS: avg %.1f (min %.1f, max %.1f)", m_benchmark.avgFps(), m_benchmark.minFps(),
+                    m_benchmark.maxFps());
+        ImGui::Text("Frame ms: avg %.3f (min %.3f, max %.3f)", m_benchmark.avgFrameMs(),
+                    m_benchmark.minFrameMs(), m_benchmark.maxFrameMs());
+        if (m_benchmark.peakMemoryBytes() > 0) {
+            ImGui::Text("Peak memory: %.1f MB",
+                        static_cast<double>(m_benchmark.peakMemoryBytes()) / (1024.0 * 1024.0));
+        }
+    }
+
+    ImGui::Separator();
+    ImGui::Checkbox("Export as JSON", &m_benchmarkJson);
+    ImGui::SameLine();
+    if (ImGui::Button("Export")) {
+        const char* path = m_benchmarkJson ? "ikore_benchmark.json" : "ikore_benchmark.csv";
+        const sim::ExportFormat format = m_benchmarkJson ? sim::ExportFormat::Json : sim::ExportFormat::Csv;
+        if (m_benchmark.exportToFile(path, format)) {
+            m_benchmarkStatus = "Exported " + std::to_string(m_benchmark.sampleCount()) +
+                                " samples to " + path;
+        } else {
+            m_benchmarkStatus = "Export failed";
+        }
+    }
+    if (!m_benchmarkStatus.empty()) ImGui::TextUnformatted(m_benchmarkStatus.c_str());
 
     ImGui::End();
 }

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "core/Benchmark.h"
 #include "core/DebugConsole.h"
 #include "core/InputMap.h"
 #include "core/PerfStats.h"
@@ -100,6 +101,7 @@ private:
     void renderInputBindings();
     void renderScaling();
     void applyScaling();
+    void renderBenchmark();
 
     bool m_initialized{false};
     bool m_visible{false};
@@ -113,6 +115,7 @@ private:
     bool m_showHierarchy{true};
     bool m_showInput{true};
     bool m_showScaling{true};
+    bool m_showBenchmark{true};
     PerfStats m_perf;
     DebugConsole m_console;
     Hud m_hud;
@@ -166,6 +169,12 @@ private:
     // ImGui (font + style) and the HUD; the user scale persists in settings.
     UiScaleConfig m_uiScale;
     float m_effectiveScale{1.0f};
+
+    // Benchmark capture (#62): records FPS/frame-time/memory over a run (fed each
+    // frame from update() while capturing) and exports via the #155 format.
+    Benchmark m_benchmark;
+    bool m_benchmarkJson{false};
+    std::string m_benchmarkStatus;
 };
 
 } // namespace IKore

--- a/tests/test_benchmark.cpp
+++ b/tests/test_benchmark.cpp
@@ -1,0 +1,181 @@
+// Test for the performance benchmark recorder - Milestone 9, #62.
+//
+// Verifies capture lifecycle (only records while running), sample values, summary
+// statistics (avg/min/max frame time and FPS, peak memory, duration), and export
+// through the deterministic DataExporter format (#155) as CSV and JSON, including
+// a round trip to disk.
+//
+// Pure std + header-only (reuses the header-only DataExporter):
+//   g++ -std=c++17 -I src tests/test_benchmark.cpp -o test_benchmark
+
+#include "core/Benchmark.h"
+
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(double a, double b) { return std::fabs(a - b) < 1e-4; }
+
+static std::size_t countLines(const std::string& s) {
+    std::size_t n = 0;
+    for (char c : s) {
+        if (c == '\n') ++n;
+    }
+    return n;
+}
+
+static void testCaptureLifecycle() {
+    Benchmark b;
+    CHECK(!b.capturing());
+
+    // Records before start are ignored (negligible cost when idle/disabled).
+    b.record(0.016, 100);
+    CHECK(b.sampleCount() == 0);
+
+    b.start();
+    CHECK(b.capturing());
+    b.record(0.010, 1000);
+    b.record(0.020, 2000);
+    CHECK(b.sampleCount() == 2);
+
+    b.stop();
+    CHECK(!b.capturing());
+    b.record(0.030, 3000); // ignored after stop
+    CHECK(b.sampleCount() == 2);
+
+    // start() clears the prior run.
+    b.start();
+    CHECK(b.sampleCount() == 0);
+    CHECK(approx(b.durationSeconds(), 0.0));
+}
+
+static void testSamplesAndSummary() {
+    Benchmark b;
+    b.start();
+    b.record(0.010, 1000); // 10 ms -> 100 fps
+    b.record(0.020, 2000); // 20 ms -> 50 fps
+    b.record(0.030, 1500); // 30 ms -> ~33.3 fps
+    b.stop();
+
+    CHECK(b.sampleCount() == 3);
+
+    // Time accumulates across samples.
+    CHECK(approx(b.samples()[0].timeSeconds, 0.01));
+    CHECK(approx(b.samples()[1].timeSeconds, 0.03));
+    CHECK(approx(b.samples()[2].timeSeconds, 0.06));
+    CHECK(approx(b.durationSeconds(), 0.06));
+
+    // Per-sample values.
+    CHECK(approx(b.samples()[0].frameMs, 10.0));
+    CHECK(approx(b.samples()[0].fps, 100.0));
+    CHECK(b.samples()[1].memoryBytes == 2000);
+
+    // Summary.
+    CHECK(approx(b.avgFrameMs(), 20.0));
+    CHECK(approx(b.minFrameMs(), 10.0));
+    CHECK(approx(b.maxFrameMs(), 30.0));
+    CHECK(approx(b.avgFps(), 50.0));                 // 1000 / 20
+    CHECK(approx(b.maxFps(), 100.0));                // fastest frame (10 ms)
+    CHECK(approx(b.minFps(), 1000.0 / 30.0));        // slowest frame (30 ms)
+    CHECK(b.peakMemoryBytes() == 2000);
+}
+
+static void testEmptySummarySafe() {
+    Benchmark b;
+    CHECK(approx(b.avgFrameMs(), 0.0));
+    CHECK(approx(b.minFrameMs(), 0.0));
+    CHECK(approx(b.maxFrameMs(), 0.0));
+    CHECK(approx(b.avgFps(), 0.0));
+    CHECK(approx(b.minFps(), 0.0));
+    CHECK(approx(b.maxFps(), 0.0));
+    CHECK(b.peakMemoryBytes() == 0);
+    CHECK(approx(b.durationSeconds(), 0.0));
+}
+
+static void testCsvExport() {
+    Benchmark b;
+    b.start();
+    b.record(0.010, 1000);
+    b.record(0.020, 2000);
+    b.stop();
+
+    std::ostringstream os;
+    b.exportTo(os, sim::ExportFormat::Csv);
+    const std::string out = os.str();
+
+    // Header + one row per sample, and clean integral formatting.
+    CHECK(out.find("frame,time_s,frame_ms,fps,memory_bytes\n") == 0);
+    CHECK(out.find("0,0.01,10,100,1000\n") != std::string::npos);
+    CHECK(out.find("1,0.03,20,50,2000\n") != std::string::npos);
+    CHECK(countLines(out) == 3); // header + 2 rows
+}
+
+static void testJsonExport() {
+    Benchmark b;
+    b.start();
+    b.record(0.010, 1000);
+    b.stop();
+
+    std::ostringstream os;
+    b.exportTo(os, sim::ExportFormat::Json);
+    const std::string out = os.str();
+
+    CHECK(out.front() == '[');
+    CHECK(out.find("\"frame\":0") != std::string::npos);
+    CHECK(out.find("\"memory_bytes\":1000") != std::string::npos);
+    CHECK(out.find(']') != std::string::npos);
+}
+
+static void testExportToFileRoundTrip() {
+    const std::string path = "ikore_benchmark_test.csv";
+    Benchmark b;
+    b.start();
+    b.record(0.010, 1000);
+    b.record(0.020, 2000);
+    b.record(0.030, 3000);
+    b.stop();
+
+    CHECK(b.exportToFile(path, sim::ExportFormat::Csv));
+
+    std::ifstream in(path);
+    CHECK(in.good());
+    std::stringstream ss;
+    ss << in.rdbuf();
+    const std::string content = ss.str();
+    in.close();
+
+    CHECK(content.find("frame,time_s,frame_ms,fps,memory_bytes") == 0);
+    CHECK(countLines(content) == 4); // header + 3 rows
+
+    std::remove(path.c_str());
+}
+
+int main() {
+    testCaptureLifecycle();
+    testSamplesAndSummary();
+    testEmptySummarySafe();
+    testCsvExport();
+    testJsonExport();
+    testExportToFileRoundTrip();
+
+    if (g_failures == 0) {
+        std::printf("All benchmark tests passed.\n");
+        return 0;
+    }
+    std::printf("%d benchmark test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Adds a benchmarking panel that captures FPS, frame time, and memory over a run and exports the data to a structured, parseable file. Follows the same split proven by #53-#61: a headless, unit-tested core plus a thin ImGui panel wired into `DebugUI`.

Closes #62

## Core: `src/core/Benchmark.h` (header-only, std only)

- Explicit capture lifecycle (`start` / `stop` / `reset`); `record()` appends a sample only while capturing, so it is a single-branch no-op when idle or disabled. Each sample holds accumulated time, frame ms, fps, and memory.
- Summary stats: duration, avg/min/max frame time, avg/min/max FPS, and peak memory (all safe on an empty run).
- `exportTo()` / `exportToFile()` reuse the deterministic `DataExporter` format from Milestone 12 (#155) to write columns `[frame, time_s, frame_ms, fps, memory_bytes]` as CSV or JSON.
- The frame-time and memory values are the same ones the perf overlay uses (`PerfStats`, #53), fed by the engine.

## Panel: `src/ui/DebugUI`

- A "Benchmark" window with **Start** / **Stop** / **Reset**, live sample-count / duration / FPS / frame-time / peak-memory readouts, a CSV-or-JSON toggle, and an **Export** button that writes `ikore_benchmark.csv` or `.json` and reports the result.
- Capture is driven from `update()` each frame while running (using `PerfStats::residentBytes()` for memory), so it records over the whole session regardless of panel visibility and costs nothing (a single branch) when not capturing.

## Testing

- `tests/test_benchmark.cpp` covers the capture lifecycle (records only while running; ignores records before start and after stop), sample values and time accumulation, summary statistics, empty-run safety, and CSV/JSON export through the #155 format (exact header and row formatting) plus a to-file round trip.
- Passes locally under ASan/UBSan (`All benchmark tests passed.`).
- New CMake target `test_benchmark`.
- The ImGui panel is compiled by CI (CodeQL c-cpp build).

## Acceptance criteria

- Metrics record over a session and export to a structured, parseable file: the recorder captures per-frame FPS/frame-time/memory across a run and exports via the deterministic `DataExporter` (CSV header + one row per sample, or a single JSON array); verified in the unit test including a disk round trip.
- Capture has negligible impact when idle or disabled: `record()` returns on one branch unless a run is active, and `update()` only calls it while capturing, so nothing is sampled or allocated when off.

## Notes

- Reuses existing infrastructure directly: `PerfStats` (#53) for the metric values and `IKore::sim::DataExporter` (#155) for the export format, rather than duplicating either.