### PR TITLE
Add header-only PBR BRDF math (#233)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,11 @@ add_executable(test_frame_graph
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_frame_graph.cpp
 )
 
+# PBR BRDF math: GGX / Smith / Fresnel / sRGB (rendering P2 / #233) - header-only.
+add_executable(test_pbr_brdf
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pbr_brdf.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/render/PbrBrdf.h
+++ b/src/render/PbrBrdf.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <cmath>
+
+/**
+ * @file PbrBrdf.h
+ * @brief Header-only Cook-Torrance PBR BRDF math (issue #233, rendering P2).
+ *
+ * First half of P2 in docs/RENDERING_MODERNIZATION.md: the metallic-roughness
+ * microfacet math, isolated as pure functions so it is unit-testable without a GL
+ * context (mirrors how RenderPassGraph.h shipped). No renderer changes here - this
+ * is the math the future PBR shader path will mirror.
+ *
+ * Provides the three Cook-Torrance terms - the GGX/Trowbridge-Reitz normal
+ * distribution D, the Smith geometry/visibility term G (Schlick-GGX with a
+ * roughness remap), and the Fresnel-Schlick term F - plus sRGB<->linear
+ * conversions. All scalar float math, std only.
+ */
+namespace IKore {
+namespace render {
+
+inline constexpr float kPi = 3.14159265358979323846f;
+
+inline float clamp01(float x) { return x < 0.0f ? 0.0f : (x > 1.0f ? 1.0f : x); }
+
+/// Clamp perceptual roughness to (0, 1]. A small positive floor avoids the
+/// division-by-zero mirror singularity at roughness 0 while staying finite.
+inline float clampRoughness(float roughness) {
+    return roughness < 1.0e-3f ? 1.0e-3f : (roughness > 1.0f ? 1.0f : roughness);
+}
+
+/// GGX alpha = roughness^2 (the "roughness remap" for the distribution).
+inline float roughnessToAlpha(float roughness) {
+    const float r = clampRoughness(roughness);
+    return r * r;
+}
+
+/**
+ * @brief GGX / Trowbridge-Reitz normal distribution D.
+ * @param NdotH cos of the angle between the surface normal and the half vector.
+ * @param roughness perceptual roughness in [0, 1].
+ *
+ * Normalized so that the integral of D * (N.H) over the hemisphere is 1.
+ */
+inline float distributionGGX(float NdotH, float roughness) {
+    const float a = roughnessToAlpha(roughness);
+    const float a2 = a * a;
+    const float nh = clamp01(NdotH);
+    const float nh2 = nh * nh;
+    // Algebraically NdotH^2 * (a2 - 1) + 1, but written to avoid catastrophic
+    // cancellation so a tiny a2 (very smooth surfaces) stays finite at NdotH = 1.
+    const float d = nh2 * a2 + (1.0f - nh2);
+    return a2 / (kPi * d * d);
+}
+
+/// Schlick-GGX geometry term for one direction, given the remapped roughness @p k.
+inline float geometrySchlickGGX(float NdotX, float k) {
+    const float x = clamp01(NdotX);
+    const float denom = x * (1.0f - k) + k;
+    return denom > 0.0f ? x / denom : 0.0f;
+}
+
+/// Roughness remap for direct (analytic) lighting: k = (roughness + 1)^2 / 8.
+inline float roughnessToKDirect(float roughness) {
+    const float r = clamp01(roughness);
+    return (r + 1.0f) * (r + 1.0f) / 8.0f;
+}
+
+/// Roughness remap for image-based lighting: k = roughness^2 / 2.
+inline float roughnessToKIBL(float roughness) {
+    const float r = clamp01(roughness);
+    return (r * r) / 2.0f;
+}
+
+/**
+ * @brief Smith geometry term G = G1(NdotV) * G1(NdotL) using the direct-lighting
+ *        roughness remap. Returns a masking/shadowing factor in [0, 1].
+ */
+inline float geometrySmith(float NdotV, float NdotL, float roughness) {
+    const float k = roughnessToKDirect(roughness);
+    return geometrySchlickGGX(NdotV, k) * geometrySchlickGGX(NdotL, k);
+}
+
+/**
+ * @brief Fresnel-Schlick approximation F.
+ * @param cosTheta cos of the angle between the view (or light) and the half vector.
+ * @param f0 reflectance at normal incidence.
+ *
+ * Returns f0 at normal incidence and 1 at grazing angles (never below f0 or above 1
+ * for f0 in [0, 1], so it does not create energy).
+ */
+inline float fresnelSchlick(float cosTheta, float f0) {
+    const float m = 1.0f - clamp01(cosTheta);
+    const float m5 = m * m * m * m * m; // (1 - cosTheta)^5
+    return f0 + (1.0f - f0) * m5;
+}
+
+/// Normal-incidence reflectance F0 from an index of refraction (air interface).
+/// For example n = 1.5 (glass) gives F0 = 0.04, the common dielectric default.
+inline float fresnelF0FromIor(float ior) {
+    const float r = (ior - 1.0f) / (ior + 1.0f);
+    return r * r;
+}
+
+/// Convert an sRGB-encoded channel value to linear.
+inline float srgbToLinear(float c) {
+    return c <= 0.04045f ? c / 12.92f : std::pow((c + 0.055f) / 1.055f, 2.4f);
+}
+
+/// Convert a linear channel value to sRGB-encoded.
+inline float linearToSrgb(float c) {
+    return c <= 0.0031308f ? c * 12.92f : 1.055f * std::pow(c, 1.0f / 2.4f) - 0.055f;
+}
+
+} // namespace render
+} // namespace IKore

--- a/tests/test_pbr_brdf.cpp
+++ b/tests/test_pbr_brdf.cpp
@@ -1,0 +1,129 @@
+// Test for the header-only PBR BRDF math - issue #233 (rendering P2).
+//
+// Verifies the Cook-Torrance terms without a GL context: GGX distribution D
+// (including hemisphere energy normalization), Smith geometry G, Fresnel-Schlick
+// F, sRGB<->linear round-trip, and edge cases (roughness 0/1, grazing angles).
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_pbr_brdf.cpp -o test_pbr_brdf
+
+#include "render/PbrBrdf.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore::render;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-3f) { return std::fabs(a - b) < eps; }
+
+// 2*pi * integral over the upper hemisphere of D(theta) * cos(theta) * sin(theta).
+// For a correctly normalized NDF this equals 1.
+static double ggxHemisphereIntegral(float roughness) {
+    const int n = 100000;
+    const double halfPi = static_cast<double>(kPi) / 2.0;
+    const double dTheta = halfPi / n;
+    double sum = 0.0;
+    for (int i = 0; i < n; ++i) {
+        const double theta = (i + 0.5) * dTheta;
+        const double nh = std::cos(theta);
+        const double d = distributionGGX(static_cast<float>(nh), roughness);
+        sum += d * nh * std::sin(theta) * dTheta;
+    }
+    return 2.0 * static_cast<double>(kPi) * sum;
+}
+
+static void testDistribution() {
+    // D is non-negative and peaks when the half vector aligns with the normal.
+    CHECK(distributionGGX(1.0f, 0.5f) > 0.0f);
+    CHECK(distributionGGX(1.0f, 0.5f) > distributionGGX(0.5f, 0.5f));
+    CHECK(distributionGGX(0.5f, 0.5f) > distributionGGX(0.1f, 0.5f));
+
+    // Fully rough: alpha^2 = 1 so D = 1/pi for every direction.
+    CHECK(approx(distributionGGX(1.0f, 1.0f), 1.0f / kPi));
+    CHECK(approx(distributionGGX(0.3f, 1.0f), 1.0f / kPi));
+
+    // Edge cases stay finite (roughness 0 must not divide by zero).
+    CHECK(std::isfinite(distributionGGX(1.0f, 0.0f)));
+    CHECK(std::isfinite(distributionGGX(0.0f, 0.0f)));
+    CHECK(distributionGGX(1.0f, 0.0f) > distributionGGX(1.0f, 0.5f)); // sharper when smoother
+}
+
+static void testEnergyConservation() {
+    // The GGX NDF integrates to 1 over the hemisphere (energy-conserving).
+    CHECK(approx(static_cast<float>(ggxHemisphereIntegral(0.3f)), 1.0f, 0.02f));
+    CHECK(approx(static_cast<float>(ggxHemisphereIntegral(0.5f)), 1.0f, 0.02f));
+    CHECK(approx(static_cast<float>(ggxHemisphereIntegral(0.8f)), 1.0f, 0.02f));
+}
+
+static void testGeometry() {
+    // Full facing: both G1 terms are 1, so G = 1.
+    CHECK(approx(geometrySmith(1.0f, 1.0f, 0.5f), 1.0f));
+
+    // G stays within [0, 1] and vanishes at grazing angles.
+    const float g = geometrySmith(0.5f, 0.5f, 0.5f);
+    CHECK(g > 0.0f && g < 1.0f);
+    CHECK(approx(geometrySmith(0.0f, 1.0f, 0.5f), 0.0f)); // grazing view -> masked
+    CHECK(approx(geometrySmith(1.0f, 0.0f, 0.5f), 0.0f)); // grazing light -> shadowed
+
+    // Monotonic: more head-on is less occluded.
+    CHECK(geometrySmith(0.9f, 0.9f, 0.5f) > geometrySmith(0.2f, 0.2f, 0.5f));
+
+    // Roughness remaps: direct = (r+1)^2/8, IBL = r^2/2.
+    CHECK(approx(roughnessToKDirect(1.0f), 4.0f / 8.0f));
+    CHECK(approx(roughnessToKIBL(1.0f), 0.5f));
+    CHECK(std::isfinite(geometrySmith(0.5f, 0.5f, 0.0f)));
+    CHECK(std::isfinite(geometrySmith(0.5f, 0.5f, 1.0f)));
+}
+
+static void testFresnel() {
+    // Normal incidence returns F0; grazing returns 1.
+    CHECK(approx(fresnelSchlick(1.0f, 0.04f), 0.04f));
+    CHECK(approx(fresnelSchlick(0.0f, 0.04f), 1.0f));
+
+    // Never dips below F0 or exceeds 1 (no energy created), and rises toward grazing.
+    const float mid = fresnelSchlick(0.5f, 0.04f);
+    CHECK(mid >= 0.04f && mid <= 1.0f);
+    CHECK(fresnelSchlick(0.2f, 0.04f) > fresnelSchlick(0.8f, 0.04f));
+
+    // Known dielectric value: glass (IOR 1.5) has F0 = 0.04.
+    CHECK(approx(fresnelF0FromIor(1.5f), 0.04f));
+}
+
+static void testSrgb() {
+    // Endpoints and a known midpoint.
+    CHECK(approx(srgbToLinear(0.0f), 0.0f));
+    CHECK(approx(srgbToLinear(1.0f), 1.0f));
+    CHECK(approx(srgbToLinear(0.5f), 0.21404f, 1e-3f));
+    CHECK(approx(linearToSrgb(1.0f), 1.0f));
+
+    // Round-trip linear -> sRGB -> linear across the range.
+    const float samples[] = {0.0f, 0.02f, 0.1f, 0.25f, 0.5f, 0.75f, 1.0f};
+    for (float v : samples) {
+        CHECK(approx(srgbToLinear(linearToSrgb(v)), v, 1e-4f));
+    }
+}
+
+int main() {
+    testDistribution();
+    testEnergyConservation();
+    testGeometry();
+    testFresnel();
+    testSrgb();
+
+    if (g_failures == 0) {
+        std::printf("All PBR BRDF tests passed.\n");
+        return 0;
+    }
+    std::printf("%d PBR BRDF test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

First half of rendering P2 (`docs/RENDERING_MODERNIZATION.md`): the metallic-roughness microfacet math, isolated as pure functions so it is unit-testable without a GL context - the same header-only convention as `RenderPassGraph.h`. No renderer changes here; this is the math the future PBR shader path will mirror, and it blocks the shader-path issue.

Closes #233

## Core: `src/render/PbrBrdf.h` (header-only, std only)

- `distributionGGX` - GGX / Trowbridge-Reitz normal distribution `D` (alpha = roughness^2), written to avoid catastrophic cancellation so very smooth surfaces stay finite at `NdotH = 1`.
- `geometrySmith` / `geometrySchlickGGX` - Smith geometry/visibility term `G`, with both the direct-lighting and IBL roughness remaps (`roughnessToKDirect` = `(r+1)^2/8`, `roughnessToKIBL` = `r^2/2`).
- `fresnelSchlick` and `fresnelF0FromIor` - Fresnel-Schlick `F`, plus a helper for `F0` from an index of refraction.
- `srgbToLinear` / `linearToSrgb`.

## Testing

`tests/test_pbr_brdf.cpp` covers:
- **Energy conservation** - the GGX NDF integrates to 1 over the hemisphere (numeric check for several roughness values).
- **Known-value spot checks** - `D = 1/pi` when fully rough, `F0 = 0.04` for glass (IOR 1.5), Fresnel endpoints (`F0` at normal incidence, 1 at grazing), sRGB midpoint (`0.5 -> 0.214`) and round-trip.
- **Monotonicity** - `D` peaks at the normal; `G` and `F` move the right way with angle.
- **Edge cases** - roughness 0 and 1 stay finite (no divide-by-zero); grazing angles drive `G` to 0 and `F` to 1.

Passes locally under ASan/UBSan (`All PBR BRDF tests passed.`). New CMake target `test_pbr_brdf`; also compiled by CI's CodeQL c-cpp build.

## Acceptance criteria

- Compiles standalone with just an include path: yes (`g++ -std=c++17 -I src ...`).
- Test runs headless under the CMake `test_*` pattern and is added to CI: yes (`test_pbr_brdf`).
- No renderer changes - pure math + tests: yes.

## Notes

Caught and fixed a real numerical bug while testing: the textbook denominator `NdotH^2*(a2 - 1) + 1` cancels to zero in float for near-zero roughness (producing `inf`); the code uses the algebraically identical `NdotH^2*a2 + (1 - NdotH^2)`, which the roughness-0 edge-case test now guards.