### PR TITLE
Add end-to-end vertical slice: import -> crowd -> rewind (roadmap section 6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,6 +665,11 @@ add_executable(test_log_system
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_log_system.cpp
 )
 
+# Vertical-slice integration: import -> nav -> crowd -> rewind (roadmap section 6).
+add_executable(test_vertical_slice
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_vertical_slice.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/game/VerticalSlice.h
+++ b/src/game/VerticalSlice.h
@@ -1,0 +1,251 @@
+#pragma once
+
+#include "core/ecs/ECS.h"
+#include "core/ecs/components/Components.h"
+#include "core/sim/Crowd.h"
+#include "core/sim/Simulation.h"
+#include "core/sim/Timeline.h"
+#include "world/GeoJsonImporter.h"
+#include "world/NavMesh.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+/**
+ * @file VerticalSlice.h
+ * @brief The roadmap's headline vertical slice, composed end to end (EXPANSION_IDEAS 6).
+ *
+ * "Import a real neighborhood, walk it, watch a crowd navigate it, then rewind
+ * time." This is the integration that ties the finished foundations into one
+ * story: the GeoJSON importer (world), a baked nav grid + flow field (world/sim),
+ * an archetype-ECS crowd (ecs/sim), and deterministic fixed-step time with
+ * snapshot rewind (sim::Timeline).
+ *
+ * The pieces already exist and are individually tested; this is the glue plus a
+ * small, testable state machine. It is headless (no GL): the ImGui walkthrough and
+ * rewind scrubber sit on top of this in DebugUI. Because every dependency is
+ * header-only and glm-free (ecs::Vec3), the whole slice is unit-testable, including
+ * its determinism guarantee: replaying from a rewound tick reproduces the crowd
+ * exactly. Header-only, std only.
+ */
+namespace IKore {
+namespace game {
+
+/// Per-agent state captured each tick so the crowd can be rewound and replayed.
+struct AgentSnapshot {
+    ecs::Vec3 position;
+    bool arrived{false};
+};
+using CrowdState = std::vector<AgentSnapshot>;
+
+class VerticalSlice {
+public:
+    struct Config {
+        float cellSize{1.0f};            ///< Nav-grid cell size (world units).
+        float agentRadius{0.3f};         ///< Obstacle inflation for baking.
+        float boundsMargin{4.0f};        ///< Padding around the imported extents.
+        float agentSpeed{4.0f};          ///< Crowd agent speed (units/second).
+        double fixedDelta{1.0 / 60.0};   ///< Deterministic simulation step.
+        int maxStepsPerFrame{8};         ///< Timeline catch-up clamp.
+        std::size_t historyCapacity{600};///< Rewind window in ticks.
+        std::uint64_t seed{1};           ///< Deterministic spawn scatter.
+    };
+
+    VerticalSlice() : VerticalSlice(Config{}) {}
+
+    explicit VerticalSlice(Config config)
+        : m_config(config),
+          m_timeline(CrowdState{}, config.seed, config.fixedDelta, config.historyCapacity,
+                     config.maxStepsPerFrame) {}
+
+    /// Import a neighborhood from GeoJSON and bake the nav grid. Returns true if the
+    /// result has any walkable space.
+    bool loadFromGeoJson(const std::string& geojson, const world::GeoImportOptions& options = {}) {
+        m_city = world::importString(geojson, options);
+        return bakeFromCity();
+    }
+
+    /// Build directly from an already-parsed city (used by tests and tooling).
+    bool buildFrom(const world::City& city) {
+        m_city = city;
+        return bakeFromCity();
+    }
+
+    /// Choose the crowd's destination and build the flow field toward it.
+    void setGoal(const ecs::Vec3& goal) {
+        m_goal = goal;
+        m_field = sim::buildFlowField(m_grid, goal);
+        m_hasField = true;
+    }
+
+    /**
+     * @brief Spawn up to @p count agents on walkable cells, scattered deterministically.
+     *
+     * Cells within one cell of the goal are skipped so agents actually travel. The
+     * spawn set only depends on the config seed and the grid, so runs reproduce.
+     */
+    std::size_t spawnCrowd(int count) {
+        std::vector<ecs::Vec3> spots;
+        const int goalCx = m_grid.cellX(m_goal.x), goalCz = m_grid.cellZ(m_goal.z);
+        for (int cz = 0; cz < m_grid.height; ++cz) {
+            for (int cx = 0; cx < m_grid.width; ++cx) {
+                if (!m_grid.isWalkable(cx, cz)) continue;
+                if (m_hasField && std::abs(cx - goalCx) <= 1 && std::abs(cz - goalCz) <= 1) continue;
+                spots.push_back(m_grid.cellCenter(cx, cz));
+            }
+        }
+        if (spots.empty() || count <= 0) return 0;
+
+        sim::DeterministicRng rng(m_config.seed);
+        for (int i = 0; i < count; ++i) {
+            const ecs::Vec3& pos = spots[static_cast<std::size_t>(rng.nextInt(0, static_cast<int>(spots.size())))];
+            m_agents.push_back(sim::spawnAgent(m_registry, pos, m_config.agentSpeed));
+        }
+        captureInto(m_initialState);
+        return m_agents.size();
+    }
+
+    /// Advance exactly one fixed tick. Returns the number of agents still moving.
+    int step() {
+        if (!m_hasField) return 0;
+        m_timeline.advance(m_config.fixedDelta,
+                           [this](CrowdState& state, std::uint64_t, sim::DeterministicRng&) {
+                               simulateStep(state);
+                           });
+        return m_moving;
+    }
+
+    /// Advance by real elapsed time (runs the appropriate number of fixed steps).
+    int advance(double realSeconds) {
+        if (!m_hasField) return 0;
+        m_timeline.advance(realSeconds,
+                           [this](CrowdState& state, std::uint64_t, sim::DeterministicRng&) {
+                               simulateStep(state);
+                           });
+        return m_moving;
+    }
+
+    /// Rewind to @p tick and restore the crowd to how it was then (if in-window).
+    bool rewindTo(std::uint64_t tick) {
+        if (!m_timeline.rewindTo(tick)) return false;
+        restoreFrom(m_timeline.state());
+        return true;
+    }
+
+    /// Restore the crowd to its spawn state (does not reset the timeline clock).
+    void resetCrowd() { restoreFrom(m_initialState); }
+
+    // --- Accessors ---------------------------------------------------------
+    const world::City& city() const { return m_city; }
+    const world::NavGrid& grid() const { return m_grid; }
+    const sim::FlowField& field() const { return m_field; }
+    ecs::Registry& registry() { return m_registry; }
+    ecs::Vec3 goal() const { return m_goal; }
+    bool hasGoal() const { return m_hasField; }
+
+    std::uint64_t tick() const { return m_timeline.tick(); }
+    std::uint64_t oldestTick() const { return m_timeline.oldestTick(); }
+    std::size_t agentCount() const { return m_agents.size(); }
+    int agentsMoving() const { return m_moving; }
+
+    ecs::Vec3 agentPosition(std::size_t i) const {
+        return m_registry.get<ecs::Transform>(m_agents[i]).position;
+    }
+    bool agentArrived(std::size_t i) const { return m_registry.get<sim::CrowdAgent>(m_agents[i]).arrived; }
+
+    /// Number of agents that have reached the goal.
+    std::size_t arrivedCount() const {
+        std::size_t n = 0;
+        for (std::size_t i = 0; i < m_agents.size(); ++i) {
+            if (agentArrived(i)) ++n;
+        }
+        return n;
+    }
+
+private:
+    // The timeline's per-tick step: advance the crowd, then mirror it into the
+    // snapshot state so it can be rewound. steerCrowd is deterministic, so the same
+    // start state always produces the same trajectory.
+    void simulateStep(CrowdState& state) {
+        m_moving = sim::steerCrowd(m_registry, m_grid, m_field, static_cast<float>(m_config.fixedDelta));
+        captureInto(state);
+    }
+
+    void captureInto(CrowdState& state) const {
+        state.resize(m_agents.size());
+        for (std::size_t i = 0; i < m_agents.size(); ++i) {
+            state[i].position = m_registry.get<ecs::Transform>(m_agents[i]).position;
+            state[i].arrived = m_registry.get<sim::CrowdAgent>(m_agents[i]).arrived;
+        }
+    }
+
+    void restoreFrom(const CrowdState& state) {
+        const std::size_t n = state.size() < m_agents.size() ? state.size() : m_agents.size();
+        for (std::size_t i = 0; i < n; ++i) {
+            m_registry.get<ecs::Transform>(m_agents[i]).position = state[i].position;
+            m_registry.get<sim::CrowdAgent>(m_agents[i]).arrived = state[i].arrived;
+        }
+    }
+
+    bool bakeFromCity() {
+        float minX = 0.0f, minZ = 0.0f, maxX = 0.0f, maxZ = 0.0f;
+        if (!computeBounds(minX, minZ, maxX, maxZ)) return false;
+
+        std::vector<world::Obstacle> obstacles;
+        obstacles.reserve(m_city.buildings.size());
+        for (const world::Building& b : m_city.buildings) {
+            obstacles.push_back(world::Obstacle{b.center, b.size, 0.0f});
+        }
+        m_grid = world::bake(minX, minZ, maxX, maxZ, m_config.cellSize, obstacles, m_config.agentRadius);
+        return m_grid.walkableCount() > 0;
+    }
+
+    bool computeBounds(float& minX, float& minZ, float& maxX, float& maxZ) const {
+        bool any = false;
+        const auto include = [&](const ecs::Vec3& p) {
+            if (!any) {
+                minX = maxX = p.x;
+                minZ = maxZ = p.z;
+                any = true;
+            } else {
+                if (p.x < minX) minX = p.x;
+                if (p.x > maxX) maxX = p.x;
+                if (p.z < minZ) minZ = p.z;
+                if (p.z > maxZ) maxZ = p.z;
+            }
+        };
+        for (const world::Building& b : m_city.buildings) {
+            for (const ecs::Vec3& p : b.footprint) include(p);
+        }
+        for (const world::Road& r : m_city.roads) {
+            for (const ecs::Vec3& p : r.centerline) include(p);
+        }
+        for (const world::Region& region : m_city.regions) {
+            for (const ecs::Vec3& p : region.footprint) include(p);
+        }
+        if (!any) return false;
+        minX -= m_config.boundsMargin;
+        minZ -= m_config.boundsMargin;
+        maxX += m_config.boundsMargin;
+        maxZ += m_config.boundsMargin;
+        return true;
+    }
+
+    Config m_config;
+    world::City m_city;
+    world::NavGrid m_grid;
+    sim::FlowField m_field;
+    ecs::Registry m_registry;
+    std::vector<ecs::Entity> m_agents;
+    sim::Timeline<CrowdState> m_timeline;
+    CrowdState m_initialState;
+    ecs::Vec3 m_goal{};
+    bool m_hasField{false};
+    int m_moving{0};
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_vertical_slice.cpp
+++ b/tests/test_vertical_slice.cpp
@@ -1,0 +1,171 @@
+// Test for the vertical-slice integration - roadmap EXPANSION_IDEAS section 6.
+//
+// Ties the finished foundations together and verifies the whole path: import a
+// neighborhood (GeoJSON), bake a nav grid, build a flow field, spawn a crowd that
+// navigates to the goal, and rewind/replay the run deterministically.
+//
+// Pure std + header-only (importer, nav mesh, crowd, timeline, ECS are all
+// header-only and glm-free):
+//   g++ -std=c++17 -I src tests/test_vertical_slice.cpp -o test_vertical_slice
+
+#include "game/VerticalSlice.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+namespace game = IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// A real-ish OSM-style neighborhood: two roads sharing a node, two buildings, and
+// a park - the same shape the GeoJSON importer test uses.
+static const char* kGeoJson = R"JSON({
+  "type": "FeatureCollection",
+  "features": [
+    { "type":"Feature", "properties":{"highway":"residential"},
+      "geometry":{"type":"LineString","coordinates":[[0,0],[0.0001,0],[0.0002,0]]} },
+    { "type":"Feature", "properties":{"highway":"residential"},
+      "geometry":{"type":"LineString","coordinates":[[0.0002,0],[0.0002,0.0001]]} },
+    { "type":"Feature", "properties":{"building":"yes","height":"10"},
+      "geometry":{"type":"Polygon","coordinates":[[[0,0],[0.0001,0],[0.0001,0.0001],[0,0.0001],[0,0]]]} },
+    { "type":"Feature", "properties":{"building":"yes","building:levels":"3"},
+      "geometry":{"type":"Polygon","coordinates":[[[0.0003,0],[0.0004,0],[0.0004,0.0001],[0.0003,0.0001],[0.0003,0]]]} },
+    { "type":"Feature", "properties":{"leisure":"park"},
+      "geometry":{"type":"Polygon","coordinates":[[[0,0.0002],[0.0002,0.0002],[0.0002,0.0003],[0,0.0003],[0,0.0002]]]} }
+  ]
+})JSON";
+
+// A hand-built city: a large open plaza (defines the extent) with one building
+// obstacle in the middle. Deterministic and importer-independent.
+static world::City makePlazaCity() {
+    world::City city;
+
+    world::Region plaza;
+    plaza.footprint = {{0.0f, 0.0f, 0.0f}, {40.0f, 0.0f, 0.0f}, {40.0f, 0.0f, 40.0f}, {0.0f, 0.0f, 40.0f}};
+    city.regions.push_back(plaza);
+
+    world::Building block;
+    block.center = {20.0f, 3.0f, 20.0f};
+    block.size = {6.0f, 6.0f, 6.0f};
+    block.footprint = {{17.0f, 0.0f, 17.0f}, {23.0f, 0.0f, 17.0f}, {23.0f, 0.0f, 23.0f}, {17.0f, 0.0f, 23.0f}};
+    city.buildings.push_back(block);
+
+    return city;
+}
+
+static std::vector<ecs::Vec3> snapshotPositions(const game::VerticalSlice& slice) {
+    std::vector<ecs::Vec3> out;
+    for (std::size_t i = 0; i < slice.agentCount(); ++i) out.push_back(slice.agentPosition(i));
+    return out;
+}
+
+static bool samePositions(const std::vector<ecs::Vec3>& a, const std::vector<ecs::Vec3>& b) {
+    if (a.size() != b.size()) return false;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (a[i].x != b[i].x || a[i].y != b[i].y || a[i].z != b[i].z) return false;
+    }
+    return true;
+}
+
+static void stepTo(game::VerticalSlice& slice, std::uint64_t target) {
+    while (slice.tick() < target) slice.step();
+}
+
+static void testImportAndBake() {
+    game::VerticalSlice slice({/*cellSize=*/2.0f});
+    CHECK(slice.loadFromGeoJson(kGeoJson));
+    CHECK(slice.city().buildings.size() == 2);
+    CHECK(slice.city().roads.size() == 2);
+    CHECK(slice.grid().walkableCount() > 0); // buildings block some cells, not all
+}
+
+static void testSpawnOnWalkableCells() {
+    game::VerticalSlice slice;
+    CHECK(slice.buildFrom(makePlazaCity()));
+    slice.setGoal(ecs::Vec3{36.0f, 0.0f, 36.0f});
+    CHECK(slice.hasGoal());
+
+    const std::size_t spawned = slice.spawnCrowd(32);
+    CHECK(spawned == 32);
+    CHECK(slice.agentCount() == 32);
+    CHECK(slice.arrivedCount() == 0); // none have moved yet
+
+    // Every agent starts on a walkable cell.
+    for (std::size_t i = 0; i < slice.agentCount(); ++i) {
+        const ecs::Vec3 p = slice.agentPosition(i);
+        CHECK(slice.grid().isWalkable(slice.grid().cellX(p.x), slice.grid().cellZ(p.z)));
+    }
+}
+
+static void testCrowdReachesGoal() {
+    game::VerticalSlice slice({/*cellSize=*/1.0f, /*agentRadius=*/0.3f, /*boundsMargin=*/4.0f,
+                               /*agentSpeed=*/8.0f});
+    CHECK(slice.buildFrom(makePlazaCity()));
+    slice.setGoal(ecs::Vec3{36.0f, 0.0f, 36.0f});
+    slice.spawnCrowd(16);
+    CHECK(slice.agentCount() == 16);
+
+    // Drive the simulation until the crowd arrives (bounded so the test terminates).
+    int moving = slice.agentsMoving();
+    for (int i = 0; i < 4000 && (i == 0 || moving > 0); ++i) moving = slice.step();
+
+    CHECK(slice.agentsMoving() == 0);
+    CHECK(slice.arrivedCount() == slice.agentCount()); // all reached the goal
+}
+
+static void testDeterministicRewindAndReplay() {
+    game::VerticalSlice slice({/*cellSize=*/1.0f, /*agentRadius=*/0.3f, /*boundsMargin=*/4.0f,
+                               /*agentSpeed=*/6.0f});
+    slice.buildFrom(makePlazaCity());
+    slice.setGoal(ecs::Vec3{36.0f, 0.0f, 36.0f});
+    slice.spawnCrowd(24);
+
+    stepTo(slice, 30);
+    CHECK(slice.tick() == 30);
+    const std::vector<ecs::Vec3> at30 = snapshotPositions(slice);
+
+    stepTo(slice, 60);
+    CHECK(slice.tick() == 60);
+    const std::vector<ecs::Vec3> at60 = snapshotPositions(slice);
+
+    // The two snapshots differ (the crowd actually moved between them).
+    CHECK(!samePositions(at30, at60));
+
+    // Rewind restores the exact state at tick 30.
+    CHECK(slice.rewindTo(30));
+    CHECK(slice.tick() == 30);
+    CHECK(samePositions(snapshotPositions(slice), at30));
+
+    // Replaying forward reproduces tick 60 bit-for-bit (deterministic).
+    stepTo(slice, 60);
+    CHECK(samePositions(snapshotPositions(slice), at60));
+
+    // Rewinding outside the retained window fails without changing state.
+    const std::uint64_t current = slice.tick();
+    CHECK(!slice.rewindTo(current + 100));
+    CHECK(slice.tick() == current);
+}
+
+int main() {
+    testImportAndBake();
+    testSpawnOnWalkableCells();
+    testCrowdReachesGoal();
+    testDeterministicRewindAndReplay();
+
+    if (g_failures == 0) {
+        std::printf("All vertical slice tests passed.\n");
+        return 0;
+    }
+    std::printf("%d vertical slice test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements the roadmap's headline deliverable (`EXPANSION_IDEAS.md` section 6): the integration that ties the finished foundations into one story - **"import a neighborhood, watch a crowd navigate it, then rewind time."** The individual systems (GeoJSON importer, nav mesh, crowd, deterministic timeline, archetype ECS) already existed and were tested in isolation; this is the glue that makes them a coherent slice, plus a small, testable state machine.

This is a roadmap deliverable rather than a tracked issue, so it references `EXPANSION_IDEAS.md` section 6 instead of closing an issue number.

## Core: `src/game/VerticalSlice.h` (header-only, std only)

Composes the existing systems:

- `world::importString` (GeoJSON) -> `City`, or `buildFrom(City)` directly for tooling/tests.
- `world::bake` -> `NavGrid`, blocking cells under building footprints (inflated by the agent radius).
- `sim::buildFlowField` toward a chosen goal.
- an archetype-ECS crowd (`sim::spawnAgent` / `sim::steerCrowd`) advanced through `sim::Timeline` (fixed-step, deterministic RNG, snapshot rewind). Each tick the crowd is mirrored into the timeline's snapshot state, so `rewindTo()` restores the exact crowd and replaying forward reproduces it bit-for-bit.

It stays headless (`ecs::Vec3`, no glm/GL), so the whole slice is unit-testable; the ImGui walkthrough and rewind scrubber will build on top of this in `DebugUI` (natural follow-up).

## Testing

`tests/test_vertical_slice.cpp` covers:
- GeoJSON import + nav-grid bake (two buildings block some but not all cells).
- Spawning a crowd only on walkable cells, scattered deterministically from the config seed.
- The crowd navigating around a building obstacle until **every** agent reaches the goal.
- Deterministic rewind/replay: rewinding to an earlier tick restores the exact positions, replaying forward reproduces the later tick exactly, and out-of-window rewinds are rejected without changing state.

Passes locally under ASan/UBSan (`All vertical slice tests passed.`). New CMake target `test_vertical_slice`. The header is header-only and also compiled by CI's CodeQL c-cpp build.

## Why this

Per the roadmap reconciliation, every feature *tier* already had modules in the tree, but nothing wired them into the end-to-end slice that is the project's elevator pitch. This turns those finished systems into a runnable, deterministic story and gives the eventual demo/tutorial its backbone.

## Follow-ups

- An ImGui "Vertical Slice" panel in `DebugUI` (play/pause/step + rewind scrubber over this scenario), tying in the Milestone 9 editor.
- Feeding the crowd's agents into the entity inspector / scene view for in-editor inspection.