### PR TITLE
Add HDR ACES tone-mapping resolve, opt-in (#235)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,6 +698,11 @@ add_executable(test_pbr_material
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pbr_material.cpp
 )
 
+# HDR exposure + ACES tone-mapping resolve math (rendering P3 / #235) - header-only.
+add_executable(test_tone_mapping
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tone_mapping.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -529,11 +529,17 @@ void PostProcessor::initialize(int width, int height) {
     // Load copy shader
     std::string shaderError;
     m_copyShader = Shader::loadFromFilesCached("src/shaders/copy.vert", "src/shaders/copy.frag", shaderError);
-    
+
     if (!m_copyShader) {
         LOG_ERROR("Failed to load copy shader: " + shaderError);
     }
-    
+
+    // Load the HDR ACES tone-map resolve shader (issue #235).
+    m_toneMapShader = Shader::loadFromFilesCached("src/shaders/tonemap.vert", "src/shaders/tonemap.frag", shaderError);
+    if (!m_toneMapShader) {
+        LOG_ERROR("Failed to load tonemap shader: " + shaderError);
+    }
+
     m_initialized = true;
     LOG_INFO("PostProcessor initialized with resolution: " + std::to_string(width) + "x" + std::to_string(height));
 }
@@ -568,7 +574,24 @@ void PostProcessor::endFrame() {
 
 void PostProcessor::renderEffectChain(GLuint inputTexture, GLuint outputFramebuffer) {
     if (!m_initialized) return;
-    
+
+    // Opt-in HDR resolve (issue #235): tone-map the raw HDR scene through exposure +
+    // ACES in a single pass, so bright highlights roll off instead of clipping.
+    // Disabled by default, so the LDR effect chain below is the unchanged fallback.
+    // (Composing ACES with the bloom/FXAA chain is a follow-up.)
+    if (m_toneMapEnabled && m_toneMapShader) {
+        glBindFramebuffer(GL_FRAMEBUFFER, outputFramebuffer);
+        glDisable(GL_DEPTH_TEST);
+        m_toneMapShader->use();
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, inputTexture);
+        glUniform1i(glGetUniformLocation(m_toneMapShader->id(), "hdrScene"), 0);
+        m_toneMapShader->setFloat("exposure", m_exposure);
+        renderQuad();
+        glEnable(GL_DEPTH_TEST);
+        return;
+    }
+
     GLuint currentTexture = inputTexture;
     
     // Apply effects in order: SSAO -> Bloom -> FXAA

--- a/src/PostProcessor.h
+++ b/src/PostProcessor.h
@@ -200,7 +200,12 @@ private:
     
     GLuint m_quadVAO, m_quadVBO;
     std::shared_ptr<Shader> m_copyShader;
-    
+
+    // HDR ACES tone-mapping resolve (issue #235). Opt-in and off by default.
+    std::shared_ptr<Shader> m_toneMapShader;
+    float m_exposure{1.0f};
+    bool m_toneMapEnabled{false};
+
     int m_width, m_height;
     bool m_initialized;
 
@@ -225,6 +230,14 @@ public:
     FXAAEffect* getFXAAEffect() { return m_fxaaEffect.get(); }
     SSAOEffect* getSSAOEffect() { return m_ssaoEffect.get(); }
     
+    // HDR ACES tone-mapping resolve (issue #235). When enabled, endFrame() resolves
+    // the HDR scene through exposure + ACES in a single pass; when disabled (the
+    // default), the existing LDR effect chain is the unchanged fallback.
+    void setToneMapEnabled(bool enabled) { m_toneMapEnabled = enabled; }
+    bool isToneMapEnabled() const { return m_toneMapEnabled; }
+    void setExposure(float exposure) { m_exposure = exposure > 0.0f ? exposure : 0.0f; }
+    float getExposure() const { return m_exposure; }
+
     // Getters
     bool isInitialized() const { return m_initialized; }
     int getWidth() const { return m_width; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1117,6 +1117,23 @@ void key_callback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action,
                 LOG_INFO("SSAO effect " + std::string(ssao->isEnabled() ? "enabled" : "disabled"));
             }
         }
+        else if (key == GLFW_KEY_H && g_postProcessor) {
+            // Toggle HDR ACES tone-mapping resolve (issue #235). Off by default; the
+            // LDR effect chain is the fallback.
+            const bool on = !g_postProcessor->isToneMapEnabled();
+            g_postProcessor->setToneMapEnabled(on);
+            LOG_INFO(std::string("HDR ACES tone mapping ") + (on ? "enabled" : "disabled"));
+        }
+        else if ((key == GLFW_KEY_EQUAL || key == GLFW_KEY_KP_ADD) && g_postProcessor) {
+            // Increase exposure.
+            g_postProcessor->setExposure(g_postProcessor->getExposure() * 1.25f);
+            LOG_INFO("Exposure: " + std::to_string(g_postProcessor->getExposure()));
+        }
+        else if ((key == GLFW_KEY_MINUS || key == GLFW_KEY_KP_SUBTRACT) && g_postProcessor) {
+            // Decrease exposure.
+            g_postProcessor->setExposure(g_postProcessor->getExposure() / 1.25f);
+            LOG_INFO("Exposure: " + std::to_string(g_postProcessor->getExposure()));
+        }
         else if (key == GLFW_KEY_4 && g_skybox) {
             // Toggle Skybox
             g_skybox->setEnabled(!g_skybox->isEnabled());

--- a/src/render/ToneMapping.h
+++ b/src/render/ToneMapping.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "core/ecs/components/Components.h" // ecs::Vec3
+#include "render/PbrBrdf.h"                  // clamp01
+
+#include <cmath>
+
+/**
+ * @file ToneMapping.h
+ * @brief HDR exposure + ACES tone mapping math (issue #235, rendering P3).
+ *
+ * The resolve step of the HDR pipeline: take a linear HDR color, apply an exposure
+ * multiplier, map it into displayable [0, 1] with the Narkowicz ACES filmic curve,
+ * and gamma-encode (pow 1/2.2, matching the engine's existing bloom_combine.frag).
+ * Kept as pure functions so the tone curve is unit-testable without a GL context;
+ * the resolve fragment shader (src/shaders/tonemap.frag) mirrors these exactly.
+ *
+ * Header-only, GL-free (uses ecs::Vec3 for the color overload).
+ */
+namespace IKore {
+namespace render {
+
+/**
+ * @brief Narkowicz ACES filmic tone-map curve for one channel.
+ * @param x Linear HDR value (negative inputs are clamped to 0).
+ * @return Tone-mapped value in [0, 1]. Saturates toward 1, so bright highlights
+ *         roll off instead of clipping/overflowing.
+ */
+inline float acesFilmic(float x) {
+    if (x < 0.0f) x = 0.0f;
+    const float a = 2.51f;
+    const float b = 0.03f;
+    const float c = 2.43f;
+    const float d = 0.59f;
+    const float e = 0.14f;
+    return clamp01((x * (a * x + b)) / (x * (c * x + d) + e));
+}
+
+/// Apply exposure to a linear HDR channel (simple linear scale).
+inline float applyExposure(float linearHdr, float exposure) { return linearHdr * exposure; }
+
+/**
+ * @brief Full resolve for one channel: exposure -> ACES -> sRGB encode.
+ * @return Display value in [0, 1].
+ */
+inline float resolveChannel(float linearHdr, float exposure) {
+    return std::pow(acesFilmic(applyExposure(linearHdr, exposure)), 1.0f / 2.2f);
+}
+
+/// Resolve a linear HDR color to a display color (per channel).
+inline ecs::Vec3 resolveColor(const ecs::Vec3& linearHdr, float exposure) {
+    return ecs::Vec3{resolveChannel(linearHdr.x, exposure), resolveChannel(linearHdr.y, exposure),
+                     resolveChannel(linearHdr.z, exposure)};
+}
+
+} // namespace render
+} // namespace IKore

--- a/src/shaders/tonemap.frag
+++ b/src/shaders/tonemap.frag
@@ -1,0 +1,27 @@
+#version 330 core
+out vec4 FragColor;
+
+in vec2 TexCoord;
+
+uniform sampler2D hdrScene;
+uniform float exposure;
+
+// HDR resolve (issue #235): exposure -> Narkowicz ACES filmic -> gamma. Mirrors
+// src/render/ToneMapping.h (acesFilmic / applyExposure / resolveChannel), which is
+// unit-tested. Gamma uses pow(1/2.2) to match the engine's bloom_combine.frag.
+vec3 aces(vec3 x) {
+    x = max(x, vec3(0.0));
+    const float a = 2.51;
+    const float b = 0.03;
+    const float c = 2.43;
+    const float d = 0.59;
+    const float e = 0.14;
+    return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
+}
+
+void main() {
+    vec3 hdr = texture(hdrScene, TexCoord).rgb;
+    vec3 mapped = aces(hdr * exposure);
+    mapped = pow(mapped, vec3(1.0 / 2.2));
+    FragColor = vec4(mapped, 1.0);
+}

--- a/src/shaders/tonemap.vert
+++ b/src/shaders/tonemap.vert
@@ -1,0 +1,11 @@
+#version 330 core
+layout (location = 0) in vec2 aPos;
+layout (location = 1) in vec2 aTexCoord;
+
+out vec2 TexCoord;
+
+// Fullscreen resolve pass (issue #235). Matches the post-processor quad layout.
+void main() {
+    TexCoord = aTexCoord;
+    gl_Position = vec4(aPos, 0.0, 1.0);
+}

--- a/tests/test_tone_mapping.cpp
+++ b/tests/test_tone_mapping.cpp
@@ -1,0 +1,101 @@
+// Test for the HDR exposure + ACES tone-mapping math - issue #235 (rendering P3).
+//
+// The resolve fragment shader mirrors these functions, so testing them here
+// verifies the tone curve headlessly (GLSL is not compiled in CI). Covers the ACES
+// curve shape (monotonic, 0->0, saturates to 1 without clipping), exposure control,
+// and the per-channel resolve.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_tone_mapping.cpp -o test_tone_mapping
+
+#include "render/ToneMapping.h"
+
+#include <cmath>
+#include <cstdio>
+#include <initializer_list>
+
+using namespace IKore::render;
+using Vec3 = IKore::ecs::Vec3;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-3f) { return std::fabs(a - b) < eps; }
+
+static void testAcesCurveShape() {
+    CHECK(approx(acesFilmic(0.0f), 0.0f)); // black stays black
+    CHECK(acesFilmic(0.18f) > 0.0f);
+
+    // Monotonic increasing.
+    CHECK(acesFilmic(0.1f) < acesFilmic(0.5f));
+    CHECK(acesFilmic(0.5f) < acesFilmic(1.0f));
+    CHECK(acesFilmic(1.0f) < acesFilmic(4.0f));
+
+    // Always within [0, 1] and saturates (no clipping/overflow) for bright input.
+    CHECK(acesFilmic(1000.0f) <= 1.0f);
+    CHECK(approx(acesFilmic(1000.0f), 1.0f, 1e-2f));
+    CHECK(acesFilmic(1e9f) <= 1.0f);
+
+    // Negative input clamps to black.
+    CHECK(approx(acesFilmic(-5.0f), 0.0f));
+
+    // Known value: ACES(1.0) = 2.54 / 3.16 ~= 0.8038.
+    CHECK(approx(acesFilmic(1.0f), 0.8038f, 2e-3f));
+}
+
+static void testExposure() {
+    CHECK(approx(applyExposure(0.5f, 2.0f), 1.0f));
+
+    // More exposure brightens a mid tone (until it saturates).
+    const float dim = resolveChannel(0.2f, 0.5f);
+    const float mid = resolveChannel(0.2f, 1.0f);
+    const float bright = resolveChannel(0.2f, 4.0f);
+    CHECK(dim < mid);
+    CHECK(mid < bright);
+}
+
+static void testResolveChannel() {
+    // Output is always displayable [0, 1].
+    for (float hdr : {0.0f, 0.1f, 0.5f, 1.0f, 5.0f, 50.0f}) {
+        const float v = resolveChannel(hdr, 1.0f);
+        CHECK(v >= 0.0f && v <= 1.0f);
+    }
+    CHECK(approx(resolveChannel(0.0f, 1.0f), 0.0f)); // black -> black
+    // A very bright pixel resolves near white, not above it.
+    CHECK(resolveChannel(50.0f, 1.0f) > 0.9f);
+}
+
+static void testResolveColor() {
+    const Vec3 hdr{2.0f, 0.5f, 0.1f};
+    const Vec3 out = resolveColor(hdr, 1.0f);
+    CHECK(out.x >= 0.0f && out.x <= 1.0f);
+    CHECK(out.y >= 0.0f && out.y <= 1.0f);
+    CHECK(out.z >= 0.0f && out.z <= 1.0f);
+    // Brighter input channel resolves to a brighter output channel.
+    CHECK(out.x > out.y);
+    CHECK(out.y > out.z);
+    // Per-channel consistency with resolveChannel.
+    CHECK(approx(out.x, resolveChannel(hdr.x, 1.0f)));
+    CHECK(approx(out.z, resolveChannel(hdr.z, 1.0f)));
+}
+
+int main() {
+    testAcesCurveShape();
+    testExposure();
+    testResolveChannel();
+    testResolveColor();
+
+    if (g_failures == 0) {
+        std::printf("All tone mapping tests passed.\n");
+        return 0;
+    }
+    std::printf("%d tone mapping test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Rendering P3 (`docs/RENDERING_MODERNIZATION.md`): resolve the already-HDR (`GL_RGBA16F`) scene through exposure + Narkowicz ACES tone mapping so bright highlights roll off instead of clipping. Added **opt-in and off by default**, so the existing LDR effect chain is the untouched fallback.

Closes #235

## Tone-map math (headless, tested)

- `src/render/ToneMapping.h` adds `acesFilmic`, `applyExposure`, `resolveChannel`, and a `resolveColor` overload (built on `PbrBrdf.h`). Gamma uses `pow(1/2.2)` to match the engine's existing `bloom_combine.frag`.
- `tests/test_tone_mapping.cpp` covers the ACES curve shape (0->0, monotonic, saturates to <= 1 with **no clipping/overflow**, known value `ACES(1) ~= 0.804`), exposure control, and per-channel resolve.

## Resolve shader + integration

- `src/shaders/tonemap.vert` / `tonemap.frag` implement the fullscreen resolve - a line-for-line transcription of `ToneMapping.h`.
- `PostProcessor` gains `setToneMapEnabled`/`isToneMapEnabled` and `setExposure`/`getExposure` (default **disabled**, exposure 1.0), loads the tonemap shader, and in `renderEffectChain`, when enabled, resolves the **raw HDR scene** in a single pass and returns. This avoids a double tone-map with bloom's Reinhard, and when disabled the existing chain runs unchanged.
- `src/main.cpp`: key **H** toggles the ACES resolve; **+/-** adjust exposure at runtime.

## Testing & verification

- The tone curve is unit-tested under ASan/UBSan (`All tone mapping tests passed.`); the shader mirrors it. C++ builds via CI (CodeQL c-cpp). New CMake target `test_tone_mapping`.
- **Honest limitation:** GLSL isn't compiled in CI and the engine isn't run here, so the on-screen result needs in-engine visual QA. The feature is off by default, so existing scenes are unaffected.

## Acceptance criteria

- No clipping artifacts on bright highlights: ACES saturates smoothly to `<= 1` (verified in the unit test).
- Exposure adjustable at runtime: yes (`setExposure` + `+/-` keys).
- LDR fallback still renders existing scenes correctly: yes - the resolve is off by default and the existing effect chain is untouched.

## Follow-up

Composing ACES with the bloom/FXAA chain (so HDR mode also keeps bloom, tone-mapping exactly once at the end by moving Reinhard out of `bloom_combine`) is deliberately left as an in-engine tuning step, since it changes default visuals and needs visual iteration. Today's opt-in resolve is a clean single tone-map of the HDR scene.