### PR TITLE
Rendering modernization: plan + render-pass graph foundation (#226)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,6 +678,11 @@ add_executable(sample_benchmark_export
     ${CMAKE_CURRENT_SOURCE_DIR}/samples/benchmark_export_demo.cpp
 )
 
+# Render-pass dependency graph (rendering modernization step 1 / #226) - header-only.
+add_executable(test_render_pass_graph
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_render_pass_graph.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/docs/RENDERING_MODERNIZATION.md
+++ b/docs/RENDERING_MODERNIZATION.md
@@ -1,0 +1,70 @@
+# Rendering Modernization Plan
+
+Status: proposed. This is the "short plan of prioritized improvements" that issue
+#226 asks to agree on **before** any large rendering change. It is optional and
+"catch-up, not unique" per `EXPANSION_IDEAS.md` section 5.4: rendering is not the
+engine's differentiator, so the guiding principle is **high value, low risk,
+isolated, and no regressions** to existing scenes.
+
+The engine today has a forward renderer with Blinn-Phong lighting, directional and
+point (cubemap) shadow maps, frustum culling, a GPU/compute particle system, and
+post-processing (bloom, SSAO, FXAA) plus a skybox.
+
+## Guiding constraints
+
+- Each change is isolated and independently revertible.
+- Prefer additive, data-driven changes over renderer rewrites.
+- Anything testable gets a headless unit test (the pass graph below is the first).
+- No visual regression to existing sample scenes.
+
+## Prioritized improvements
+
+### P1 - Render-pass graph / pass abstraction (foundation, started here)
+
+Describe the frame as named passes with explicit dependencies and compute the
+execution order, instead of hard-coding the sequence in the renderer. This makes
+inserting or reordering passes (deferred shading, HDR, extra post) a data change.
+
+- **Delivered in this issue (isolated, tested):** `src/render/RenderPassGraph.h`
+  plus `tests/test_render_pass_graph.cpp` - deterministic topological ordering
+  with cycle detection. It is not yet wired into the GL renderer, so it cannot
+  regress anything.
+- **Next (needs agreement):** adopt the graph in the renderer to sequence the
+  existing passes, one pass at a time, verifying each against the current output.
+- Effort: medium. Risk: low while unwired; medium during adoption.
+
+### P2 - PBR materials (metallic-roughness)
+
+Move from Blinn-Phong to a metallic-roughness PBR model with image-based lighting.
+
+- Start with header-only, unit-testable BRDF math (GGX distribution, Smith
+  geometry, Fresnel-Schlick, sRGB/linear conversion), then a new shader path
+  behind a material flag so Phong materials keep rendering unchanged.
+- Effort: high. Risk: medium (gated behind a material flag; opt-in per material).
+
+### P3 - HDR pipeline + tone mapping
+
+Render lighting to an HDR target and tone-map (for example ACES) on resolve, with
+exposure control. Pairs naturally with P2 and improves bloom quality.
+
+- Isolate as a resolve pass in the P1 graph; keep an LDR fallback.
+- Effort: medium. Risk: medium.
+
+### P4 - Shadow and lighting quality
+
+Incremental quality wins: cascaded shadow maps for the directional light, PCF/soft
+shadows, and normal-mapping support in the material path.
+
+- Effort: medium per item. Risk: low to medium; each item is independent.
+
+## Explicitly out of scope (for now)
+
+A full deferred/clustered renderer or a Vulkan/RHI backend. These are large
+rewrites with little differentiation payoff for this engine and should only be
+considered if a concrete need appears.
+
+## Suggested sequencing
+
+P1 foundation (this issue) -> agree on adoption -> P2 BRDF math + opt-in PBR path
+-> P3 HDR/tone mapping -> P4 quality passes. Each step ships behind a flag or as an
+added pass so existing scenes render unchanged until the step is validated.

--- a/src/render/RenderPassGraph.h
+++ b/src/render/RenderPassGraph.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @file RenderPassGraph.h
+ * @brief Declarative render-pass dependency graph (issue #226, step 1).
+ *
+ * The first, isolated step of rendering modernization
+ * (see `docs/RENDERING_MODERNIZATION.md`): describe the frame as named passes with
+ * explicit dependencies (shadow -> gbuffer -> lighting -> post ...), then compute a
+ * valid execution order instead of hard-coding the sequence in the renderer. This
+ * makes reordering/inserting passes (deferred shading, HDR, extra post) a data
+ * change rather than a code change.
+ *
+ * This header is intentionally standalone - it is not yet wired into the GL
+ * renderer, so it cannot regress existing scenes - and it is header-only and
+ * dependency-free, so the ordering logic is unit-testable without a GL context.
+ * Ordering is deterministic: among passes whose dependencies are all satisfied,
+ * the earliest-added one runs first.
+ */
+namespace IKore {
+namespace render {
+
+class RenderPassGraph {
+public:
+    /// Register a pass by name, with the names of passes that must run before it.
+    /// Duplicate names are ignored (the first registration wins), so insertion
+    /// order - and therefore the deterministic tie-break order - stays stable.
+    void addPass(const std::string& name, std::vector<std::string> dependencies = {}) {
+        if (m_index.count(name) != 0) return;
+        m_index.emplace(name, m_passes.size());
+        m_passes.push_back(Pass{name, std::move(dependencies)});
+    }
+
+    bool hasPass(const std::string& name) const { return m_index.count(name) != 0; }
+    std::size_t passCount() const { return m_passes.size(); }
+
+    /// True if every dependency listed by every pass names a registered pass.
+    bool dependenciesResolved() const {
+        for (const Pass& pass : m_passes) {
+            for (const std::string& dep : pass.dependencies) {
+                if (m_index.count(dep) == 0) return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @brief A topological execution order: every pass appears after all of its
+     *        (registered) dependencies. Dependencies that name an unregistered
+     *        pass impose no constraint. Returns an empty vector if the graph is
+     *        empty or contains a dependency cycle (see hasCycle()).
+     */
+    std::vector<std::string> order() const {
+        std::vector<bool> done(m_passes.size(), false);
+        std::vector<std::string> result;
+        result.reserve(m_passes.size());
+        std::size_t remaining = m_passes.size();
+
+        while (remaining > 0) {
+            bool progressed = false;
+            for (std::size_t i = 0; i < m_passes.size(); ++i) {
+                if (done[i] || !ready(i, done)) continue;
+                done[i] = true;
+                result.push_back(m_passes[i].name);
+                --remaining;
+                progressed = true;
+            }
+            if (!progressed) return {}; // remaining passes form a cycle
+        }
+        return result;
+    }
+
+    /// True if the graph contains a dependency cycle.
+    bool hasCycle() const { return !m_passes.empty() && order().empty(); }
+
+    void clear() {
+        m_passes.clear();
+        m_index.clear();
+    }
+
+private:
+    struct Pass {
+        std::string name;
+        std::vector<std::string> dependencies;
+    };
+
+    // A pass is ready when all its registered dependencies are already done.
+    bool ready(std::size_t i, const std::vector<bool>& done) const {
+        for (const std::string& dep : m_passes[i].dependencies) {
+            auto it = m_index.find(dep);
+            if (it == m_index.end()) continue; // unregistered dep: not a constraint
+            if (!done[it->second]) return false;
+        }
+        return true;
+    }
+
+    std::vector<Pass> m_passes;
+    std::unordered_map<std::string, std::size_t> m_index;
+};
+
+} // namespace render
+} // namespace IKore

--- a/tests/test_render_pass_graph.cpp
+++ b/tests/test_render_pass_graph.cpp
@@ -1,0 +1,152 @@
+// Test for the render-pass dependency graph - issue #226, step 1.
+//
+// Verifies deterministic topological ordering (dependencies before dependents),
+// stable insertion-order tie-breaking, dependency resolution checks, and cycle
+// detection. This core is not yet wired into the GL renderer.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_render_pass_graph.cpp -o test_render_pass_graph
+
+#include "render/RenderPassGraph.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore::render;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static int indexOf(const std::vector<std::string>& order, const std::string& name) {
+    for (std::size_t i = 0; i < order.size(); ++i) {
+        if (order[i] == name) return static_cast<int>(i);
+    }
+    return -1;
+}
+
+static void testLinearChain() {
+    RenderPassGraph g;
+    g.addPass("a");
+    g.addPass("b", {"a"});
+    g.addPass("c", {"b"});
+
+    CHECK(g.passCount() == 3);
+    CHECK(g.hasPass("b") && !g.hasPass("z"));
+    CHECK(g.dependenciesResolved());
+    CHECK(!g.hasCycle());
+
+    const std::vector<std::string> order = g.order();
+    CHECK(order.size() == 3);
+    CHECK(order[0] == "a" && order[1] == "b" && order[2] == "c");
+}
+
+static void testIndependentPassesKeepInsertionOrder() {
+    RenderPassGraph g;
+    g.addPass("first");
+    g.addPass("second");
+    g.addPass("third");
+    const std::vector<std::string> order = g.order();
+    CHECK(order.size() == 3);
+    CHECK(order[0] == "first" && order[1] == "second" && order[2] == "third");
+}
+
+static void testDiamond() {
+    RenderPassGraph g;
+    g.addPass("root");
+    g.addPass("left", {"root"});
+    g.addPass("right", {"root"});
+    g.addPass("merge", {"left", "right"});
+
+    const std::vector<std::string> order = g.order();
+    CHECK(order.size() == 4);
+    CHECK(indexOf(order, "root") < indexOf(order, "left"));
+    CHECK(indexOf(order, "root") < indexOf(order, "right"));
+    CHECK(indexOf(order, "left") < indexOf(order, "merge"));
+    CHECK(indexOf(order, "right") < indexOf(order, "merge"));
+    // Deterministic tie-break: left was added before right.
+    CHECK(indexOf(order, "left") < indexOf(order, "right"));
+}
+
+static void testDependencyDeclaredBeforeItsProducer() {
+    // A pass may list a dependency that is registered later; ordering still holds.
+    RenderPassGraph g;
+    g.addPass("consumer", {"producer"});
+    g.addPass("producer");
+    CHECK(g.dependenciesResolved());
+    const std::vector<std::string> order = g.order();
+    CHECK(order.size() == 2);
+    CHECK(indexOf(order, "producer") < indexOf(order, "consumer"));
+}
+
+static void testUnresolvedDependency() {
+    RenderPassGraph g;
+    g.addPass("lighting", {"gbuffer"}); // gbuffer never registered
+    CHECK(!g.dependenciesResolved());
+    // An unregistered dependency imposes no constraint, so ordering still succeeds.
+    CHECK(!g.hasCycle());
+    const std::vector<std::string> order = g.order();
+    CHECK(order.size() == 1 && order[0] == "lighting");
+}
+
+static void testCycleDetection() {
+    RenderPassGraph g;
+    g.addPass("a", {"b"});
+    g.addPass("b", {"a"});
+    CHECK(g.hasCycle());
+    CHECK(g.order().empty());
+
+    RenderPassGraph selfLoop;
+    selfLoop.addPass("x", {"x"});
+    CHECK(selfLoop.hasCycle());
+}
+
+static void testRealisticPipeline() {
+    // A forward pipeline resembling the engine's passes.
+    RenderPassGraph g;
+    g.addPass("shadow");
+    g.addPass("gbuffer");
+    g.addPass("lighting", {"gbuffer", "shadow"});
+    g.addPass("bloom", {"lighting"});
+    g.addPass("ssao", {"gbuffer"});
+    g.addPass("composite", {"lighting", "bloom", "ssao"});
+    g.addPass("fxaa", {"composite"});
+    g.addPass("present", {"fxaa"});
+
+    CHECK(g.dependenciesResolved());
+    CHECK(!g.hasCycle());
+    const std::vector<std::string> order = g.order();
+    CHECK(order.size() == 8);
+    CHECK(indexOf(order, "shadow") < indexOf(order, "lighting"));
+    CHECK(indexOf(order, "gbuffer") < indexOf(order, "lighting"));
+    CHECK(indexOf(order, "gbuffer") < indexOf(order, "ssao"));
+    CHECK(indexOf(order, "lighting") < indexOf(order, "composite"));
+    CHECK(indexOf(order, "bloom") < indexOf(order, "composite"));
+    CHECK(indexOf(order, "ssao") < indexOf(order, "composite"));
+    CHECK(indexOf(order, "composite") < indexOf(order, "fxaa"));
+    CHECK(order.back() == "present");
+}
+
+int main() {
+    testLinearChain();
+    testIndependentPassesKeepInsertionOrder();
+    testDiamond();
+    testDependencyDeclaredBeforeItsProducer();
+    testUnresolvedDependency();
+    testCycleDetection();
+    testRealisticPipeline();
+
+    if (g_failures == 0) {
+        std::printf("All render pass graph tests passed.\n");
+        return 0;
+    }
+    std::printf("%d render pass graph test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Optional roadmap item (`EXPANSION_IDEAS.md` section 5.4: "catch-up, not unique"). The issue asks for a short, prioritized plan **agreed before any large rendering change**, so this PR delivers the plan plus the single lowest-risk foundation, and gates everything else on agreement - no renderer rewrite.

Closes #226

## What's added

- **`docs/RENDERING_MODERNIZATION.md`** - a prioritized plan:
  - **P1** render-pass graph / pass abstraction (started here)
  - **P2** metallic-roughness PBR (header-only BRDF math first, opt-in per material)
  - **P3** HDR pipeline + tone mapping
  - **P4** shadow/lighting quality (cascades, PCF, normal maps)
  
  Each with rationale, effort, and risk; an explicit out-of-scope section (no deferred/clustered or Vulkan/RHI rewrite); and a sequencing note. Guiding principle: high value, low risk, isolated, no regressions.
- **`src/render/RenderPassGraph.h`** - step 1, delivered **in isolation**: describe the frame as named passes with explicit dependencies and compute a deterministic topological execution order (cycle detection + stable insertion-order tie-breaking), so inserting/reordering passes becomes a data change rather than a code change. It is **not wired into the GL renderer**, so it cannot regress existing scenes.
- **`tests/test_render_pass_graph.cpp`** - covers linear chains, independent passes, diamonds, out-of-order declaration, unresolved dependencies, cycle and self-loop detection, and a realistic forward-pipeline ordering.

## Testing

- `test_render_pass_graph` passes under ASan/UBSan (`All render pass graph tests passed.`).
- New CMake target; the header is also compiled by CI's CodeQL c-cpp build.
- ASCII-only.

## Acceptance criteria

- A short plan of prioritized rendering improvements is agreed before large changes: the plan is here; the larger P1 adoption and P2-P4 are explicitly gated on agreement.
- Any implemented change is isolated, tested where possible, and does not regress existing scenes: the only code is the standalone, unit-tested pass graph, which is not wired into the renderer.