### PR TITLE
Add runnable samples folder (#224)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -670,6 +670,14 @@ add_executable(test_vertical_slice
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_vertical_slice.cpp
 )
 
+# Runnable samples (roadmap section 7 / #224) - header-only, no GL context needed.
+add_executable(sample_vertical_slice
+    ${CMAKE_CURRENT_SOURCE_DIR}/samples/vertical_slice_demo.cpp
+)
+add_executable(sample_benchmark_export
+    ${CMAKE_CURRENT_SOURCE_DIR}/samples/benchmark_export_demo.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,29 @@
+# Samples
+
+Small, self-contained programs that exercise the engine's header-only cores with
+no GL context, so they build and run anywhere. Each is also a CMake target.
+
+## Build and run
+
+With CMake (from a build directory):
+
+```
+cmake --build . --target sample_vertical_slice
+./sample_vertical_slice
+```
+
+Or directly with a compiler:
+
+```
+g++ -std=c++17 -I src samples/vertical_slice_demo.cpp -o sample_vertical_slice
+./sample_vertical_slice
+```
+
+## What's here
+
+- `vertical_slice_demo.cpp` (`sample_vertical_slice`): the roadmap vertical slice
+  end to end - import a neighborhood from GeoJSON, bake a nav grid, spawn a crowd
+  that navigates to a goal, then rewind time and replay it deterministically.
+- `benchmark_export_demo.cpp` (`sample_benchmark_export`): capture FPS, frame
+  time, and memory over a simulated run and export the samples via the
+  deterministic data-export format (CSV to a file, JSON to stdout).

--- a/samples/benchmark_export_demo.cpp
+++ b/samples/benchmark_export_demo.cpp
@@ -1,0 +1,57 @@
+// Sample: capture performance metrics over a run and export them.
+//
+// Feeds a simulated frame loop into the benchmark recorder (the same core the
+// in-engine benchmark panel uses), prints the summary, and exports the per-frame
+// samples via the deterministic data-export format as CSV (to a file) and JSON
+// (to stdout). No GL context required.
+//
+// Build (also wired into CMake as sample_benchmark_export):
+//   g++ -std=c++17 -I src samples/benchmark_export_demo.cpp -o sample_benchmark_export
+//   ./sample_benchmark_export
+
+#include "core/Benchmark.h"
+
+#include <cstdio>
+#include <iostream>
+
+using namespace IKore;
+
+int main() {
+    Benchmark benchmark;
+    benchmark.start();
+
+    // Simulate 120 frames at ~60 FPS, with an occasional hitch and slowly growing
+    // memory, so the exported data has some shape to inspect.
+    for (int frame = 0; frame < 120; ++frame) {
+        const double frameSeconds = (frame % 20 == 0) ? 0.033 : 0.016; // periodic hitch
+        const long memoryBytes = 50L * 1024 * 1024 + static_cast<long>(frame) * 4096;
+        benchmark.record(frameSeconds, memoryBytes);
+    }
+    benchmark.stop();
+
+    std::printf("Captured %zu frames over %.3f s.\n", benchmark.sampleCount(),
+                benchmark.durationSeconds());
+    std::printf("FPS: avg %.1f (min %.1f, max %.1f)\n", benchmark.avgFps(), benchmark.minFps(),
+                benchmark.maxFps());
+    std::printf("Frame ms: avg %.3f (min %.3f, max %.3f)\n", benchmark.avgFrameMs(),
+                benchmark.minFrameMs(), benchmark.maxFrameMs());
+    std::printf("Peak memory: %.1f MB\n",
+                static_cast<double>(benchmark.peakMemoryBytes()) / (1024.0 * 1024.0));
+
+    const char* csvPath = "benchmark_sample.csv";
+    if (benchmark.exportToFile(csvPath, sim::ExportFormat::Csv)) {
+        std::printf("Exported %zu samples to %s (CSV).\n", benchmark.sampleCount(), csvPath);
+    } else {
+        std::printf("Failed to write %s.\n", csvPath);
+    }
+
+    std::printf("\nFirst rows as JSON:\n");
+    Benchmark preview;
+    preview.start();
+    preview.record(0.016, 52428800);
+    preview.record(0.033, 52432896);
+    preview.stop();
+    preview.exportTo(std::cout, sim::ExportFormat::Json);
+
+    return 0;
+}

--- a/samples/vertical_slice_demo.cpp
+++ b/samples/vertical_slice_demo.cpp
@@ -1,0 +1,96 @@
+// Sample: the roadmap vertical slice, end to end and headless.
+//
+// Imports a small neighborhood from GeoJSON, bakes a nav grid, spawns a crowd that
+// navigates to a goal, then rewinds time and replays - printing what happens at
+// each stage. No GL context required, so it runs anywhere.
+//
+// Build (also wired into CMake as sample_vertical_slice):
+//   g++ -std=c++17 -I src samples/vertical_slice_demo.cpp -o sample_vertical_slice
+//   ./sample_vertical_slice
+
+#include "game/VerticalSlice.h"
+
+#include <cstdio>
+
+using namespace IKore;
+
+// A tiny OSM-style neighborhood: two roads, two buildings, and a park.
+static const char* kNeighborhood = R"JSON({
+  "type": "FeatureCollection",
+  "features": [
+    { "type":"Feature", "properties":{"highway":"residential"},
+      "geometry":{"type":"LineString","coordinates":[[0,0],[0.0001,0],[0.0002,0]]} },
+    { "type":"Feature", "properties":{"highway":"residential"},
+      "geometry":{"type":"LineString","coordinates":[[0.0002,0],[0.0002,0.0001]]} },
+    { "type":"Feature", "properties":{"building":"yes","height":"10"},
+      "geometry":{"type":"Polygon","coordinates":[[[0,0],[0.0001,0],[0.0001,0.0001],[0,0.0001],[0,0]]]} },
+    { "type":"Feature", "properties":{"building":"yes","building:levels":"3"},
+      "geometry":{"type":"Polygon","coordinates":[[[0.0003,0],[0.0004,0],[0.0004,0.0001],[0.0003,0.0001],[0.0003,0]]]} },
+    { "type":"Feature", "properties":{"leisure":"park"},
+      "geometry":{"type":"Polygon","coordinates":[[[0,0.0002],[0.0002,0.0002],[0.0002,0.0003],[0,0.0003],[0,0.0002]]]} }
+  ]
+})JSON";
+
+// Pick a walkable cell in the far corner of the grid to use as the crowd's goal.
+static ecs::Vec3 farWalkableCell(const world::NavGrid& grid) {
+    ecs::Vec3 best{};
+    float bestScore = -1.0e30f;
+    for (int cz = 0; cz < grid.height; ++cz) {
+        for (int cx = 0; cx < grid.width; ++cx) {
+            if (!grid.isWalkable(cx, cz)) continue;
+            const ecs::Vec3 c = grid.cellCenter(cx, cz);
+            const float score = c.x + c.z;
+            if (score > bestScore) {
+                bestScore = score;
+                best = c;
+            }
+        }
+    }
+    return best;
+}
+
+int main() {
+    game::VerticalSlice::Config config;
+    config.cellSize = 2.0f;
+    config.historyCapacity = 3000; // retain the whole run so we can rewind to the midpoint
+    game::VerticalSlice slice(config);
+
+    if (!slice.loadFromGeoJson(kNeighborhood)) {
+        std::printf("Failed to import neighborhood (no walkable space).\n");
+        return 1;
+    }
+    std::printf("Imported neighborhood: %zu buildings, %zu roads, %zu regions.\n",
+                slice.city().buildings.size(), slice.city().roads.size(),
+                slice.city().regions.size());
+    std::printf("Baked nav grid: %d x %d cells, %zu walkable.\n", slice.grid().width,
+                slice.grid().height, slice.grid().walkableCount());
+
+    const ecs::Vec3 goal = farWalkableCell(slice.grid());
+    slice.setGoal(goal);
+    const std::size_t spawned = slice.spawnCrowd(200);
+    std::printf("Goal at (%.1f, %.1f); spawned %zu agents.\n", goal.x, goal.z, spawned);
+
+    // Run the fixed-step simulation for a bounded number of ticks (agents that
+    // land in a disconnected pocket may never reach the goal, so we cap it).
+    int moving = slice.agentsMoving();
+    for (int i = 0; i < 2000 && (i == 0 || moving > 0); ++i) moving = slice.step();
+    const std::uint64_t endTick = slice.tick();
+    const std::size_t arrivedAtEnd = slice.arrivedCount();
+    std::printf("After %llu ticks: %zu of %zu agents reached the goal.\n",
+                static_cast<unsigned long long>(endTick), arrivedAtEnd, slice.agentCount());
+
+    // Rewind to the halfway point, then replay forward - the crowd is restored and
+    // the replay reproduces the same outcome (deterministic time control).
+    const std::uint64_t midpoint = endTick / 2;
+    if (slice.rewindTo(midpoint)) {
+        std::printf("Rewound to tick %llu: %zu agents had arrived by then.\n",
+                    static_cast<unsigned long long>(midpoint), slice.arrivedCount());
+        while (slice.tick() < endTick) slice.step();
+        std::printf("Replayed forward to tick %llu: %zu agents arrived (matches the first run: %s).\n",
+                    static_cast<unsigned long long>(slice.tick()), slice.arrivedCount(),
+                    slice.arrivedCount() == arrivedAtEnd ? "yes" : "no");
+    }
+
+    std::printf("Done.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Roadmap quick win (`EXPANSION_IDEAS.md` section 7): ship small, self-contained programs so a newcomer sees results in one command. Both samples exercise the header-only cores with no GL context, so they build and run anywhere, and both are CMake targets.

Closes #224

## What's added

- `samples/vertical_slice_demo.cpp` (`sample_vertical_slice`): the vertical slice end to end - import a neighborhood from GeoJSON, bake a nav grid, spawn a 200-agent crowd that navigates to a goal, then rewind to the midpoint and replay, showing the outcome is reproduced deterministically.
- `samples/benchmark_export_demo.cpp` (`sample_benchmark_export`): capture FPS, frame time, and memory over a simulated frame loop and export the samples via the deterministic data-export format (CSV to a file, JSON to stdout).
- `samples/README.md` documents how to build and run them.

Both reuse existing engine modules (`VerticalSlice`, `Benchmark`, `DataExporter`) rather than duplicating logic.

## Sample output (verified locally)

```
Imported neighborhood: 2 buildings, 2 roads, 1 regions.
Baked nav grid: 27 x 21 cells, 469 walkable.
Goal at (49.0, 37.0); spawned 200 agents.
After 2000 ticks: 199 of 200 agents reached the goal.
Rewound to tick 1000: 194 agents had arrived by then.
Replayed forward to tick 2000: 199 agents arrived (matches the first run: yes).
Done.
```

## Testing

- Each sample builds and runs under ASan/UBSan and prints meaningful output.
- New CMake targets `sample_vertical_slice` and `sample_benchmark_export`; both are also compiled by CI's CodeQL c-cpp build.

## Acceptance criteria

- At least two samples build and run from a single command and print meaningful output: yes (two, shown above).
- Samples reuse existing engine modules rather than duplicating logic: yes.
- CMake targets exist for each sample: yes.