### PR TITLE
Add cascaded shadow map math foundation (rendering P4, #236)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,6 +703,12 @@ add_executable(test_tone_mapping
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tone_mapping.cpp
 )
 
+# Cascaded shadow map math: splits / cascade selection / frustum fit / ortho
+# (rendering P4 / #236) - header-only.
+add_executable(test_shadow_cascades
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_shadow_cascades.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/render/ShadowCascades.h
+++ b/src/render/ShadowCascades.h
@@ -1,0 +1,192 @@
+#pragma once
+
+#include "core/Picking.h" // for pick::Mat4, pick::unproject, ecs::Vec3
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <vector>
+
+/**
+ * @file ShadowCascades.h
+ * @brief Cascaded Shadow Maps (CSM) math foundation for the directional light
+ *        (issue #236, rendering modernization P4).
+ *
+ * A single directional shadow map has to cover the whole view frustum at one
+ * resolution, so near-field shadows look blocky while far-field detail is wasted.
+ * CSM splits the view frustum into a few depth ranges (cascades) and gives each
+ * its own tightly fitted shadow map, so texels concentrate where the camera is
+ * looking. This header is the renderer-agnostic, glm-free, unit-testable math
+ * behind that:
+ *
+ *   - cascadeSplitDistances(): where to cut the frustum along view depth, using
+ *     the practical (logarithmic/uniform blend) split scheme.
+ *   - selectCascade(): which cascade a given view-space depth falls into. Mirrors
+ *     the per-fragment selection the shader does, so CPU and GPU agree.
+ *   - frustumCornersWorld(): the eight world-space corners of a (sub-)frustum,
+ *     unprojected from the NDC cube through an inverse view-projection.
+ *   - lightSpaceBounds() + orthoFromBounds(): fit a tight light-space AABB around
+ *     a cascade's corners and build the orthographic projection that maps it to
+ *     the [-1, 1] clip cube, i.e. the per-cascade light matrix.
+ *
+ * Matrices are column-major (matching glm and pick::Mat4), so the engine can pass
+ * glm::value_ptr(...) straight in, and the ortho this builds can be uploaded as a
+ * light-space matrix without transposition. Vectors reuse the glm-free ecs::Vec3,
+ * so the whole thing is testable without glm or a GL context. Header-only.
+ *
+ * The GPU wiring (a depth texture array, one shadow pass per cascade, and the
+ * shader sampling the selected cascade with a cross-cascade blend band) mirrors
+ * this core the way pbr.frag mirrors PbrBrdf.h and tonemap.frag mirrors
+ * ToneMapping.h; that integration is a visual follow-up since it cannot be
+ * verified headlessly.
+ */
+namespace IKore {
+namespace render {
+
+using Vec3 = ecs::Vec3;
+using Mat4 = pick::Mat4;
+
+/**
+ * @brief Split view-space depth into cascade boundaries using the practical scheme.
+ * @param nearZ  Camera near-plane distance (view space, > 0).
+ * @param farZ   Camera far-plane distance (view space, > nearZ).
+ * @param count  Number of cascades (clamped to >= 1).
+ * @param lambda Blend between uniform (0) and logarithmic (1) splits, clamped [0, 1].
+ * @return count+1 boundary distances [nearZ, s1, ..., farZ], strictly increasing.
+ *
+ * Cascade i covers the depth range [result[i], result[i+1]]. The uniform scheme
+ * spaces splits evenly in depth (good far-field coverage); the logarithmic scheme
+ * packs them toward the camera (good near-field detail). The practical scheme
+ * (Zhang et al., "Parallel-Split Shadow Maps") blends the two:
+ *   split(i) = lambda * near * (far/near)^(i/count) + (1 - lambda) * (near + (far-near)*i/count)
+ * The endpoints are pinned exactly to nearZ and farZ so callers can rely on them.
+ */
+inline std::vector<float> cascadeSplitDistances(float nearZ, float farZ, int count, float lambda) {
+    if (count < 1) count = 1;
+    if (lambda < 0.0f) lambda = 0.0f;
+    if (lambda > 1.0f) lambda = 1.0f;
+    // The logarithmic term needs a strictly positive near distance.
+    const float safeNear = nearZ > 1e-6f ? nearZ : 1e-6f;
+
+    std::vector<float> splits(static_cast<std::size_t>(count) + 1u);
+    splits.front() = nearZ;
+    splits.back() = farZ;
+    const float range = farZ - safeNear;
+    const float ratio = farZ / safeNear;
+    for (int i = 1; i < count; ++i) {
+        const float p = static_cast<float>(i) / static_cast<float>(count);
+        const float logSplit = safeNear * std::pow(ratio, p);
+        const float uniformSplit = safeNear + range * p;
+        splits[static_cast<std::size_t>(i)] = lambda * logSplit + (1.0f - lambda) * uniformSplit;
+    }
+    return splits;
+}
+
+/**
+ * @brief Pick the cascade index for a view-space depth, mirroring the shader.
+ * @param viewDepth  Positive distance from the camera along view Z.
+ * @param boundaries The count+1 boundaries from cascadeSplitDistances().
+ * @return Cascade index in [0, count-1].
+ *
+ * Cascade i owns depths up to boundaries[i+1]. Depths at or beyond the far
+ * boundary clamp to the last cascade, and depths at or before the near boundary
+ * fall into cascade 0, so every depth maps to a valid cascade. The engine and the
+ * shader must share this selection or fragments sample the wrong cascade at the seams.
+ */
+inline int selectCascade(float viewDepth, const std::vector<float>& boundaries) {
+    if (boundaries.size() < 2) return 0;
+    const int count = static_cast<int>(boundaries.size()) - 1;
+    for (int i = 0; i < count; ++i) {
+        if (viewDepth <= boundaries[static_cast<std::size_t>(i) + 1u]) return i;
+    }
+    return count - 1;
+}
+
+/**
+ * @brief The eight world-space corners of a frustum given its inverse view-projection.
+ * @param invViewProj Inverse of (projection * view) for the frustum (or sub-frustum).
+ * @return Corners of the NDC cube unprojected to world space.
+ *
+ * Corners span the OpenGL NDC cube (x, y, z each in {-1, +1}); z = -1 is the near
+ * plane and z = +1 the far plane. To fit a single cascade, pass the inverse
+ * view-projection of a camera whose near/far were narrowed to that cascade's
+ * depth slice.
+ */
+inline std::array<Vec3, 8> frustumCornersWorld(const Mat4& invViewProj) {
+    std::array<Vec3, 8> corners{};
+    int idx = 0;
+    for (int xi = 0; xi < 2; ++xi) {
+        const float ndcX = xi == 0 ? -1.0f : 1.0f;
+        for (int yi = 0; yi < 2; ++yi) {
+            const float ndcY = yi == 0 ? -1.0f : 1.0f;
+            for (int zi = 0; zi < 2; ++zi) {
+                const float ndcZ = zi == 0 ? -1.0f : 1.0f;
+                corners[static_cast<std::size_t>(idx++)] = pick::unproject(invViewProj, ndcX, ndcY, ndcZ);
+            }
+        }
+    }
+    return corners;
+}
+
+/// An axis-aligned bounding box in some space (here, light space).
+struct Aabb {
+    Vec3 min;
+    Vec3 max;
+};
+
+/**
+ * @brief Fit an axis-aligned bounding box around frustum corners in light space.
+ * @param corners   World-space frustum corners (from frustumCornersWorld()).
+ * @param lightView The directional light's view matrix (world -> light space, affine).
+ * @return The component-wise min/max of the corners transformed into light space.
+ *
+ * Transforming by an affine view matrix keeps w = 1, so the perspective divide in
+ * unproject() is a no-op here; it is reused purely as a point transform. The
+ * resulting box is what a cascade's orthographic projection should cover.
+ */
+inline Aabb lightSpaceBounds(const std::array<Vec3, 8>& corners, const Mat4& lightView) {
+    const float big = 1e30f;
+    Aabb box{Vec3{big, big, big}, Vec3{-big, -big, -big}};
+    for (const Vec3& worldCorner : corners) {
+        const Vec3 p = pick::unproject(lightView, worldCorner.x, worldCorner.y, worldCorner.z);
+        box.min.x = std::min(box.min.x, p.x);
+        box.min.y = std::min(box.min.y, p.y);
+        box.min.z = std::min(box.min.z, p.z);
+        box.max.x = std::max(box.max.x, p.x);
+        box.max.y = std::max(box.max.y, p.y);
+        box.max.z = std::max(box.max.z, p.z);
+    }
+    return box;
+}
+
+/**
+ * @brief Build the orthographic projection that maps a light-space AABB to clip space.
+ * @param box A light-space AABB (from lightSpaceBounds()).
+ * @return A column-major ortho matrix mapping box.min -> -1 and box.max -> +1 on x, y, z.
+ *
+ * This is the per-cascade light matrix (combined with the light view when the
+ * corners were transformed): a point at the box center lands at the clip origin,
+ * min corners at (-1,-1,-1) and max corners at (+1,+1,+1). Degenerate extents
+ * fall back to a unit span to avoid division by zero.
+ */
+inline Mat4 orthoFromBounds(const Aabb& box) {
+    float rl = box.max.x - box.min.x;
+    float tb = box.max.y - box.min.y;
+    float fn = box.max.z - box.min.z;
+    if (std::fabs(rl) < 1e-8f) rl = 1.0f;
+    if (std::fabs(tb) < 1e-8f) tb = 1.0f;
+    if (std::fabs(fn) < 1e-8f) fn = 1.0f;
+
+    Mat4 r{};
+    r.m[0] = 2.0f / rl;
+    r.m[5] = 2.0f / tb;
+    r.m[10] = 2.0f / fn;
+    r.m[12] = -(box.max.x + box.min.x) / rl;
+    r.m[13] = -(box.max.y + box.min.y) / tb;
+    r.m[14] = -(box.max.z + box.min.z) / fn;
+    r.m[15] = 1.0f;
+    return r;
+}
+
+} // namespace render
+} // namespace IKore

--- a/tests/test_shadow_cascades.cpp
+++ b/tests/test_shadow_cascades.cpp
@@ -1,0 +1,186 @@
+// Test for the cascaded shadow map (CSM) math - issue #236 (rendering P4).
+//
+// The GPU integration (depth texture array, per-cascade passes, and the shader's
+// per-fragment cascade selection + seam blend) mirrors these functions, so testing
+// them here verifies the split scheme, cascade selection, frustum fit, and ortho
+// projection headlessly (GLSL is not compiled in CI, and the GL engine cannot run
+// in this environment).
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_shadow_cascades.cpp -o test_shadow_cascades
+
+#include "render/ShadowCascades.h"
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::render;
+using IKore::pick::unproject;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-3f) { return std::fabs(a - b) < eps; }
+
+static void testSplitCountAndEndpoints() {
+    const std::vector<float> s = cascadeSplitDistances(0.1f, 100.0f, 4, 0.5f);
+    CHECK(s.size() == 5u); // count + 1 boundaries
+    CHECK(approx(s.front(), 0.1f));   // pinned to near
+    CHECK(approx(s.back(), 100.0f));  // pinned to far
+    // Strictly increasing.
+    for (std::size_t i = 1; i < s.size(); ++i) CHECK(s[i] > s[i - 1]);
+
+    // Count clamps to at least one cascade (two boundaries).
+    CHECK(cascadeSplitDistances(1.0f, 100.0f, 0, 0.5f).size() == 2u);
+    CHECK(cascadeSplitDistances(1.0f, 100.0f, -3, 0.5f).size() == 2u);
+    const std::vector<float> one = cascadeSplitDistances(1.0f, 100.0f, 1, 0.5f);
+    CHECK(one.size() == 2u);
+    CHECK(approx(one.front(), 1.0f));
+    CHECK(approx(one.back(), 100.0f));
+}
+
+static void testSplitSchemes() {
+    // lambda = 0 -> uniform spacing in depth.
+    const std::vector<float> uni = cascadeSplitDistances(1.0f, 101.0f, 4, 0.0f);
+    CHECK(approx(uni[1], 26.0f, 1e-2f));  // 1 + 100 * 0.25
+    CHECK(approx(uni[2], 51.0f, 1e-2f));  // 1 + 100 * 0.50
+    CHECK(approx(uni[3], 76.0f, 1e-2f));  // 1 + 100 * 0.75
+
+    // lambda = 1 -> logarithmic spacing. near*(far/near)^0.5 = 1*sqrt(100) = 10.
+    const std::vector<float> logd = cascadeSplitDistances(1.0f, 100.0f, 2, 1.0f);
+    CHECK(approx(logd[1], 10.0f, 1e-2f));
+
+    // lambda is clamped to [0, 1].
+    const std::vector<float> hi = cascadeSplitDistances(1.0f, 101.0f, 4, 2.0f);
+    const std::vector<float> lo = cascadeSplitDistances(1.0f, 101.0f, 4, -1.0f);
+    for (int i = 1; i < 4; ++i) {
+        CHECK(approx(hi[static_cast<std::size_t>(i)],
+                     cascadeSplitDistances(1.0f, 101.0f, 4, 1.0f)[static_cast<std::size_t>(i)]));
+        CHECK(approx(lo[static_cast<std::size_t>(i)],
+                     cascadeSplitDistances(1.0f, 101.0f, 4, 0.0f)[static_cast<std::size_t>(i)]));
+    }
+
+    // Practical blend lies between the logarithmic and uniform splits.
+    const std::vector<float> mix = cascadeSplitDistances(1.0f, 100.0f, 2, 0.5f);
+    CHECK(mix[1] > 10.0f);     // above the pure-log split
+    CHECK(mix[1] < 50.5f);     // below the pure-uniform split (1 + 99*0.5)
+    CHECK(approx(mix[1], 0.5f * 10.0f + 0.5f * 50.5f, 1e-2f));
+}
+
+static void testSelectCascade() {
+    // 3 cascades: [1,10], [10,50], [50,100].
+    const std::vector<float> b{1.0f, 10.0f, 50.0f, 100.0f};
+    CHECK(selectCascade(5.0f, b) == 0);
+    CHECK(selectCascade(10.0f, b) == 0);   // upper boundary belongs to the lower cascade
+    CHECK(selectCascade(10.1f, b) == 1);
+    CHECK(selectCascade(50.0f, b) == 1);
+    CHECK(selectCascade(50.1f, b) == 2);
+    CHECK(selectCascade(100.0f, b) == 2);
+    CHECK(selectCascade(999.0f, b) == 2); // beyond far clamps to the last cascade
+    CHECK(selectCascade(0.5f, b) == 0);   // before near falls into cascade 0
+    CHECK(selectCascade(-5.0f, b) == 0);
+
+    // Degenerate boundary lists never index out of range.
+    CHECK(selectCascade(5.0f, std::vector<float>{}) == 0);
+    CHECK(selectCascade(5.0f, std::vector<float>{42.0f}) == 0);
+}
+
+static void testFrustumCornersIdentity() {
+    // With an identity inverse view-projection, unproject is the identity, so the
+    // corners are exactly the NDC cube corners.
+    const std::array<Vec3, 8> c = frustumCornersWorld(Mat4::identity());
+    for (const Vec3& v : c) {
+        CHECK(approx(std::fabs(v.x), 1.0f));
+        CHECK(approx(std::fabs(v.y), 1.0f));
+        CHECK(approx(std::fabs(v.z), 1.0f));
+    }
+    // Loop order: first corner is (-1,-1,-1), last is (+1,+1,+1).
+    CHECK(approx(c[0].x, -1.0f) && approx(c[0].y, -1.0f) && approx(c[0].z, -1.0f));
+    CHECK(approx(c[7].x, 1.0f) && approx(c[7].y, 1.0f) && approx(c[7].z, 1.0f));
+}
+
+static void testLightSpaceBounds() {
+    const std::array<Vec3, 8> corners = frustumCornersWorld(Mat4::identity());
+
+    // Identity light view: bounds are the NDC cube.
+    const Aabb id = lightSpaceBounds(corners, Mat4::identity());
+    CHECK(approx(id.min.x, -1.0f) && approx(id.min.y, -1.0f) && approx(id.min.z, -1.0f));
+    CHECK(approx(id.max.x, 1.0f) && approx(id.max.y, 1.0f) && approx(id.max.z, 1.0f));
+
+    // Translated light view (column-major translation in m[12]) shifts the box.
+    Mat4 trans = Mat4::identity();
+    trans.m[12] = 10.0f;
+    const Aabb t = lightSpaceBounds(corners, trans);
+    CHECK(approx(t.min.x, 9.0f) && approx(t.max.x, 11.0f));
+    CHECK(approx(t.min.y, -1.0f) && approx(t.max.y, 1.0f));
+
+    // Scaled light view widens the box on that axis.
+    Mat4 scale = Mat4::identity();
+    scale.m[0] = 2.0f;
+    const Aabb s = lightSpaceBounds(corners, scale);
+    CHECK(approx(s.min.x, -2.0f) && approx(s.max.x, 2.0f));
+}
+
+static void testOrthoFromBounds() {
+    // Symmetric box maps min -> -1, max -> +1, center -> 0.
+    const Aabb box{Vec3{-2.0f, -4.0f, -6.0f}, Vec3{2.0f, 4.0f, 6.0f}};
+    const Mat4 o = orthoFromBounds(box);
+    const Vec3 lo = unproject(o, box.min.x, box.min.y, box.min.z);
+    const Vec3 hi = unproject(o, box.max.x, box.max.y, box.max.z);
+    const Vec3 mid = unproject(o, 0.0f, 0.0f, 0.0f);
+    CHECK(approx(lo.x, -1.0f) && approx(lo.y, -1.0f) && approx(lo.z, -1.0f));
+    CHECK(approx(hi.x, 1.0f) && approx(hi.y, 1.0f) && approx(hi.z, 1.0f));
+    CHECK(approx(mid.x, 0.0f) && approx(mid.y, 0.0f) && approx(mid.z, 0.0f));
+
+    // Asymmetric box: center (5,10,20) maps to the clip origin.
+    const Aabb off{Vec3{0.0f, 0.0f, 0.0f}, Vec3{10.0f, 20.0f, 40.0f}};
+    const Mat4 o2 = orthoFromBounds(off);
+    const Vec3 c = unproject(o2, 5.0f, 10.0f, 20.0f);
+    CHECK(approx(c.x, 0.0f) && approx(c.y, 0.0f) && approx(c.z, 0.0f));
+    const Vec3 lo2 = unproject(o2, 0.0f, 0.0f, 0.0f);
+    CHECK(approx(lo2.x, -1.0f) && approx(lo2.y, -1.0f) && approx(lo2.z, -1.0f));
+
+    // Degenerate extent falls back to a unit span, producing finite output.
+    const Aabb flat{Vec3{0.0f, 0.0f, 0.0f}, Vec3{0.0f, 5.0f, 5.0f}};
+    const Mat4 o3 = orthoFromBounds(flat);
+    const Vec3 f = unproject(o3, 0.0f, 5.0f, 5.0f);
+    CHECK(std::isfinite(f.x) && std::isfinite(f.y) && std::isfinite(f.z));
+}
+
+static void testEndToEndUnitFrustum() {
+    // A cascade whose light-space bounds are exactly the NDC cube yields an identity
+    // ortho, so corners round-trip through the full pipeline unchanged.
+    const std::array<Vec3, 8> corners = frustumCornersWorld(Mat4::identity());
+    const Aabb bounds = lightSpaceBounds(corners, Mat4::identity());
+    const Mat4 ortho = orthoFromBounds(bounds);
+    for (const Vec3& v : corners) {
+        const Vec3 clip = unproject(ortho, v.x, v.y, v.z);
+        CHECK(approx(clip.x, v.x) && approx(clip.y, v.y) && approx(clip.z, v.z));
+    }
+}
+
+int main() {
+    testSplitCountAndEndpoints();
+    testSplitSchemes();
+    testSelectCascade();
+    testFrustumCornersIdentity();
+    testLightSpaceBounds();
+    testOrthoFromBounds();
+    testEndToEndUnitFrustum();
+
+    if (g_failures == 0) {
+        std::printf("All shadow cascade tests passed.\n");
+        return 0;
+    }
+    std::printf("%d shadow cascade test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #236. Rendering modernization P4 (shadow/lighting quality).

A single directional shadow map has to spread one resolution across the whole view frustum, so near-field shadows look blocky while far-field texels are wasted. Cascaded shadow maps (CSM) split the view frustum into a few depth ranges (cascades) and give each its own tightly fitted shadow map, concentrating texels where the camera is looking.

This PR adds the renderer-agnostic, glm-free, unit-tested math behind CSM, following the same staging used for the PBR (#233 / #234) and HDR (#235) work: a headless core that the GLSL side mirrors, kept independent of the working single-shadow path so nothing existing changes.

## What is included

`src/render/ShadowCascades.h` (header-only, `IKore::render`):

- `cascadeSplitDistances(near, far, count, lambda)` - practical split scheme (logarithmic vs uniform blend, Zhang et al. parallel-split shadow maps). Returns `count+1` boundaries with the endpoints pinned exactly to near/far; `count` clamped to >= 1 and `lambda` clamped to [0, 1].
- `selectCascade(viewDepth, boundaries)` - the cascade a view-space depth falls into, matching what the shader does per fragment so CPU and GPU agree; depths beyond the far boundary clamp to the last cascade.
- `frustumCornersWorld(invViewProj)` - the eight world-space corners of a (sub-)frustum, unprojected from the NDC cube (reuses `pick::unproject`).
- `Aabb` + `lightSpaceBounds(corners, lightView)` - a tight light-space box around a cascade's corners.
- `orthoFromBounds(box)` - the column-major orthographic matrix mapping that box to the [-1, 1] clip cube, i.e. the per-cascade light matrix.

## Testing

`tests/test_shadow_cascades.cpp` covers:

- split count / endpoints / strict monotonicity, count clamping;
- the uniform (lambda 0), logarithmic (lambda 1), and practical (blend) schemes, plus lambda clamping;
- cascade selection across ranges, boundary ownership, and out-of-range clamps (including empty / single-element boundary lists);
- frustum corners and light-space bounds for identity, translated, and scaled matrices;
- ortho min / max / center mapping with a degenerate-extent fallback;
- a full-pipeline round trip (corners -> light-space bounds -> ortho).

Built and run locally under `-fsanitize=address,undefined` with `-Wall -Wextra -pedantic`; all cases pass, no sanitizer diagnostics. Registered as `test_shadow_cascades` in CMake next to the other render tests.

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_shadow_cascades.cpp -o test_shadow_cascades && ./test_shadow_cascades
All shadow cascade tests passed.
```

## Scope and follow-up

This PR is the tested CSM math foundation only. The GPU wiring (a depth texture array, one shadow pass per cascade, and the fragment shader sampling the selected cascade with a cross-cascade blend band) mirrors this core the way `pbr.frag` mirrors `PbrBrdf.h` and `tonemap.frag` mirrors `ToneMapping.h`. That integration is deferred to a visual follow-up because it modifies the working single-shadow path and cannot be verified headlessly (GLSL is not compiled in CI and the GL engine cannot run in this environment); it needs in-engine visual QA (sharper near-field shadows, no seam popping, clean degradation to a single cascade).

## Notes

- Additive and regression-safe: no existing file behavior changes; the existing shadow path is untouched.
- CI note: the CodeQL "Analyze (c-cpp)" job builds the engine via cmake + make but does not run the unit tests, and does not compile GLSL. The test above was verified locally.