### PR TITLE
[M9] Add logging system with in-engine log viewer (#63)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -660,6 +660,11 @@ add_executable(test_benchmark
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_benchmark.cpp
 )
 
+# Structured logging system (Milestone 9 / #63) - header-only.
+add_executable(test_log_system
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_log_system.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/core/LogSystem.h
+++ b/src/core/LogSystem.h
@@ -1,0 +1,177 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <fstream>
+#include <functional>
+#include <set>
+#include <string>
+#include <vector>
+
+/**
+ * @file LogSystem.h
+ * @brief Structured logging with levels, categories, sinks, and a viewer ring (#63).
+ *
+ * Milestone 9 (In-Engine Editor & Tooling). The headless core behind the in-engine
+ * log viewer: log messages with a level (Trace..Error) and a category, keep a
+ * bounded in-memory ring for the viewer's real-time tail, optionally mirror to a
+ * readable file sink, and fan out to registered sinks (e.g. the debug console, #54).
+ * Sub-threshold messages are dropped on a single branch, and each accepted message
+ * is an O(1) ring push plus a buffered file write, so real-time logging does not
+ * impact the frame rate.
+ *
+ * Records carry a monotonic index instead of a wall-clock timestamp, so the core is
+ * deterministic and unit-testable without a clock. Header-only, std only.
+ */
+namespace IKore {
+
+enum class LogLevel { Trace, Debug, Info, Warning, Error };
+
+inline const char* logLevelName(LogLevel level) {
+    switch (level) {
+        case LogLevel::Trace: return "TRACE";
+        case LogLevel::Debug: return "DEBUG";
+        case LogLevel::Info: return "INFO";
+        case LogLevel::Warning: return "WARN";
+        case LogLevel::Error: return "ERROR";
+    }
+    return "?";
+}
+
+struct LogRecord {
+    std::uint64_t index{0};
+    LogLevel level{LogLevel::Info};
+    std::string category;
+    std::string message;
+
+    /// Readable one-line form: "[LEVEL] [category] message" (category omitted if empty).
+    std::string format() const {
+        std::string out = "[";
+        out += logLevelName(level);
+        out += "]";
+        if (!category.empty()) {
+            out += " [";
+            out += category;
+            out += "]";
+        }
+        out += " ";
+        out += message;
+        return out;
+    }
+};
+
+class LogSystem {
+public:
+    using Sink = std::function<void(const LogRecord&)>;
+
+    explicit LogSystem(std::size_t capacity = 1000)
+        : m_capacity(capacity == 0 ? 1 : capacity) {}
+
+    void setMinLevel(LogLevel level) { m_minLevel = level; }
+    LogLevel minLevel() const { return m_minLevel; }
+
+    /// Log a message. Dropped on one branch if below the minimum level.
+    void log(LogLevel level, const std::string& category, const std::string& message) {
+        if (static_cast<int>(level) < static_cast<int>(m_minLevel)) return;
+
+        LogRecord record{m_nextIndex++, level, category, message};
+        m_records.push_back(record);
+        while (m_records.size() > m_capacity) m_records.pop_front();
+        if (!category.empty()) m_categories.insert(category);
+        ++m_levelCounts[static_cast<int>(level)];
+
+        if (m_file.is_open()) {
+            m_file << record.format() << "\n";
+            if (level == LogLevel::Error) m_file.flush(); // errors persist immediately
+        }
+        for (const Sink& sink : m_sinks) {
+            if (sink) sink(record);
+        }
+    }
+
+    void trace(const std::string& category, const std::string& message) {
+        log(LogLevel::Trace, category, message);
+    }
+    void debug(const std::string& category, const std::string& message) {
+        log(LogLevel::Debug, category, message);
+    }
+    void info(const std::string& category, const std::string& message) {
+        log(LogLevel::Info, category, message);
+    }
+    void warning(const std::string& category, const std::string& message) {
+        log(LogLevel::Warning, category, message);
+    }
+    void error(const std::string& category, const std::string& message) {
+        log(LogLevel::Error, category, message);
+    }
+
+    /// Bounded ring of recent records, oldest first (the viewer's tail).
+    const std::deque<LogRecord>& records() const { return m_records; }
+    /// Cumulative accepted records this session (monotonic; survives clear()).
+    std::uint64_t totalLogged() const { return m_nextIndex; }
+
+    /// Cumulative count of records at or above @p level (a cheap summary stat).
+    std::size_t countAtLeast(LogLevel level) const {
+        std::size_t total = 0;
+        for (int i = static_cast<int>(level); i <= static_cast<int>(LogLevel::Error); ++i) {
+            total += m_levelCounts[i];
+        }
+        return total;
+    }
+
+    /// Distinct categories seen so far, sorted.
+    std::vector<std::string> categories() const {
+        return std::vector<std::string>(m_categories.begin(), m_categories.end());
+    }
+
+    /// Snapshot of ring records at or above @p minLevel, optionally one category.
+    std::vector<LogRecord> filter(LogLevel minLevel, const std::string& category = "") const {
+        std::vector<LogRecord> out;
+        for (const LogRecord& r : m_records) {
+            if (static_cast<int>(r.level) < static_cast<int>(minLevel)) continue;
+            if (!category.empty() && r.category != category) continue;
+            out.push_back(r);
+        }
+        return out;
+    }
+
+    /// Empty the viewer ring and category set (totals and file are unaffected).
+    void clear() {
+        m_records.clear();
+        m_categories.clear();
+    }
+
+    /// Register a sink called for each accepted record; returns its id.
+    int addSink(Sink sink) {
+        m_sinks.push_back(std::move(sink));
+        return static_cast<int>(m_sinks.size()) - 1;
+    }
+
+    /// Open a file sink (truncating). Returns false if it cannot be opened.
+    bool openFile(const std::string& path) {
+        m_file.close();
+        m_file.clear();
+        m_file.open(path, std::ios::trunc);
+        return m_file.is_open();
+    }
+    void closeFile() {
+        if (m_file.is_open()) {
+            m_file.flush();
+            m_file.close();
+        }
+    }
+    bool fileOpen() const { return m_file.is_open(); }
+
+private:
+    std::deque<LogRecord> m_records;
+    std::set<std::string> m_categories;
+    std::vector<Sink> m_sinks;
+    std::ofstream m_file;
+    std::size_t m_capacity;
+    std::uint64_t m_nextIndex{0};
+    LogLevel m_minLevel{LogLevel::Trace};
+    std::size_t m_levelCounts[5]{0, 0, 0, 0, 0};
+};
+
+} // namespace IKore

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -305,6 +305,15 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
     m_inputMap.addAction("AltFire", {InputDevice::Mouse, 1});
     m_inputMap.loadFromFile("ikore_input.ini");
 
+    // Logging + in-engine viewer (#63): mirror every log line into the debug
+    // console (#54), open a readable file sink, and seed a few example records.
+    m_log.addSink([this](const LogRecord& record) { m_console.print(record.format()); });
+    m_log.openFile("ikore_log.txt");
+    m_log.info("engine", "Log system online");
+    m_log.debug("physics", "Broadphase pairs: 128");
+    m_log.warning("render", "Shader cache miss for 'pbr'");
+    m_log.error("audio", "Failed to open device (using fallback)");
+
     m_initialized = true;
     LOG_INFO("DebugUI: Dear ImGui initialized (press F1 to toggle)");
     return true;
@@ -312,6 +321,7 @@ bool DebugUI::initialize(GLFWwindow* window, const char* glslVersion) {
 
 void DebugUI::shutdown() {
     if (!m_initialized) return;
+    m_log.closeFile(); // flush any buffered log lines to disk (#63)
     ImGui_ImplOpenGL3_Shutdown();
     ImGui_ImplGlfw_Shutdown();
     ImGui::DestroyContext();
@@ -327,6 +337,14 @@ void DebugUI::update(float deltaTimeSeconds) {
     // capturing this is a single branch, so it costs nothing when idle/disabled.
     if (m_benchmark.capturing()) {
         m_benchmark.record(static_cast<double>(deltaTimeSeconds), PerfStats::residentBytes());
+    }
+
+    // Demo heartbeat log (#63) every ~2s, to show the viewer's real-time tail and
+    // the console feed updating live.
+    m_logClock += deltaTimeSeconds;
+    if (m_logClock >= 2.0f) {
+        m_logClock = 0.0f;
+        m_log.info("engine", "Heartbeat at frame " + std::to_string(m_perf.frameCount()));
     }
 
     // Animate the demo HUD state so the data-bound widgets visibly update. In a
@@ -384,6 +402,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     ImGui::Checkbox("Show input bindings (#60)", &m_showInput);
     ImGui::Checkbox("Show UI scaling (#61)", &m_showScaling);
     ImGui::Checkbox("Show benchmark (#62)", &m_showBenchmark);
+    ImGui::Checkbox("Show log viewer (#63)", &m_showLog);
     ImGui::Checkbox("Show ImGui demo window", &m_showDemoWindow);
     ImGui::End();
 
@@ -397,6 +416,7 @@ void DebugUI::buildUI(float deltaTimeSeconds) {
     renderInputBindings();
     renderScaling();
     renderBenchmark();
+    renderLog();
 
     if (m_showDemoWindow) {
         ImGui::ShowDemoWindow(&m_showDemoWindow);
@@ -849,6 +869,72 @@ void DebugUI::renderBenchmark() {
         }
     }
     if (!m_benchmarkStatus.empty()) ImGui::TextUnformatted(m_benchmarkStatus.c_str());
+
+    ImGui::End();
+}
+
+static ImVec4 colorForLogLevel(LogLevel level) {
+    switch (level) {
+        case LogLevel::Trace: return ImVec4(0.55f, 0.55f, 0.55f, 1.0f);
+        case LogLevel::Debug: return ImVec4(0.65f, 0.75f, 0.95f, 1.0f);
+        case LogLevel::Info: return ImVec4(0.85f, 0.85f, 0.85f, 1.0f);
+        case LogLevel::Warning: return ImVec4(0.95f, 0.80f, 0.35f, 1.0f);
+        case LogLevel::Error: return ImVec4(0.95f, 0.40f, 0.40f, 1.0f);
+    }
+    return ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+}
+
+void DebugUI::renderLog() {
+    if (!m_showLog) return;
+
+    ImGui::Begin("Log Viewer", &m_showLog);
+
+    // Filter controls: minimum level and category.
+    static const char* levelNames[] = {"TRACE", "DEBUG", "INFO", "WARN", "ERROR"};
+    ImGui::SetNextItemWidth(110.0f);
+    ImGui::Combo("Min level", &m_logFilterLevel, levelNames, IM_ARRAYSIZE(levelNames));
+
+    const std::vector<std::string> cats = m_log.categories();
+    if (m_logCategoryIndex > static_cast<int>(cats.size())) m_logCategoryIndex = 0;
+    const char* catPreview =
+        m_logCategoryIndex == 0 ? "(all)" : cats[static_cast<std::size_t>(m_logCategoryIndex - 1)].c_str();
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(150.0f);
+    if (ImGui::BeginCombo("Category", catPreview)) {
+        if (ImGui::Selectable("(all)", m_logCategoryIndex == 0)) m_logCategoryIndex = 0;
+        for (int i = 0; i < static_cast<int>(cats.size()); ++i) {
+            if (ImGui::Selectable(cats[static_cast<std::size_t>(i)].c_str(), m_logCategoryIndex == i + 1)) {
+                m_logCategoryIndex = i + 1;
+            }
+        }
+        ImGui::EndCombo();
+    }
+    ImGui::SameLine();
+    ImGui::Checkbox("Auto-scroll", &m_logAutoScroll);
+    ImGui::SameLine();
+    if (ImGui::Button("Clear")) m_log.clear();
+
+    ImGui::Text("Total: %llu    Warnings+: %zu    Errors: %zu",
+                static_cast<unsigned long long>(m_log.totalLogged()),
+                m_log.countAtLeast(LogLevel::Warning), m_log.countAtLeast(LogLevel::Error));
+    ImGui::Separator();
+
+    const LogLevel minLevel = static_cast<LogLevel>(m_logFilterLevel);
+    const std::string catFilter =
+        m_logCategoryIndex > 0 ? cats[static_cast<std::size_t>(m_logCategoryIndex - 1)] : std::string();
+
+    // Real-time tail: iterate the ring in place (no per-frame allocation) and
+    // auto-scroll to the newest line while pinned to the bottom.
+    ImGui::BeginChild("log_scroll", ImVec2(0.0f, 0.0f), true, ImGuiWindowFlags_HorizontalScrollbar);
+    for (const LogRecord& record : m_log.records()) {
+        if (static_cast<int>(record.level) < static_cast<int>(minLevel)) continue;
+        if (!catFilter.empty() && record.category != catFilter) continue;
+        ImGui::PushStyleColor(ImGuiCol_Text, colorForLogLevel(record.level));
+        ImGui::TextUnformatted(record.format().c_str());
+        ImGui::PopStyleColor();
+    }
+    if (m_logAutoScroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) ImGui::SetScrollHereY(1.0f);
+    ImGui::EndChild();
 
     ImGui::End();
 }

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -3,6 +3,7 @@
 #include "core/Benchmark.h"
 #include "core/DebugConsole.h"
 #include "core/InputMap.h"
+#include "core/LogSystem.h"
 #include "core/PerfStats.h"
 #include "core/Picking.h"
 #include "core/Settings.h"
@@ -102,6 +103,7 @@ private:
     void renderScaling();
     void applyScaling();
     void renderBenchmark();
+    void renderLog();
 
     bool m_initialized{false};
     bool m_visible{false};
@@ -116,6 +118,7 @@ private:
     bool m_showInput{true};
     bool m_showScaling{true};
     bool m_showBenchmark{true};
+    bool m_showLog{true};
     PerfStats m_perf;
     DebugConsole m_console;
     Hud m_hud;
@@ -175,6 +178,14 @@ private:
     Benchmark m_benchmark;
     bool m_benchmarkJson{false};
     std::string m_benchmarkStatus;
+
+    // Logging + in-engine viewer (#63): structured logs feed the console (#54) and a
+    // file sink; the viewer filters by level/category and tails in real time.
+    LogSystem m_log;
+    int m_logFilterLevel{0};   // index into LogLevel for the viewer's min level
+    int m_logCategoryIndex{0}; // 0 = all categories
+    bool m_logAutoScroll{true};
+    float m_logClock{0.0f};    // paces the demo heartbeat log
 };
 
 } // namespace IKore

--- a/tests/test_log_system.cpp
+++ b/tests/test_log_system.cpp
@@ -1,0 +1,185 @@
+// Test for the structured logging core - Milestone 9, #63.
+//
+// Verifies levels and categories, the level threshold (dropping sub-threshold
+// messages cheaply), the bounded viewer ring vs cumulative totals, per-level
+// counts, category listing, filtering, sinks (the console-feed mechanism), and the
+// readable file sink.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_log_system.cpp -o test_log_system
+
+#include "core/LogSystem.h"
+
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static std::size_t countLines(const std::string& s) {
+    std::size_t n = 0;
+    for (char c : s) {
+        if (c == '\n') ++n;
+    }
+    return n;
+}
+
+static void testLevelsCategoriesAndFormat() {
+    LogSystem log;
+    log.info("engine", "started");
+    log.warning("render", "shader cache miss");
+    log.error("audio", "device open failed");
+
+    CHECK(log.records().size() == 3);
+    CHECK(log.totalLogged() == 3);
+    CHECK(log.records()[0].level == LogLevel::Info);
+    CHECK(log.records()[0].category == "engine");
+    CHECK(log.records()[0].message == "started");
+    CHECK(log.records()[0].index == 0);
+    CHECK(log.records()[2].index == 2);
+
+    CHECK(log.records()[0].format() == "[INFO] [engine] started");
+    CHECK(log.records()[1].format() == "[WARN] [render] shader cache miss");
+
+    // Level names.
+    CHECK(std::string(logLevelName(LogLevel::Error)) == "ERROR");
+    CHECK(std::string(logLevelName(LogLevel::Trace)) == "TRACE");
+}
+
+static void testMinLevelThreshold() {
+    LogSystem log;
+    log.setMinLevel(LogLevel::Warning);
+    log.trace("x", "t");
+    log.debug("x", "d");
+    log.info("x", "i");     // all three below Warning -> dropped
+    log.warning("x", "w");
+    log.error("x", "e");
+
+    CHECK(log.records().size() == 2);
+    CHECK(log.totalLogged() == 2); // dropped messages are not counted
+    CHECK(log.records()[0].level == LogLevel::Warning);
+    CHECK(log.records()[1].level == LogLevel::Error);
+}
+
+static void testRingCapacityVsTotal() {
+    LogSystem log(3); // ring holds only the last 3
+    for (int i = 0; i < 5; ++i) log.info("n", "m" + std::to_string(i));
+
+    CHECK(log.records().size() == 3);
+    CHECK(log.totalLogged() == 5);
+    CHECK(log.records().front().message == "m2"); // oldest surviving
+    CHECK(log.records().back().message == "m4");
+    CHECK(log.records().back().index == 4); // indices stay monotonic
+
+    // clear() empties the ring but not the cumulative total.
+    log.clear();
+    CHECK(log.records().empty());
+    CHECK(log.totalLogged() == 5);
+    log.info("n", "again");
+    CHECK(log.records().back().index == 5); // continues past clear
+}
+
+static void testCountsAndCategories() {
+    LogSystem log;
+    log.info("a", "1");
+    log.info("b", "2");
+    log.warning("a", "3");
+    log.error("c", "4");
+
+    CHECK(log.countAtLeast(LogLevel::Warning) == 2); // warning + error
+    CHECK(log.countAtLeast(LogLevel::Error) == 1);
+    CHECK(log.countAtLeast(LogLevel::Trace) == 4);   // everything
+
+    const std::vector<std::string> cats = log.categories();
+    CHECK(cats.size() == 3);
+    CHECK(cats[0] == "a" && cats[1] == "b" && cats[2] == "c"); // sorted
+}
+
+static void testFilter() {
+    LogSystem log;
+    log.info("render", "i1");
+    log.warning("render", "w1");
+    log.warning("audio", "w2");
+    log.error("render", "e1");
+
+    // By level only.
+    CHECK(log.filter(LogLevel::Warning).size() == 3);
+    // By level and category.
+    const std::vector<LogRecord> renderWarnPlus = log.filter(LogLevel::Warning, "render");
+    CHECK(renderWarnPlus.size() == 2);
+    CHECK(renderWarnPlus[0].message == "w1" && renderWarnPlus[1].message == "e1");
+    // Category with a low threshold picks up everything in that category.
+    CHECK(log.filter(LogLevel::Trace, "render").size() == 3);
+}
+
+static void testSinksFeedConsole() {
+    LogSystem log;
+    std::vector<std::string> consoleLines; // stands in for the debug console (#54)
+    log.addSink([&consoleLines](const LogRecord& r) { consoleLines.push_back(r.format()); });
+
+    log.info("engine", "hello");
+    log.setMinLevel(LogLevel::Warning);
+    log.info("engine", "dropped"); // below threshold: sink must NOT fire
+    log.error("engine", "boom");
+
+    CHECK(consoleLines.size() == 2);
+    CHECK(consoleLines[0] == "[INFO] [engine] hello");
+    CHECK(consoleLines[1] == "[ERROR] [engine] boom");
+}
+
+static void testFileSink() {
+    const std::string path = "ikore_log_test.txt";
+    {
+        LogSystem log;
+        CHECK(log.openFile(path));
+        CHECK(log.fileOpen());
+        log.info("engine", "line one");
+        log.warning("render", "line two");
+        log.error("audio", "line three");
+        log.closeFile();
+        CHECK(!log.fileOpen());
+    }
+
+    std::ifstream in(path);
+    CHECK(in.good());
+    std::stringstream ss;
+    ss << in.rdbuf();
+    const std::string content = ss.str();
+    in.close();
+
+    CHECK(countLines(content) == 3);
+    CHECK(content.find("[INFO] [engine] line one") != std::string::npos);
+    CHECK(content.find("[WARN] [render] line two") != std::string::npos);
+    CHECK(content.find("[ERROR] [audio] line three") != std::string::npos);
+
+    std::remove(path.c_str());
+}
+
+int main() {
+    testLevelsCategoriesAndFormat();
+    testMinLevelThreshold();
+    testRingCapacityVsTotal();
+    testCountsAndCategories();
+    testFilter();
+    testSinksFeedConsole();
+    testFileSink();
+
+    if (g_failures == 0) {
+        std::printf("All log system tests passed.\n");
+        return 0;
+    }
+    std::printf("%d log system test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Part of Milestone 9: In-Engine Editor & Tooling. Adds structured logging (levels and categories) with a file sink and an in-engine log viewer that filters by level/category and tails in real time, feeding the debug console (#54). Follows the same split proven by #53-#62: a headless, unit-tested core plus a thin ImGui panel wired into `DebugUI`. **This completes Milestone 9** (#53-#63).

Closes #63

## Core: `src/core/LogSystem.h` (header-only, std only)

- `log()` with a level (`Trace`..`Error`) and a category, plus `trace`/`debug`/`info`/`warning`/`error` convenience methods. A minimum-level threshold drops sub-threshold messages on a single branch.
- A bounded in-memory ring for the viewer (`records()`), a monotonic cumulative total (`totalLogged()`), and per-level counts (`countAtLeast()`). Records carry a monotonic index rather than a wall-clock timestamp, so the core is deterministic and testable.
- A readable file sink (`openFile` / `closeFile`; error-level records flush immediately) and generic sinks (`addSink`) so consumers like the console receive each record. `filter()` / `categories()` back the viewer's level/category filters.
- Each accepted log is an O(1) ring push plus a buffered file write, so real-time logging does not impact the frame rate.

## Panel: `src/ui/DebugUI`

- A "Log Viewer" window with a minimum-level combo, a category combo, an **Auto-scroll** toggle (real-time tail), a **Clear** button, per-level color coding, and a total / warnings+ / errors summary. The tail iterates the ring in place (no per-frame allocation).
- On init a sink mirrors every log line into the debug console (#54), a file sink (`ikore_log.txt`) is opened, and a few example records are seeded; a demo heartbeat logs every ~2s to show the live tail. The file is flushed and closed on shutdown.

## Testing

- `tests/test_log_system.cpp` covers levels/categories and the readable format, the min-level threshold (dropped messages are neither stored nor counted), the bounded ring vs cumulative total across `clear()`, per-level counts, sorted categories, level+category filtering, sinks (including that sub-threshold records do not fire them), and the file-sink round trip.
- Passes locally under ASan/UBSan (`All log system tests passed.`).
- New CMake target `test_log_system`.
- The ImGui panel is compiled by CI (CodeQL c-cpp build).

## Acceptance criteria

- Logs capture errors, warnings, and info to a readable file and to the viewer: `log()` records to the ring (viewer) and the file sink in a readable `[LEVEL] [category] message` form; verified by the unit test (including the file round trip), and the panel shows the same records with per-level coloring.
- Real-time logging does not impact frame rate: sub-threshold messages return on one branch, and each accepted record is O(1) plus a buffered write (errors flush; the rest flush on close), with the viewer tailing the ring without per-frame allocation.

## Notes

- Self-contained `LogSystem` (separate from the existing `Logger`); the demo drives it from `DebugUI` (mirroring #53-#62). Engine systems adopt it by logging via `LogSystem` and, if desired, routing the existing logger through a sink.