### PR TITLE
Adopt render-pass graph in the renderer (#232)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -683,6 +683,11 @@ add_executable(test_render_pass_graph
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_render_pass_graph.cpp
 )
 
+# Concrete frame graph + executor adoption (rendering modernization P1 / #232) - header-only.
+add_executable(test_frame_graph
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_frame_graph.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/docs/RENDERING_MODERNIZATION.md
+++ b/docs/RENDERING_MODERNIZATION.md
@@ -19,19 +19,27 @@ post-processing (bloom, SSAO, FXAA) plus a skybox.
 
 ## Prioritized improvements
 
-### P1 - Render-pass graph / pass abstraction (foundation, started here)
+### P1 - Render-pass graph / pass abstraction (foundation + adoption, done)
 
 Describe the frame as named passes with explicit dependencies and compute the
 execution order, instead of hard-coding the sequence in the renderer. This makes
 inserting or reordering passes (deferred shading, HDR, extra post) a data change.
 
-- **Delivered in this issue (isolated, tested):** `src/render/RenderPassGraph.h`
-  plus `tests/test_render_pass_graph.cpp` - deterministic topological ordering
-  with cycle detection. It is not yet wired into the GL renderer, so it cannot
-  regress anything.
-- **Next (needs agreement):** adopt the graph in the renderer to sequence the
-  existing passes, one pass at a time, verifying each against the current output.
-- Effort: medium. Risk: low while unwired; medium during adoption.
+- **Foundation (#226, isolated, tested):** `src/render/RenderPassGraph.h` plus
+  `tests/test_render_pass_graph.cpp` - deterministic topological ordering with
+  cycle detection, header-only and GL-free.
+- **Adoption (#232, done):** `src/render/FrameGraph.h` defines the renderer's real
+  pass set as data (`buildDefaultFrameGraph()`:
+  `shadow -> scene_begin -> skybox -> forward -> particles -> postprocess`) and a
+  `FrameGraphExecutor` that runs each pass's handler in the computed order. The
+  main render loop (`src/main.cpp`) now binds a handler per pass and calls
+  `execute()` instead of a hard-coded sequence, so reordering/inserting a pass is a
+  change to `buildDefaultFrameGraph()`, not to the loop. The graph is built to
+  reproduce the exact pre-adoption order, so existing scenes render unchanged;
+  `tests/test_frame_graph.cpp` pins that order headlessly.
+- **Next:** as later passes land (P2/P3), express them as nodes in
+  `buildDefaultFrameGraph()` rather than new inline code in the loop.
+- Effort: medium. Risk: low (order is byte-identical to the previous sequence).
 
 ### P2 - PBR materials (metallic-roughness)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "ParticleSystem.h"
 #include "ShadowMap.h"
 #include "Frustum.h"
+#include "render/FrameGraph.h"
 #include "core/Entity.h"
 #include "core/EntityTypes.h"
 #include "core/Transform.h"
@@ -569,6 +570,21 @@ int main() {
 
     LOG_INFO("Starting main game loop with delta time calculation");
 
+    // === Render frame graph ===
+    // The per-frame render passes run in the order computed by the render-pass
+    // dependency graph rather than a hard-coded sequence (rendering modernization
+    // P1 / #232). Reordering or inserting a pass is a change to
+    // buildDefaultFrameGraph(), not to the loop below. The order is computed once;
+    // handlers are (re)bound each frame to the current frame's locals.
+    IKore::render::FrameGraphExecutor frameGraph(IKore::render::buildDefaultFrameGraph());
+    {
+        std::string order;
+        for (const std::string& pass : frameGraph.order()) {
+            order += (order.empty() ? "" : " -> ") + pass;
+        }
+        LOG_INFO("Render frame graph pass order: " + order);
+    }
+
     while (!glfwWindowShouldClose(window)) {
         auto frameStart = std::chrono::high_resolution_clock::now();
 
@@ -658,42 +674,13 @@ int main() {
             sin(currentFrameTime * 0.5f) * 2.0f + 2.0f
         ));
 
-        // === SHADOW MAPPING PASSES ===
-        
-        // Update shadow maps with current light positions
-        if (dirShadowMap) {
-            dirShadowMap->setLightSpaceMatrix(dirLight.direction, glm::vec3(0.0f), 15.0f);
-        }
-        
-        if (pointShadowMap) {
-            pointShadowMap->setPointLightMatrices(pointLight.position, 25.0f);
-        }
-        
-        // Render directional light shadow map
-        if (dirShadowMap && shadowShaderPtr) {
-            dirShadowMap->beginShadowPass();
-            shadowShaderPtr->use();
-            
-            // Set light space matrix
-            glm::mat4 lightSpaceMatrix = dirShadowMap->getLightSpaceMatrix();
-            shadowShaderPtr->setMat4("lightSpaceMatrix", glm::value_ptr(lightSpaceMatrix));
-            
-            // Render scene objects to shadow map
-            renderSceneObjects(shadowShaderPtr, VAO, modelLoaded, cubeModel, currentFrameTime);
-            
-            dirShadowMap->endShadowPass();
-        }
-        
-        // Render point light shadow map (if point shadow shader is available)
-        // Note: This would require the point shadow shader with geometry shader
-        // For now, we'll focus on directional light shadows
-        
-        // === END SHADOW MAPPING PASSES ===
+        // === FRAME RENDER GRAPH ===
+        // The per-frame passes below are bound to handlers and then run in the
+        // order the render-pass graph computed (see buildDefaultFrameGraph()):
+        //   shadow -> scene_begin -> skybox -> forward -> particles -> postprocess
 
-        // Begin post-processing frame (renders to framebuffer)
-        postProcessor.beginFrame();
-        
-        // Get camera matrices for this frame - use Camera Component if enabled
+        // Camera matrices for this frame, shared by the skybox/forward/particle
+        // passes. Use the Camera Component if enabled.
         glm::mat4 view, projection;
         if (g_useCameraComponent && g_enhancedCamera) {
             view = g_enhancedCamera->getViewMatrix();
@@ -702,15 +689,43 @@ int main() {
             view = camera.getViewMatrix();
             projection = camera.getProjectionMatrix();
         }
-        
+
         // Update frustum for culling
         if (g_frustumCullingEnabled) {
             g_frustumCuller.updateFrustum(view, projection);
         }
-        
-        // Render skybox first (as background)
-        skybox.render(view, projection);
-        
+
+        frameGraph.setHandler(IKore::render::passes::Shadow, [&]() {
+            // Update shadow maps with current light positions
+            if (dirShadowMap) {
+                dirShadowMap->setLightSpaceMatrix(dirLight.direction, glm::vec3(0.0f), 15.0f);
+            }
+            if (pointShadowMap) {
+                pointShadowMap->setPointLightMatrices(pointLight.position, 25.0f);
+            }
+            // Render directional light shadow map
+            if (dirShadowMap && shadowShaderPtr) {
+                dirShadowMap->beginShadowPass();
+                shadowShaderPtr->use();
+                glm::mat4 lightSpaceMatrix = dirShadowMap->getLightSpaceMatrix();
+                shadowShaderPtr->setMat4("lightSpaceMatrix", glm::value_ptr(lightSpaceMatrix));
+                renderSceneObjects(shadowShaderPtr, VAO, modelLoaded, cubeModel, currentFrameTime);
+                dirShadowMap->endShadowPass();
+            }
+            // Point light shadow map needs a geometry-shader path; not rendered yet.
+        });
+
+        frameGraph.setHandler(IKore::render::passes::SceneBegin, [&]() {
+            // Bind the offscreen post-processing target and clear it.
+            postProcessor.beginFrame();
+        });
+
+        frameGraph.setHandler(IKore::render::passes::Skybox, [&]() {
+            // Render skybox first (as background)
+            skybox.render(view, projection);
+        });
+
+        frameGraph.setHandler(IKore::render::passes::Forward, [&]() {
         if(shaderPtr) {
             shaderPtr->use();
             
@@ -936,12 +951,20 @@ int main() {
             // Unbind textures
             textureManager.unbindAll();
         }
+        });  // end forward pass handler
 
-        // Render particle systems
-        particleManager.renderAll(view, projection);
+        frameGraph.setHandler(IKore::render::passes::Particles, [&]() {
+            // Render particle systems
+            particleManager.renderAll(view, projection);
+        });
 
-        // End post-processing frame (applies effects and renders to screen)
-        postProcessor.endFrame();
+        frameGraph.setHandler(IKore::render::passes::PostProcess, [&]() {
+            // End post-processing frame (applies effects and renders to screen)
+            postProcessor.endFrame();
+        });
+
+        // Run the registered passes in dependency order.
+        frameGraph.execute();
 
         // Render Entity Debug Overlay (after all scene rendering)
         IKore::getEntityDebugSystem().renderDebugOverlay();

--- a/src/render/FrameGraph.h
+++ b/src/render/FrameGraph.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "render/RenderPassGraph.h"
+
+/**
+ * @file FrameGraph.h
+ * @brief The engine's concrete frame described as a RenderPassGraph, plus a small
+ *        executor that runs named passes in the computed order (issue #232).
+ *
+ * `RenderPassGraph` (issue #226) only knows how to order names. This header is the
+ * "adoption" step from `docs/RENDERING_MODERNIZATION.md` P1: it defines the real
+ * pass set of the forward renderer as data (`buildDefaultFrameGraph()`) and a
+ * `FrameGraphExecutor` that maps each pass name to a callback and invokes them in
+ * dependency order. The renderer's frame loop drives `execute()` instead of a
+ * hard-coded sequence, so reordering or inserting a pass becomes a data change
+ * here rather than an edit to the render loop.
+ *
+ * Both pieces are GL-free and header-only, so the frame topology and the executor
+ * are unit-testable without a graphics context (see tests/test_frame_graph.cpp).
+ */
+namespace IKore {
+namespace render {
+
+/// Canonical names of the passes that make up the default forward frame.
+namespace passes {
+inline constexpr const char* Shadow = "shadow";           ///< Shadow-map depth pass.
+inline constexpr const char* SceneBegin = "scene_begin";  ///< Bind + clear the offscreen color target.
+inline constexpr const char* Skybox = "skybox";           ///< Background skybox.
+inline constexpr const char* Forward = "forward";         ///< Lit forward/opaque scene.
+inline constexpr const char* Particles = "particles";     ///< Particle systems over the lit scene.
+inline constexpr const char* PostProcess = "postprocess"; ///< Effect chain (bloom/SSAO/FXAA) + present.
+} // namespace passes
+
+/**
+ * @brief Build the forward renderer's frame as a dependency graph.
+ *
+ * The dependencies encode the renderer's real data flow:
+ *  - the forward lighting pass samples the shadow map, so it depends on @c shadow;
+ *  - every pass that draws into the offscreen buffer depends on @c scene_begin,
+ *    which binds and clears it;
+ *  - the skybox is the background, so @c forward draws over it;
+ *  - @c particles draw over the lit scene; and
+ *  - @c postprocess consumes the finished color buffer.
+ *
+ * With the graph's deterministic tie-break (earliest-added ready pass first) this
+ * yields exactly the order the renderer used before adoption:
+ *   shadow -> scene_begin -> skybox -> forward -> particles -> postprocess
+ * so wiring the graph in cannot reorder work and cannot regress existing scenes.
+ */
+inline RenderPassGraph buildDefaultFrameGraph() {
+    RenderPassGraph graph;
+    graph.addPass(passes::Shadow);
+    graph.addPass(passes::SceneBegin);
+    graph.addPass(passes::Skybox, {passes::SceneBegin});
+    graph.addPass(passes::Forward, {passes::Shadow, passes::SceneBegin, passes::Skybox});
+    graph.addPass(passes::Particles, {passes::Forward});
+    graph.addPass(passes::PostProcess, {passes::Particles});
+    return graph;
+}
+
+/**
+ * @brief Runs named render passes in the order computed by a RenderPassGraph.
+ *
+ * The graph decides @e when each pass runs (topological order); the handler
+ * registered for a pass decides @e what it does. Reordering or inserting a pass is
+ * therefore a change to the graph, not to the render loop. A pass with no
+ * registered handler is a no-op, so passes can be wired up incrementally.
+ *
+ * The execution order is computed once at construction (the graph is static), so
+ * per-frame `execute()` only walks the precomputed order.
+ */
+class FrameGraphExecutor {
+public:
+    using Handler = std::function<void()>;
+
+    explicit FrameGraphExecutor(RenderPassGraph graph)
+        : m_graph(std::move(graph)), m_order(m_graph.order()) {}
+
+    /// Register (or replace) the handler invoked for @p pass.
+    void setHandler(const std::string& pass, Handler handler) {
+        m_handlers[pass] = std::move(handler);
+    }
+
+    /// Invoke each pass's handler in dependency order; passes without a handler
+    /// are skipped.
+    void execute() const {
+        for (const std::string& pass : m_order) {
+            auto it = m_handlers.find(pass);
+            if (it != m_handlers.end() && it->second) it->second();
+        }
+    }
+
+    const RenderPassGraph& graph() const { return m_graph; }
+
+    /// The precomputed execution order (empty if the graph contained a cycle).
+    const std::vector<std::string>& order() const { return m_order; }
+
+private:
+    RenderPassGraph m_graph;
+    std::vector<std::string> m_order;
+    std::unordered_map<std::string, Handler> m_handlers;
+};
+
+} // namespace render
+} // namespace IKore

--- a/tests/test_frame_graph.cpp
+++ b/tests/test_frame_graph.cpp
@@ -1,0 +1,105 @@
+// Test for the concrete frame graph + executor - issue #232 (rendering P1 adoption).
+//
+// Verifies that the renderer's real pass set (buildDefaultFrameGraph) resolves,
+// is acyclic, and orders to exactly the sequence the renderer used before the
+// graph was wired in - so adoption cannot cause a visual regression - and that
+// FrameGraphExecutor runs handlers in that order and skips unwired passes.
+//
+// Pure std + header-only (no GL context):
+//   g++ -std=c++17 -I src tests/test_frame_graph.cpp -o test_frame_graph
+
+#include "render/FrameGraph.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore::render;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static int indexOf(const std::vector<std::string>& order, const std::string& name) {
+    for (std::size_t i = 0; i < order.size(); ++i) {
+        if (order[i] == name) return static_cast<int>(i);
+    }
+    return -1;
+}
+
+// The default frame graph is well-formed: all six passes, deps resolve, acyclic.
+static void testDefaultFrameGraphIsWellFormed() {
+    const RenderPassGraph g = buildDefaultFrameGraph();
+    CHECK(g.passCount() == 6);
+    CHECK(g.hasPass(passes::Shadow));
+    CHECK(g.hasPass(passes::PostProcess));
+    CHECK(g.dependenciesResolved());
+    CHECK(!g.hasCycle());
+}
+
+// It must reproduce the exact pre-adoption order so no scene renders differently.
+static void testDefaultFrameGraphOrderIsStable() {
+    const std::vector<std::string> expected = {
+        passes::Shadow, passes::SceneBegin, passes::Skybox,
+        passes::Forward, passes::Particles, passes::PostProcess,
+    };
+    CHECK(buildDefaultFrameGraph().order() == expected);
+}
+
+// The real data-flow constraints hold regardless of tie-break details.
+static void testDependencyConstraintsHold() {
+    const std::vector<std::string> order = buildDefaultFrameGraph().order();
+    CHECK(indexOf(order, passes::Shadow) < indexOf(order, passes::Forward));
+    CHECK(indexOf(order, passes::SceneBegin) < indexOf(order, passes::Skybox));
+    CHECK(indexOf(order, passes::Skybox) < indexOf(order, passes::Forward));
+    CHECK(indexOf(order, passes::Forward) < indexOf(order, passes::Particles));
+    CHECK(indexOf(order, passes::Particles) < indexOf(order, passes::PostProcess));
+    CHECK(order.back() == passes::PostProcess);
+}
+
+// The executor computes the same order and invokes handlers in it.
+static void testExecutorRunsHandlersInOrder() {
+    FrameGraphExecutor exec(buildDefaultFrameGraph());
+    const std::vector<std::string> expected = {
+        passes::Shadow, passes::SceneBegin, passes::Skybox,
+        passes::Forward, passes::Particles, passes::PostProcess,
+    };
+    CHECK(exec.order() == expected);
+
+    std::vector<std::string> ran;
+    for (const std::string& p : expected) {
+        exec.setHandler(p, [p, &ran]() { ran.push_back(p); });
+    }
+    exec.execute();
+    CHECK(ran == expected);
+}
+
+// A pass with no handler is a no-op, so passes can be wired up incrementally.
+static void testUnwiredPassesAreSkipped() {
+    FrameGraphExecutor exec(buildDefaultFrameGraph());
+    int forwardRuns = 0;
+    exec.setHandler(passes::Forward, [&forwardRuns]() { ++forwardRuns; });
+    exec.execute();
+    CHECK(forwardRuns == 1); // only the one wired pass ran; the other five were skipped
+}
+
+int main() {
+    testDefaultFrameGraphIsWellFormed();
+    testDefaultFrameGraphOrderIsStable();
+    testDependencyConstraintsHold();
+    testExecutorRunsHandlersInOrder();
+    testUnwiredPassesAreSkipped();
+
+    if (g_failures == 0) {
+        std::printf("All frame graph tests passed.\n");
+        return 0;
+    }
+    std::printf("%d frame graph test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Wires the standalone `RenderPassGraph` (#226) into the actual frame loop so pass execution order is **data-driven** instead of hard-coded. This is the P1 "adoption" step from `docs/RENDERING_MODERNIZATION.md`, and the first agreed-upon follow-up to the rendering-modernization plan.

Closes #232.

## What changed

- **`src/render/FrameGraph.h`** (new, GL-free, header-only)
  - `buildDefaultFrameGraph()` describes the renderer's real pass set as data, with explicit dependencies that encode the actual data flow (forward samples the shadow map; everything drawing into the offscreen buffer depends on `scene_begin`; particles draw over the lit scene; post-processing consumes the finished buffer).
  - `FrameGraphExecutor` maps each pass name to a handler and invokes them in the graph's computed topological order. A pass with no handler is a no-op, so passes can be wired up incrementally.
- **`src/main.cpp`** — the render loop now binds a handler per pass and calls `frameGraph.execute()` instead of an inline sequence. Reordering or inserting a pass is now a change to `buildDefaultFrameGraph()`, not an edit to the loop.
- **`tests/test_frame_graph.cpp`** (new) — headless test pinning the default order, the dependency constraints, executor dispatch order, and the no-op-for-unwired-passes behavior.
- **`CMakeLists.txt`** — builds the new header-only test target.
- **`docs/RENDERING_MODERNIZATION.md`** — marks P1 adoption done and notes that later passes (P2/P3) should be expressed as graph nodes rather than new inline code.

## No visual regression

The graph's dependencies are chosen so `order()` reproduces the **exact** pre-adoption sequence:

```
shadow -> scene_begin -> skybox -> forward -> particles -> postprocess
```

Each handler wraps the original pass code verbatim; the only motion is hoisting the `view`/`projection` computation a few lines earlier, which has no GL side effects, so the rendered frame is identical. `tests/test_frame_graph.cpp` asserts that order so a future change can't silently reorder the frame.

## Testing

- `tests/test_frame_graph.cpp` and `tests/test_render_pass_graph.cpp` compile clean under `-Wall -Wextra -pedantic` and pass headlessly (`g++ -std=c++17 -I src`).
- `main.cpp` is a mechanical wrap (braces/parens balanced; each GL call appears once inside its handler); it is compiled by CI.