### PR TITLE
Add PCF soft-shadow filtering: Poisson taps and configurable softness (rendering P4, #237)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,6 +709,12 @@ add_executable(test_shadow_cascades
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_shadow_cascades.cpp
 )
 
+# PCF soft-shadow filtering math: tap sets / averaging / softness (rendering P4 /
+# #237) - header-only.
+add_executable(test_shadow_filtering
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_shadow_filtering.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/ShadowMap.cpp
+++ b/src/ShadowMap.cpp
@@ -16,6 +16,8 @@ ShadowMap::ShadowMap(Type type, int resolution)
     , m_softShadows(true)
     , m_pcfKernelSize(3)
     , m_shadowBias(0.005f)
+    , m_poissonSampling(false)
+    , m_shadowSoftness(1.0f)
 {
     m_pointLightMatrices.resize(6);
     for (int i = 0; i < 4; i++) {
@@ -249,6 +251,12 @@ void ShadowMap::setPCFKernelSize(int size) {
         size = std::max(1, size - 1);
     }
     m_pcfKernelSize = std::clamp(size, 1, 7);
+}
+
+void ShadowMap::setShadowSoftness(float softness) {
+    // Keep the footprint positive and bounded so a stray value cannot collapse the
+    // filter (0) or smear it across the whole map.
+    m_shadowSoftness = std::clamp(softness, 0.0f, 8.0f);
 }
 
 void ShadowMap::cleanup() {

--- a/src/ShadowMap.h
+++ b/src/ShadowMap.h
@@ -117,6 +117,20 @@ public:
     int getPCFKernelSize() const { return m_pcfKernelSize; }
 
     /**
+     * Use a Poisson-disk tap set instead of the box kernel for PCF (issue #237).
+     * Poisson sampling trades the regular grid's banding for smoother noise.
+     */
+    void setPoissonSampling(bool enabled) { m_poissonSampling = enabled; }
+    bool getPoissonSampling() const { return m_poissonSampling; }
+
+    /**
+     * Softness multiplier on the PCF tap footprint (issue #237). 1.0 keeps the
+     * prior one-texel-per-offset spacing; larger values widen the penumbra.
+     */
+    void setShadowSoftness(float softness);
+    float getShadowSoftness() const { return m_shadowSoftness; }
+
+    /**
      * Set shadow bias to reduce shadow acne
      */
     void setShadowBias(float bias) { m_shadowBias = bias; }
@@ -144,6 +158,8 @@ private:
     bool m_softShadows;
     int m_pcfKernelSize;
     float m_shadowBias;
+    bool m_poissonSampling;  // issue #237: Poisson-disk PCF instead of the box kernel
+    float m_shadowSoftness;  // issue #237: PCF tap footprint scale (1.0 = prior behavior)
 
     // Store previous viewport for restoration
     GLint m_previousViewport[4];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -793,7 +793,11 @@ int main() {
                 shaderPtr->setFloat("dirLight.shadowBias", dirShadowMap->getShadowBias());
                 shaderPtr->setFloat("dirLight.softShadows", dirShadowMap->getSoftShadows() ? 1.0f : 0.0f);
                 shaderPtr->setInt("dirLight.pcfKernelSize", dirShadowMap->getPCFKernelSize());
-                
+                // PCF filtering options (issue #237). Defaults (box kernel, softness
+                // 1.0) reproduce the prior soft-shadow output.
+                shaderPtr->setFloat("dirLight.poissonShadows", dirShadowMap->getPoissonSampling() ? 1.0f : 0.0f);
+                shaderPtr->setFloat("dirLight.shadowSoftness", dirShadowMap->getShadowSoftness());
+
                 // Bind shadow map texture
                 dirShadowMap->bindShadowMap(15); // Use texture unit 15 for shadow map
                 shaderPtr->setInt("dirLight.shadowMap", 15);

--- a/src/render/ShadowFiltering.h
+++ b/src/render/ShadowFiltering.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+/**
+ * @file ShadowFiltering.h
+ * @brief Percentage-closer filtering (PCF) math for soft shadows
+ *        (issue #237, rendering modernization P4).
+ *
+ * A raw shadow map yields a single depth comparison per fragment, so edges are
+ * hard and alias badly. PCF averages the comparison over several taps around the
+ * shadow lookup, turning the binary edge into a soft gradient. This header is the
+ * renderer-agnostic, dependency-free, unit-testable core behind that:
+ *
+ *   - shadowTexelSize(): the texel step for a square shadow map.
+ *   - shadowTest(): one depth comparison (in-shadow vs lit), matching the shader.
+ *   - pcfBoxOffsets(): a square (2h+1)x(2h+1) tap grid for a kernel size.
+ *   - poissonDiskOffsets(): a 16-tap Poisson disk, which trades the regular grid's
+ *     banding for noise that reads as smoother at the same tap count.
+ *   - pcfFilter(): average shadowTest over a tap set, scaled by texel size and a
+ *     softness factor. Dividing by the actual tap count keeps even kernels correct
+ *     (the older inline shader divided by kernelSize*kernelSize).
+ *
+ * The lighting shader's ShadowCalculation mirrors this the way pbr.frag mirrors
+ * PbrBrdf.h: the same tap sets, the same per-tap comparison, the same average, so
+ * the soft-shadow look can be reasoned about and tested headlessly even though
+ * GLSL is not compiled in CI and the GL engine cannot run here. A kernel size of 1
+ * (single origin tap) reproduces the hard-shadow path exactly, so that path stays
+ * available. Header-only, std only.
+ */
+namespace IKore {
+namespace render {
+
+/// Texel size (step between adjacent texels in UV) for a square shadow map.
+inline float shadowTexelSize(int resolution) {
+    return resolution > 0 ? 1.0f / static_cast<float>(resolution) : 0.0f;
+}
+
+/// One shadow comparison: 1.0 if the fragment is occluded, 0.0 if lit. Mirrors the
+/// shader's `currentDepth - bias > closestDepth`. Bias offsets the fragment depth
+/// toward the light to combat shadow acne.
+inline float shadowTest(float currentDepth, float closestDepth, float bias) {
+    return (currentDepth - bias > closestDepth) ? 1.0f : 0.0f;
+}
+
+/// A 2D sampling offset in texel units (before scaling by texel size / softness).
+struct Offset2D {
+    float x;
+    float y;
+};
+
+/**
+ * @brief Square PCF tap grid for a kernel size.
+ * @param kernelSize Filter width in texels (clamped to >= 1).
+ * @return (2h+1)^2 offsets, h = kernelSize/2, spanning [-h, h] on each axis.
+ *
+ * kernelSize 1 yields a single (0, 0) tap, i.e. the hard-shadow sample. Odd sizes
+ * (3, 5, 7) give the usual centered kernels; the count is always the true number
+ * of taps so pcfFilter's average is correct for any size.
+ */
+inline std::vector<Offset2D> pcfBoxOffsets(int kernelSize) {
+    if (kernelSize < 1) kernelSize = 1;
+    const int half = kernelSize / 2;
+    const int side = 2 * half + 1;
+    std::vector<Offset2D> offsets;
+    offsets.reserve(static_cast<std::size_t>(side * side));
+    for (int x = -half; x <= half; ++x) {
+        for (int y = -half; y <= half; ++y) {
+            offsets.push_back(Offset2D{static_cast<float>(x), static_cast<float>(y)});
+        }
+    }
+    return offsets;
+}
+
+/**
+ * @brief A fixed 16-tap Poisson disk (the widely used shadow-mapping set).
+ * @return 16 offsets distributed within a small disk around the origin.
+ *
+ * Sampling a Poisson disk instead of a regular grid replaces the grid's structured
+ * banding with unstructured noise, which the eye reads as a smoother penumbra at
+ * the same tap count. The shader uses the identical constants so CPU and GPU agree.
+ */
+inline std::vector<Offset2D> poissonDiskOffsets() {
+    return {
+        {-0.94201624f, -0.39906216f}, {0.94558609f, -0.76890725f},
+        {-0.09418410f, -0.92938870f}, {0.34495938f, 0.29387760f},
+        {-0.91588581f, 0.45771432f},  {-0.81544232f, -0.87912464f},
+        {-0.38277543f, 0.27676845f},  {0.97484398f, 0.75648379f},
+        {0.44323325f, -0.97511554f},  {0.53742981f, -0.47373420f},
+        {-0.26496911f, -0.41893023f}, {0.79197514f, 0.19090188f},
+        {-0.24188840f, 0.99706507f},  {-0.81409955f, 0.91437590f},
+        {0.19984126f, 0.78641367f},   {0.14383161f, -0.14100790f},
+    };
+}
+
+/**
+ * @brief Average the shadow test over a tap set (percentage-closer filtering).
+ * @param u,v          Shadow-map UV of the fragment.
+ * @param currentDepth Fragment depth in light space.
+ * @param bias         Depth bias against acne.
+ * @param texelSize    Shadow-map texel size (see shadowTexelSize()).
+ * @param softness     Multiplier on the tap footprint (1.0 = one texel per unit
+ *                     offset; larger widens the penumbra).
+ * @param offsets      Tap offsets in texel units (box grid or Poisson disk).
+ * @param sampleDepth  Callable (float su, float sv) -> stored shadow-map depth.
+ * @return Shadow fraction in [0, 1]; 0 fully lit, 1 fully occluded.
+ *
+ * Each tap samples the shadow map at (u, v) + offset * texelSize * softness and
+ * contributes one shadowTest; the result is the mean over all taps. With a
+ * single-tap kernel this equals a plain shadowTest, so the hard path is preserved.
+ */
+template <class SampleFn>
+inline float pcfFilter(float u, float v, float currentDepth, float bias,
+                       float texelSize, float softness,
+                       const std::vector<Offset2D>& offsets, SampleFn sampleDepth) {
+    if (offsets.empty()) return 0.0f;
+    float shadow = 0.0f;
+    for (const Offset2D& o : offsets) {
+        const float su = u + o.x * texelSize * softness;
+        const float sv = v + o.y * texelSize * softness;
+        shadow += shadowTest(currentDepth, sampleDepth(su, sv), bias);
+    }
+    return shadow / static_cast<float>(offsets.size());
+}
+
+} // namespace render
+} // namespace IKore

--- a/src/shaders/phong_shadows.frag
+++ b/src/shaders/phong_shadows.frag
@@ -35,6 +35,8 @@ struct DirectionalLight {
     float shadowBias;
     bool softShadows;
     int pcfKernelSize;
+    bool poissonShadows;  // use the Poisson disk instead of the box kernel (issue #237)
+    float shadowSoftness; // scales the PCF tap footprint; 1.0 keeps prior behavior
 };
 
 struct PointLight {
@@ -76,6 +78,8 @@ struct SpotLight {
     float shadowBias;
     bool softShadows;
     int pcfKernelSize;
+    bool poissonShadows;  // use the Poisson disk instead of the box kernel (issue #237)
+    float shadowSoftness; // scales the PCF tap footprint; 1.0 keeps prior behavior
 };
 
 #define MAX_POINT_LIGHTS 4
@@ -91,8 +95,22 @@ uniform bool useDirLight;
 
 uniform vec3 viewPos;
 
+// 16-tap Poisson disk mirroring poissonDiskOffsets() in src/render/ShadowFiltering.h
+// (issue #237). Sampling this instead of the box grid trades structured banding for
+// noise that reads as a smoother penumbra at the same tap count.
+const vec2 poissonDisk[16] = vec2[](
+    vec2(-0.94201624, -0.39906216), vec2( 0.94558609, -0.76890725),
+    vec2(-0.09418410, -0.92938870), vec2( 0.34495938,  0.29387760),
+    vec2(-0.91588581,  0.45771432), vec2(-0.81544232, -0.87912464),
+    vec2(-0.38277543,  0.27676845), vec2( 0.97484398,  0.75648379),
+    vec2( 0.44323325, -0.97511554), vec2( 0.53742981, -0.47373420),
+    vec2(-0.26496911, -0.41893023), vec2( 0.79197514,  0.19090188),
+    vec2(-0.24188840,  0.99706507), vec2(-0.81409955,  0.91437590),
+    vec2( 0.19984126,  0.78641367), vec2( 0.14383161, -0.14100790)
+);
+
 // Shadow mapping functions
-float ShadowCalculation(vec4 fragPosLightSpace, sampler2D shadowMap, float bias, bool softShadows, int kernelSize);
+float ShadowCalculation(vec4 fragPosLightSpace, sampler2D shadowMap, float bias, bool softShadows, int kernelSize, bool usePoisson, float softness);
 float PointShadowCalculation(vec3 fragPos, vec3 lightPos, samplerCube shadowCubemap, float farPlane, float bias, bool softShadows);
 
 // Lighting calculation functions
@@ -148,8 +166,9 @@ vec3 CalcDirLight(DirectionalLight light, vec3 normal, vec3 viewDir) {
     // Calculate shadow
     float shadow = 0.0;
     if (light.castShadows) {
-        shadow = ShadowCalculation(FragPosLightSpace, light.shadowMap, light.shadowBias, 
-                                 light.softShadows, light.pcfKernelSize);
+        shadow = ShadowCalculation(FragPosLightSpace, light.shadowMap, light.shadowBias,
+                                 light.softShadows, light.pcfKernelSize,
+                                 light.poissonShadows, light.shadowSoftness);
     }
     
     // Apply shadow to diffuse and specular components (not ambient)
@@ -230,8 +249,9 @@ vec3 CalcSpotLight(SpotLight light, vec3 normal, vec3 fragPos, vec3 viewDir) {
     float shadow = 0.0;
     if (light.castShadows && intensity > 0.0) {
         vec4 fragPosLightSpace = light.lightSpaceMatrix * vec4(fragPos, 1.0);
-        shadow = ShadowCalculation(fragPosLightSpace, light.shadowMap, light.shadowBias, 
-                                 light.softShadows, light.pcfKernelSize);
+        shadow = ShadowCalculation(fragPosLightSpace, light.shadowMap, light.shadowBias,
+                                 light.softShadows, light.pcfKernelSize,
+                                 light.poissonShadows, light.shadowSoftness);
     }
     
     // Apply attenuation, intensity, and shadow
@@ -243,43 +263,57 @@ vec3 CalcSpotLight(SpotLight light, vec3 normal, vec3 fragPos, vec3 viewDir) {
 }
 
 // Shadow mapping calculation for directional and spot lights
-float ShadowCalculation(vec4 fragPosLightSpace, sampler2D shadowMap, float bias, bool softShadows, int kernelSize) {
+float ShadowCalculation(vec4 fragPosLightSpace, sampler2D shadowMap, float bias, bool softShadows, int kernelSize, bool usePoisson, float softness) {
     // Perform perspective divide
     vec3 projCoords = fragPosLightSpace.xyz / fragPosLightSpace.w;
-    
+
     // Transform to [0,1] range
     projCoords = projCoords * 0.5 + 0.5;
-    
-    // Get closest depth value from light's perspective (using [0,1] range fragPosLight as coords)
-    float closestDepth = texture(shadowMap, projCoords.xy).r;
-    
+
     // Get depth of current fragment from light's perspective
     float currentDepth = projCoords.z;
-    
+
     // Check if current fragment is in shadow
     if (projCoords.z > 1.0) {
         return 0.0; // Outside far plane, not in shadow
     }
-    
+
     if (!softShadows || kernelSize <= 1) {
-        // Hard shadows
+        // Hard shadows: a single tap. Equivalent to pcfFilter() with one offset.
+        float closestDepth = texture(shadowMap, projCoords.xy).r;
         return currentDepth - bias > closestDepth ? 1.0 : 0.0;
-    } else {
-        // Soft shadows using PCF (Percentage Closer Filtering)
-        float shadow = 0.0;
-        vec2 texelSize = 1.0 / textureSize(shadowMap, 0);
-        int halfKernel = kernelSize / 2;
-        
-        for(int x = -halfKernel; x <= halfKernel; ++x) {
-            for(int y = -halfKernel; y <= halfKernel; ++y) {
-                float pcfDepth = texture(shadowMap, projCoords.xy + vec2(x, y) * texelSize).r;
-                shadow += currentDepth - bias > pcfDepth ? 1.0 : 0.0;
-            }    
-        }
-        shadow /= float(kernelSize * kernelSize);
-        
-        return shadow;
     }
+
+    // Soft shadows via PCF. Mirrors pcfFilter() in src/render/ShadowFiltering.h:
+    // average the depth comparison over a tap set (box grid or Poisson disk), each
+    // tap offset scaled by texel size and softness. Dividing by the true tap count
+    // keeps the average correct for any kernel size (the old code divided by
+    // kernelSize*kernelSize, which is wrong for even sizes).
+    vec2 texelSize = 1.0 / textureSize(shadowMap, 0);
+    float shadow = 0.0;
+
+    if (usePoisson) {
+        for (int i = 0; i < 16; ++i) {
+            vec2 offset = poissonDisk[i] * texelSize * softness;
+            float pcfDepth = texture(shadowMap, projCoords.xy + offset).r;
+            shadow += currentDepth - bias > pcfDepth ? 1.0 : 0.0;
+        }
+        shadow /= 16.0;
+    } else {
+        int halfKernel = kernelSize / 2;
+        int taps = 0;
+        for (int x = -halfKernel; x <= halfKernel; ++x) {
+            for (int y = -halfKernel; y <= halfKernel; ++y) {
+                vec2 offset = vec2(x, y) * texelSize * softness;
+                float pcfDepth = texture(shadowMap, projCoords.xy + offset).r;
+                shadow += currentDepth - bias > pcfDepth ? 1.0 : 0.0;
+                taps++;
+            }
+        }
+        shadow /= float(taps);
+    }
+
+    return shadow;
 }
 
 // Shadow mapping calculation for point lights (omnidirectional)

--- a/tests/test_shadow_filtering.cpp
+++ b/tests/test_shadow_filtering.cpp
@@ -1,0 +1,189 @@
+// Test for the PCF soft-shadow filtering math - issue #237 (rendering P4).
+//
+// The lighting shader's ShadowCalculation mirrors these functions (same tap sets,
+// same per-tap depth comparison, same average), so testing them here verifies the
+// soft-shadow math headlessly (GLSL is not compiled in CI and the GL engine cannot
+// run in this environment). Covers the depth comparison, texel size, box and
+// Poisson tap sets, the averaged filter, softness scaling, and the single-tap case
+// that reproduces the hard-shadow path.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_shadow_filtering.cpp -o test_shadow_filtering
+
+#include "render/ShadowFiltering.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::render;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-4f) { return std::fabs(a - b) < eps; }
+
+static void testShadowTest() {
+    // Occluded when the fragment is deeper than the stored depth (past the bias).
+    CHECK(approx(shadowTest(0.8f, 0.5f, 0.0f), 1.0f));
+    // Lit when the fragment is at or in front of the stored depth.
+    CHECK(approx(shadowTest(0.4f, 0.5f, 0.0f), 0.0f));
+    // Bias pulls a just-occluded fragment back into the light (fights acne).
+    CHECK(approx(shadowTest(0.505f, 0.5f, 0.0f), 1.0f));
+    CHECK(approx(shadowTest(0.505f, 0.5f, 0.01f), 0.0f));
+}
+
+static void testTexelSize() {
+    CHECK(approx(shadowTexelSize(1024), 1.0f / 1024.0f));
+    CHECK(approx(shadowTexelSize(2048), 1.0f / 2048.0f));
+    // A smaller map has larger texels (a coarser, softer footprint per tap).
+    CHECK(shadowTexelSize(512) > shadowTexelSize(2048));
+    // Degenerate resolution never divides by zero.
+    CHECK(approx(shadowTexelSize(0), 0.0f));
+    CHECK(approx(shadowTexelSize(-4), 0.0f));
+}
+
+static void testBoxOffsets() {
+    // Kernel 1 is a single origin tap (the hard-shadow sample).
+    const std::vector<Offset2D> k1 = pcfBoxOffsets(1);
+    CHECK(k1.size() == 1u);
+    CHECK(approx(k1[0].x, 0.0f) && approx(k1[0].y, 0.0f));
+
+    // Odd kernels give (2h+1)^2 centered taps.
+    CHECK(pcfBoxOffsets(3).size() == 9u);
+    CHECK(pcfBoxOffsets(5).size() == 25u);
+    CHECK(pcfBoxOffsets(7).size() == 49u);
+
+    // Sizes below 1 clamp to a single tap.
+    CHECK(pcfBoxOffsets(0).size() == 1u);
+    CHECK(pcfBoxOffsets(-3).size() == 1u);
+
+    // The grid is symmetric and includes the origin.
+    const std::vector<Offset2D> k3 = pcfBoxOffsets(3);
+    bool hasOrigin = false;
+    float sumX = 0.0f, sumY = 0.0f;
+    for (const Offset2D& o : k3) {
+        if (approx(o.x, 0.0f) && approx(o.y, 0.0f)) hasOrigin = true;
+        sumX += o.x;
+        sumY += o.y;
+    }
+    CHECK(hasOrigin);
+    CHECK(approx(sumX, 0.0f) && approx(sumY, 0.0f)); // symmetric about the origin
+}
+
+static void testPoissonDisk() {
+    const std::vector<Offset2D> disk = poissonDiskOffsets();
+    CHECK(disk.size() == 16u);
+
+    float sumX = 0.0f, sumY = 0.0f;
+    for (const Offset2D& o : disk) {
+        const float len = std::sqrt(o.x * o.x + o.y * o.y);
+        CHECK(len <= 1.3f);     // bounded within a small disk
+        CHECK(len > 0.05f);     // no degenerate zero-length tap
+        sumX += o.x;
+        sumY += o.y;
+    }
+    // Roughly centered on the origin (well distributed, not biased to one side).
+    CHECK(std::fabs(sumX / 16.0f) < 0.1f);
+    CHECK(std::fabs(sumY / 16.0f) < 0.1f);
+}
+
+static void testPcfFilterExtremes() {
+    const std::vector<Offset2D> k3 = pcfBoxOffsets(3);
+    const float texel = 1.0f / 1024.0f;
+
+    // Everything nearer than the fragment -> fully occluded.
+    const float allShadow = pcfFilter(0.5f, 0.5f, 0.8f, 0.001f, texel, 1.0f, k3,
+                                      [](float, float) { return 0.0f; });
+    CHECK(approx(allShadow, 1.0f));
+
+    // Everything behind the fragment -> fully lit.
+    const float allLit = pcfFilter(0.5f, 0.5f, 0.2f, 0.001f, texel, 1.0f, k3,
+                                   [](float, float) { return 1.0f; });
+    CHECK(approx(allLit, 0.0f));
+
+    // Result is always a valid fraction.
+    CHECK(allShadow >= 0.0f && allShadow <= 1.0f);
+    CHECK(allLit >= 0.0f && allLit <= 1.0f);
+}
+
+static void testPcfFilterPartial() {
+    // A half-plane occluder: taps left of center are occluded, the rest lit. For a
+    // 3x3 kernel that is the x = -1 column (3 of 9 taps) -> 1/3 in shadow.
+    const std::vector<Offset2D> k3 = pcfBoxOffsets(3);
+    const float u = 0.5f, texel = 0.01f;
+    const float frac = pcfFilter(u, 0.5f, 1.0f, 0.0f, texel, 1.0f, k3,
+                                 [u, texel](float su, float) {
+                                     return su < u - 0.5f * texel ? 0.0f : 2.0f;
+                                 });
+    CHECK(approx(frac, 3.0f / 9.0f, 1e-3f));
+}
+
+static void testHardPathEquivalence() {
+    // A single-tap kernel must equal a plain shadowTest at the center (this is the
+    // preserved hard-shadow path).
+    const std::vector<Offset2D> k1 = pcfBoxOffsets(1);
+    for (float d : {0.0f, 0.3f, 0.6f, 1.0f}) {
+        const float filtered = pcfFilter(0.5f, 0.5f, 0.5f, 0.002f, 0.001f, 1.0f, k1,
+                                         [d](float, float) { return d; });
+        CHECK(approx(filtered, shadowTest(0.5f, d, 0.002f)));
+    }
+}
+
+static void testSoftnessWidensFootprint() {
+    // Occluder ring: a tap is occluded only once its offset carries it past 0.5
+    // texel from center. Larger softness pushes taps outward, so more fall into the
+    // occluded region -> a larger shadow fraction.
+    const std::vector<Offset2D> k3 = pcfBoxOffsets(3);
+    const float u = 0.5f, texel = 1.0f; // unit texel keeps the arithmetic clean
+    auto ring = [u, texel](float su, float) {
+        return std::fabs(su - u) > 0.5f * texel ? 0.0f : 2.0f; // 0 = occluder
+    };
+    const float tight = pcfFilter(u, 0.5f, 1.0f, 0.0f, texel, 0.1f, k3, ring);
+    const float wide = pcfFilter(u, 0.5f, 1.0f, 0.0f, texel, 1.0f, k3, ring);
+    CHECK(approx(tight, 0.0f));      // all taps stay within 0.05 texel -> lit
+    CHECK(wide > tight);             // wider footprint reaches the occluder
+    CHECK(approx(wide, 6.0f / 9.0f, 1e-3f)); // x = -1 and x = +1 columns occluded
+}
+
+static void testPoissonFilter() {
+    const std::vector<Offset2D> disk = poissonDiskOffsets();
+    const float texel = 1.0f / 2048.0f;
+    const float allShadow = pcfFilter(0.5f, 0.5f, 0.9f, 0.001f, texel, 1.0f, disk,
+                                      [](float, float) { return 0.0f; });
+    const float allLit = pcfFilter(0.5f, 0.5f, 0.1f, 0.001f, texel, 1.0f, disk,
+                                   [](float, float) { return 1.0f; });
+    CHECK(approx(allShadow, 1.0f));
+    CHECK(approx(allLit, 0.0f));
+
+    // Empty tap set is treated as fully lit rather than dividing by zero.
+    CHECK(approx(pcfFilter(0.5f, 0.5f, 0.9f, 0.0f, texel, 1.0f, std::vector<Offset2D>{},
+                           [](float, float) { return 0.0f; }),
+                 0.0f));
+}
+
+int main() {
+    testShadowTest();
+    testTexelSize();
+    testBoxOffsets();
+    testPoissonDisk();
+    testPcfFilterExtremes();
+    testPcfFilterPartial();
+    testHardPathEquivalence();
+    testSoftnessWidensFootprint();
+    testPoissonFilter();
+
+    if (g_failures == 0) {
+        std::printf("All shadow filtering tests passed.\n");
+        return 0;
+    }
+    std::printf("%d shadow filtering test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #237. Rendering modernization P4 (shadow/lighting quality).

Directional and spot shadows sampled the shadow map once per fragment, so edges were hard and aliased. This adds percentage-closer filtering (PCF) that averages the depth comparison over several taps, turning the binary edge into a soft gradient. It follows the same staging used for the CSM (#236), PBR (#233 / #234), and HDR (#235) work: a headless, unit-tested core that the lighting shader mirrors, wired so the default path reproduces the prior output.

An earlier inline grid PCF already existed in the shader; this PR replaces it with the tested core's logic and adds the two things that were missing from #237's scope: a Poisson-disk tap option (to reduce the regular grid's banding/shimmer) and a configurable softness factor. It also fixes the previous average, which divided by `kernelSize * kernelSize` (wrong for even kernel sizes) instead of the true tap count.

## What is included

`src/render/ShadowFiltering.h` (header-only, `IKore::render`):

- `shadowTexelSize(resolution)` - shadow-map texel step (guards resolution <= 0).
- `shadowTest(currentDepth, closestDepth, bias)` - one depth comparison, matching the shader's `currentDepth - bias > closestDepth`.
- `pcfBoxOffsets(kernelSize)` - the `(2h+1)^2` box tap grid; `kernelSize` 1 is a single origin tap (the hard-shadow sample).
- `poissonDiskOffsets()` - a 16-tap Poisson disk that trades the box grid's structured banding for noise that reads as a smoother penumbra at the same tap count.
- `pcfFilter(...)` - averages `shadowTest` over a tap set, each tap scaled by texel size and a softness factor; divides by the true tap count.

`src/shaders/phong_shadows.frag`: `ShadowCalculation` now mirrors `pcfFilter` - the same box grid, the same 16-tap `poissonDisk` constants, softness-scaled offsets, and a tap-counted average. New `DirectionalLight` / `SpotLight` fields `poissonShadows` and `shadowSoftness` select the mode; the hard-shadow branch (`softShadows` off or `kernelSize <= 1`) is unchanged. The point-light cubemap already had its own PCF and is left as-is (its 3D cube-offset sampling is a different pattern; changing it unverifiably would add risk).

Engine wiring: `ShadowMap` gains `poissonSampling` and `shadowSoftness` (clamped to `[0, 8]`) with getters/setters; `main.cpp` uploads them for the directional light.

## Regression safety

The defaults (box kernel, `shadowSoftness` 1.0, Poisson off) reproduce the prior soft-shadow output for the odd kernel presets the engine actually uses (3, 5, 7), so existing scenes render unchanged. The critical detail: `main.cpp` now uploads `shadowSoftness = 1.0` explicitly, because a GLSL uniform left unset defaults to 0 and would otherwise collapse the footprint. Soft edges (larger softness) and Poisson sampling are opt-in via the new `ShadowMap` setters.

## Testing

`tests/test_shadow_filtering.cpp` covers:

- the depth comparison and bias behavior;
- texel size and its guards;
- box tap counts (1, 3, 5, 7), symmetry, origin inclusion, and sub-1 clamping;
- the Poisson disk: count (16), bounded radius, no degenerate tap, roughly centered distribution;
- `pcfFilter` extremes (fully lit / fully occluded) and a partial half-plane occluder giving the expected `3/9` fraction;
- single-tap equivalence to a plain `shadowTest` (the preserved hard path);
- softness widening the footprint (a tight footprint stays lit; a wider one reaches the occluder);
- the Poisson filter and the empty-tap-set guard (no divide by zero).

Built and run locally under `-fsanitize=address,undefined` with `-Wall -Wextra -pedantic`; all cases pass, no sanitizer diagnostics. Registered as `test_shadow_filtering` in CMake next to the other render tests.

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_shadow_filtering.cpp -o test_shadow_filtering && ./test_shadow_filtering
All shadow filtering tests passed.
```

## Scope and follow-up

Independent of the CSM (#236) and normal-mapping P4 items. Since GLSL is not compiled in CI and the GL engine cannot run in this environment, the visual result (visibly softer edges without significant shimmer, hard path unchanged, cost bounded/configurable) needs in-engine visual QA. The correctness-critical math and the default-preserving wiring are verified here; the shader mirrors the tested core line for line.

## Notes

- CI note: the CodeQL "Analyze (c-cpp)" job builds the engine via cmake + make but does not run the unit tests, and does not compile GLSL. The test above was verified locally.