### PR TITLE
Wire tangent-space normal mapping into the Phong path (rendering P4, #238)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -715,6 +715,12 @@ add_executable(test_shadow_filtering
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_shadow_filtering.cpp
 )
 
+# Tangent-space normal mapping math: tangent basis / TBN transform (rendering P4 /
+# #238) - header-only.
+add_executable(test_normal_mapping
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_normal_mapping.cpp
+)
+
 # Lua scripting layer test (Milestone 10 / #145). Links the self-built Lua
 # static lib and uses sol2 (header-only) + the header-only ECS.
 add_executable(test_scripting

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -757,7 +757,11 @@ int main() {
             
             // Set material properties (support both textured and non-textured materials)
             bool hasTextures = textureManager.getTextureCount() > 0;
-            
+
+            // These primitives carry no normal map; pin the flag off so a value left
+            // over from a prior normal-mapped model draw cannot leak in (issue #238).
+            shaderPtr->setFloat("material.useNormalTexture", 0.0f);
+
             if (hasTextures) {
                 // Using textures - set flags
                 shaderPtr->setFloat("material.useDiffuseTexture", 1.0f);

--- a/src/render/NormalMapping.h
+++ b/src/render/NormalMapping.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "core/ecs/components/Components.h" // for ecs::Vec3
+
+#include <cmath>
+
+/**
+ * @file NormalMapping.h
+ * @brief Tangent-space normal mapping math (issue #238, rendering modernization P4).
+ *
+ * A normal map stores a per-texel surface normal in tangent space (the RGB encoding
+ * of a unit normal). To light with it, each fragment needs a tangent basis (TBN:
+ * tangent, bitangent, normal) that maps tangent space to world space; the sampled
+ * normal is unpacked and rotated by that basis. This header is the renderer-agnostic,
+ * glm-free, unit-testable core behind that:
+ *
+ *   - computeTangentBasis(): per-triangle tangent/bitangent from positions and UVs
+ *     (the "compute on load if absent" fallback; Assimp does this at import time).
+ *   - orthonormalizeTangent(): Gram-Schmidt the tangent against the vertex normal,
+ *     exactly as the vertex shader does before building the TBN.
+ *   - computeBitangent(): the right-handed bitangent cross(N, T) the shader uses.
+ *   - bitangentSign(): handedness (+1 / -1) for meshes with mirrored UVs.
+ *   - unpackNormal(): decode an RGB texel in [0, 1] to a normal in [-1, 1].
+ *   - transformNormalToWorld(): rotate a tangent-space normal by the TBN basis.
+ *
+ * The Phong vertex/fragment shaders mirror orthonormalizeTangent / computeBitangent /
+ * unpackNormal / transformNormalToWorld line for line, the way pbr.frag mirrors
+ * PbrBrdf.h, so the perturbed-normal math can be tested headlessly even though GLSL
+ * is not compiled in CI and the GL engine cannot run here. A flat normal texel
+ * (0.5, 0.5, 1.0) unpacks to (0, 0, 1) and transforms back to the geometric normal,
+ * so an absent or flat normal map leaves shading unchanged. Header-only, std only.
+ */
+namespace IKore {
+namespace render {
+
+using Vec3 = ecs::Vec3;
+
+/// A 2D texture coordinate.
+struct Vec2 {
+    float x;
+    float y;
+};
+
+inline float dot(const Vec3& a, const Vec3& b) { return a.x * b.x + a.y * b.y + a.z * b.z; }
+
+inline Vec3 cross(const Vec3& a, const Vec3& b) {
+    return Vec3{a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
+}
+
+/// A per-triangle tangent basis. @c valid is false when the UVs are degenerate.
+struct TangentBasis {
+    Vec3 tangent;
+    Vec3 bitangent;
+    bool valid;
+};
+
+/**
+ * @brief Compute a triangle's tangent and bitangent from positions and UVs.
+ *
+ * Solves the standard system relating the two triangle edges to their UV deltas:
+ *   tangent   = f * ( dV2 * edge1 - dV1 * edge2 )
+ *   bitangent = f * ( dU1 * edge2 - dU2 * edge1 ),  f = 1 / (dU1*dV2 - dU2*dV1)
+ * so the tangent follows +U and the bitangent +V across the surface. When the UV
+ * area is zero (degenerate mapping) the determinant vanishes; the result is marked
+ * invalid and a safe default basis is returned instead of dividing by zero.
+ */
+inline TangentBasis computeTangentBasis(const Vec3& p0, const Vec3& p1, const Vec3& p2,
+                                        const Vec2& uv0, const Vec2& uv1, const Vec2& uv2) {
+    const Vec3 edge1 = p1 - p0;
+    const Vec3 edge2 = p2 - p0;
+    const float du1 = uv1.x - uv0.x;
+    const float dv1 = uv1.y - uv0.y;
+    const float du2 = uv2.x - uv0.x;
+    const float dv2 = uv2.y - uv0.y;
+
+    const float det = du1 * dv2 - du2 * dv1;
+    if (std::fabs(det) < 1e-12f) {
+        return TangentBasis{Vec3{1.0f, 0.0f, 0.0f}, Vec3{0.0f, 1.0f, 0.0f}, false};
+    }
+    const float f = 1.0f / det;
+    const Vec3 tangent = (edge1 * dv2 - edge2 * dv1) * f;
+    const Vec3 bitangent = (edge2 * du1 - edge1 * du2) * f;
+    return TangentBasis{tangent, bitangent, true};
+}
+
+/**
+ * @brief Gram-Schmidt orthonormalize a tangent against a normal.
+ *
+ * Removes the component of @p tangent along @p normal and normalizes, giving a unit
+ * tangent perpendicular to the (interpolated) normal. Mirrors the vertex shader's
+ * `T = normalize(T - dot(T, N) * N)`.
+ */
+inline Vec3 orthonormalizeTangent(const Vec3& normal, const Vec3& tangent) {
+    const Vec3 n = normal.normalized();
+    const Vec3 t = tangent - n * dot(n, tangent);
+    return t.normalized();
+}
+
+/// Right-handed bitangent cross(N, T), matching the vertex shader's TBN construction.
+inline Vec3 computeBitangent(const Vec3& normal, const Vec3& tangent) {
+    return cross(normal, tangent);
+}
+
+/**
+ * @brief Handedness of a tangent basis: +1 right-handed, -1 mirrored.
+ *
+ * For meshes with mirrored UVs the stored bitangent points opposite cross(N, T);
+ * this sign (usually kept in tangent.w) lets the shader flip it back.
+ */
+inline float bitangentSign(const Vec3& normal, const Vec3& tangent, const Vec3& bitangent) {
+    return dot(cross(normal, tangent), bitangent) < 0.0f ? -1.0f : 1.0f;
+}
+
+/// Decode a normal-map RGB sample in [0, 1] to a tangent-space normal in [-1, 1].
+/// Mirrors the shader's `texture(...).rgb * 2.0 - 1.0`.
+inline Vec3 unpackNormal(const Vec3& rgb) {
+    return Vec3{2.0f * rgb.x - 1.0f, 2.0f * rgb.y - 1.0f, 2.0f * rgb.z - 1.0f};
+}
+
+/**
+ * @brief Rotate a tangent-space normal into world space by the TBN basis.
+ *
+ * Computes normalize(T * n.x + B * n.y + N * n.z), i.e. the TBN matrix times the
+ * tangent-space normal, matching the fragment shader's `normalize(TBN * n)`. A flat
+ * normal (0, 0, 1) maps to the geometric normal N, so a flat map is a no-op.
+ */
+inline Vec3 transformNormalToWorld(const Vec3& tangent, const Vec3& bitangent,
+                                   const Vec3& normal, const Vec3& tangentNormal) {
+    const Vec3 world = tangent * tangentNormal.x + bitangent * tangentNormal.y + normal * tangentNormal.z;
+    return world.normalized();
+}
+
+} // namespace render
+} // namespace IKore

--- a/src/shaders/phong.frag
+++ b/src/shaders/phong.frag
@@ -4,6 +4,7 @@ out vec4 FragColor;
 in vec3 FragPos;
 in vec3 Normal;
 in vec2 TexCoord;
+in mat3 TBN; // tangent-space -> world basis for normal mapping (issue #238)
 
 struct Material {
     // Support for both texture-based and color-based materials
@@ -72,11 +73,21 @@ vec3 CalcPointLight(PointLight light, vec3 normal, vec3 fragPos, vec3 viewDir);
 vec3 CalcSpotLight(SpotLight light, vec3 normal, vec3 fragPos, vec3 viewDir);
 
 void main() {
-    vec3 norm = normalize(Normal);
+    // Surface normal: perturb by the normal map when one is bound, else use the
+    // interpolated vertex normal (the unchanged path). Mirrors unpackNormal +
+    // transformNormalToWorld in src/render/NormalMapping.h. A flat map (0.5,0.5,1)
+    // unpacks to (0,0,1) and maps back to the geometric normal, so it is a no-op.
+    vec3 norm;
+    if (material.useNormalTexture) {
+        vec3 tangentNormal = texture(material.normal, TexCoord).rgb * 2.0 - 1.0;
+        norm = normalize(TBN * tangentNormal);
+    } else {
+        norm = normalize(Normal);
+    }
     vec3 viewDir = normalize(viewPos - FragPos);
-    
+
     vec3 result = vec3(0.0);
-    
+
     // Directional light
     if (useDirLight) {
         result += CalcDirLight(dirLight, norm, viewDir);

--- a/src/shaders/phong.vert
+++ b/src/shaders/phong.vert
@@ -2,6 +2,7 @@
 layout(location = 0) in vec3 aPos;
 layout(location = 1) in vec3 aNormal;
 layout(location = 2) in vec2 aTexCoord;
+layout(location = 3) in vec3 aTangent; // supplied by the mesh VAO (issue #238)
 
 uniform mat4 model;
 uniform mat4 view;
@@ -11,11 +12,21 @@ uniform mat3 normalMatrix;
 out vec3 FragPos;
 out vec3 Normal;
 out vec2 TexCoord;
+out mat3 TBN; // tangent-space -> world basis for normal mapping (issue #238)
 
 void main() {
     FragPos = vec3(model * vec4(aPos, 1.0));
     Normal = normalMatrix * aNormal;
     TexCoord = aTexCoord;
-    
+
+    // Build the TBN basis (mirrors src/render/NormalMapping.h). Gram-Schmidt the
+    // tangent against the normal, then the right-handed bitangent. Only consumed by
+    // the fragment shader when a normal map is bound.
+    vec3 N = normalize(Normal);
+    vec3 T = normalize(normalMatrix * aTangent);
+    T = normalize(T - dot(T, N) * N);
+    vec3 B = cross(N, T);
+    TBN = mat3(T, B, N);
+
     gl_Position = projection * view * vec4(FragPos, 1.0);
 }

--- a/src/shaders/phong_shadows.frag
+++ b/src/shaders/phong_shadows.frag
@@ -5,6 +5,7 @@ in vec3 FragPos;
 in vec3 Normal;
 in vec2 TexCoord;
 in vec4 FragPosLightSpace; // Position in light space for shadow mapping
+in mat3 TBN;               // tangent-space -> world basis for normal mapping (issue #238)
 
 struct Material {
     // Support for both texture-based and color-based materials
@@ -119,11 +120,21 @@ vec3 CalcPointLight(PointLight light, vec3 normal, vec3 fragPos, vec3 viewDir);
 vec3 CalcSpotLight(SpotLight light, vec3 normal, vec3 fragPos, vec3 viewDir);
 
 void main() {
-    vec3 norm = normalize(Normal);
+    // Surface normal: perturb by the normal map when one is bound, else use the
+    // interpolated vertex normal (the unchanged path). Mirrors unpackNormal +
+    // transformNormalToWorld in src/render/NormalMapping.h. A flat map (0.5,0.5,1)
+    // unpacks to (0,0,1) and maps back to the geometric normal, so it is a no-op.
+    vec3 norm;
+    if (material.useNormalTexture) {
+        vec3 tangentNormal = texture(material.normal, TexCoord).rgb * 2.0 - 1.0;
+        norm = normalize(TBN * tangentNormal);
+    } else {
+        norm = normalize(Normal);
+    }
     vec3 viewDir = normalize(viewPos - FragPos);
-    
+
     vec3 result = vec3(0.0);
-    
+
     // Directional light
     if (useDirLight) {
         result += CalcDirLight(dirLight, norm, viewDir);

--- a/src/shaders/phong_shadows.vert
+++ b/src/shaders/phong_shadows.vert
@@ -2,11 +2,13 @@
 layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec3 aNormal;
 layout (location = 2) in vec2 aTexCoord;
+layout (location = 3) in vec3 aTangent; // supplied by the mesh VAO (issue #238)
 
 out vec3 FragPos;
 out vec3 Normal;
 out vec2 TexCoord;
 out vec4 FragPosLightSpace;
+out mat3 TBN; // tangent-space -> world basis for normal mapping (issue #238)
 
 uniform mat4 model;
 uniform mat4 view;
@@ -18,9 +20,19 @@ void main() {
     FragPos = vec3(model * vec4(aPos, 1.0));
     Normal = normalMatrix * aNormal;
     TexCoord = aTexCoord;
-    
+
+    // Build the TBN basis. Mirrors orthonormalizeTangent / computeBitangent in
+    // src/render/NormalMapping.h: Gram-Schmidt the tangent against the normal, then
+    // take the right-handed bitangent. Only used by the fragment shader when a
+    // normal map is bound, so meshes without tangents are unaffected.
+    vec3 N = normalize(Normal);
+    vec3 T = normalize(normalMatrix * aTangent);
+    T = normalize(T - dot(T, N) * N);
+    vec3 B = cross(N, T);
+    TBN = mat3(T, B, N);
+
     // Calculate position in light space for shadow mapping
     FragPosLightSpace = lightSpaceMatrix * vec4(FragPos, 1.0);
-    
+
     gl_Position = projection * view * vec4(FragPos, 1.0);
 }

--- a/tests/test_normal_mapping.cpp
+++ b/tests/test_normal_mapping.cpp
@@ -1,0 +1,160 @@
+// Test for the tangent-space normal-mapping math - issue #238 (rendering P4).
+//
+// The Phong vertex/fragment shaders mirror these functions (Gram-Schmidt tangent,
+// cross-product bitangent, normal unpack, TBN transform), so testing them here
+// verifies the perturbed-normal math headlessly (GLSL is not compiled in CI and the
+// GL engine cannot run in this environment). Also covers per-triangle tangent
+// generation (the load-time fallback) and handedness.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_normal_mapping.cpp -o test_normal_mapping
+
+#include "render/NormalMapping.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore::render;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-4f) { return std::fabs(a - b) < eps; }
+static bool approxVec(const Vec3& a, const Vec3& b, float eps = 1e-4f) {
+    return approx(a.x, b.x, eps) && approx(a.y, b.y, eps) && approx(a.z, b.z, eps);
+}
+
+static void testDotCross() {
+    CHECK(approx(dot(Vec3{1, 0, 0}, Vec3{1, 0, 0}), 1.0f));
+    CHECK(approx(dot(Vec3{1, 0, 0}, Vec3{0, 1, 0}), 0.0f));
+    CHECK(approxVec(cross(Vec3{1, 0, 0}, Vec3{0, 1, 0}), Vec3{0, 0, 1})); // right-handed
+    CHECK(approxVec(cross(Vec3{0, 1, 0}, Vec3{0, 0, 1}), Vec3{1, 0, 0}));
+}
+
+static void testComputeTangentBasis() {
+    // Triangle in the XY plane with U along +X and V along +Y.
+    const TangentBasis tb = computeTangentBasis(
+        Vec3{0, 0, 0}, Vec3{1, 0, 0}, Vec3{0, 1, 0},
+        Vec2{0, 0}, Vec2{1, 0}, Vec2{0, 1});
+    CHECK(tb.valid);
+    CHECK(approxVec(tb.tangent, Vec3{1, 0, 0}));   // +U -> +X
+    CHECK(approxVec(tb.bitangent, Vec3{0, 1, 0})); // +V -> +Y
+
+    // Scaling the U rate shortens the raw tangent but keeps its direction.
+    const TangentBasis scaled = computeTangentBasis(
+        Vec3{0, 0, 0}, Vec3{1, 0, 0}, Vec3{0, 1, 0},
+        Vec2{0, 0}, Vec2{2, 0}, Vec2{0, 1});
+    CHECK(scaled.valid);
+    CHECK(approxVec(scaled.tangent.normalized(), Vec3{1, 0, 0}));
+
+    // A triangle whose U axis runs along world +Z.
+    const TangentBasis zAxis = computeTangentBasis(
+        Vec3{0, 0, 0}, Vec3{0, 0, 1}, Vec3{0, 1, 0},
+        Vec2{0, 0}, Vec2{1, 0}, Vec2{0, 1});
+    CHECK(zAxis.valid);
+    CHECK(approxVec(zAxis.tangent.normalized(), Vec3{0, 0, 1}));
+
+    // Degenerate UVs (zero area) mark the basis invalid instead of dividing by zero.
+    const TangentBasis bad = computeTangentBasis(
+        Vec3{0, 0, 0}, Vec3{1, 0, 0}, Vec3{0, 1, 0},
+        Vec2{0.5f, 0.5f}, Vec2{0.5f, 0.5f}, Vec2{0.5f, 0.5f});
+    CHECK(!bad.valid);
+    CHECK(std::isfinite(bad.tangent.x) && std::isfinite(bad.bitangent.y));
+}
+
+static void testOrthonormalizeTangent() {
+    // Removing the normal-parallel part of the tangent leaves a unit vector in-plane.
+    const Vec3 n{0, 0, 1};
+    const Vec3 t = orthonormalizeTangent(n, Vec3{1, 0, 0.7f});
+    CHECK(approxVec(t, Vec3{1, 0, 0}));
+    CHECK(approx(t.length(), 1.0f));
+    CHECK(approx(dot(t, n), 0.0f)); // orthogonal to the normal
+
+    // An already-orthogonal tangent is just normalized.
+    const Vec3 t2 = orthonormalizeTangent(Vec3{0, 0, 1}, Vec3{0, 2, 0});
+    CHECK(approxVec(t2, Vec3{0, 1, 0}));
+}
+
+static void testBitangentAndSign() {
+    const Vec3 n{0, 0, 1}, t{1, 0, 0};
+    CHECK(approxVec(computeBitangent(n, t), Vec3{0, 1, 0})); // cross(N, T)
+
+    // Right-handed basis -> +1; a flipped bitangent (mirrored UVs) -> -1.
+    CHECK(approx(bitangentSign(n, t, Vec3{0, 1, 0}), 1.0f));
+    CHECK(approx(bitangentSign(n, t, Vec3{0, -1, 0}), -1.0f));
+}
+
+static void testUnpackNormal() {
+    // A flat normal texel decodes to (0, 0, 1).
+    CHECK(approxVec(unpackNormal(Vec3{0.5f, 0.5f, 1.0f}), Vec3{0, 0, 1}));
+    // Extremes decode to the axis extents.
+    CHECK(approxVec(unpackNormal(Vec3{1.0f, 0.5f, 0.5f}), Vec3{1, 0, 0}));
+    CHECK(approxVec(unpackNormal(Vec3{0.0f, 0.0f, 0.0f}), Vec3{-1, -1, -1}));
+}
+
+static void testTransformNormalToWorld() {
+    const Vec3 t{1, 0, 0}, b{0, 1, 0}, n{0, 0, 1};
+
+    // With an identity TBN the world normal equals the tangent-space normal.
+    CHECK(approxVec(transformNormalToWorld(t, b, n, Vec3{0, 0, 1}), Vec3{0, 0, 1}));
+    CHECK(approxVec(transformNormalToWorld(t, b, n, Vec3{1, 0, 0}), Vec3{1, 0, 0}));
+
+    // Key property: a flat tangent-space normal maps to the geometric normal, so an
+    // absent/flat normal map leaves shading unchanged. Use a rotated basis to prove
+    // it is N (not just z) that comes back.
+    const Vec3 rt{0, 0, 1}, rb{0, 1, 0}, rn{1, 0, 0};
+    const Vec3 flat = unpackNormal(Vec3{0.5f, 0.5f, 1.0f}); // (0,0,1)
+    CHECK(approxVec(transformNormalToWorld(rt, rb, rn, flat), Vec3{1, 0, 0})); // == rn
+
+    // The result is always unit length.
+    const Vec3 w = transformNormalToWorld(t, b, n, Vec3{0.3f, -0.4f, 0.8f});
+    CHECK(approx(w.length(), 1.0f));
+
+    // A tangent-space tilt toward +U rotates the world normal toward T.
+    const Vec3 tilted = transformNormalToWorld(t, b, n, Vec3{0.6f, 0.0f, 0.8f});
+    CHECK(tilted.x > 0.0f);        // leaned toward the tangent
+    CHECK(tilted.z > 0.0f);        // still mostly along the normal
+    CHECK(tilted.x < tilted.z);
+}
+
+static void testEndToEnd() {
+    // Build a basis the way the vertex shader does, then perturb like the fragment
+    // shader, and confirm a flat map reproduces the geometric normal exactly.
+    const Vec3 geoNormal = Vec3{0.2f, 0.3f, 1.0f}.normalized();
+    const Vec3 rawTangent{1.0f, 0.1f, 0.0f};
+    const Vec3 T = orthonormalizeTangent(geoNormal, rawTangent);
+    const Vec3 B = computeBitangent(geoNormal, T);
+
+    const Vec3 flatWorld = transformNormalToWorld(T, B, geoNormal, unpackNormal(Vec3{0.5f, 0.5f, 1.0f}));
+    CHECK(approxVec(flatWorld, geoNormal, 1e-3f));
+
+    // T, B, N form an orthonormal frame.
+    CHECK(approx(dot(T, geoNormal), 0.0f, 1e-3f));
+    CHECK(approx(dot(T, B), 0.0f, 1e-3f));
+    CHECK(approx(T.length(), 1.0f, 1e-3f));
+    CHECK(approx(B.length(), 1.0f, 1e-3f));
+}
+
+int main() {
+    testDotCross();
+    testComputeTangentBasis();
+    testOrthonormalizeTangent();
+    testBitangentAndSign();
+    testUnpackNormal();
+    testTransformNormalToWorld();
+    testEndToEnd();
+
+    if (g_failures == 0) {
+        std::printf("All normal mapping tests passed.\n");
+        return 0;
+    }
+    std::printf("%d normal mapping test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #238. Rendering modernization P4 (shadow/lighting quality).

The mesh and material infrastructure for normal mapping was already in place, but nothing used it: the `Vertex` struct carries tangents/bitangents (VAO locations 3/4), Assimp imports with `aiProcess_CalcTangentSpace`, `Material` has a `normal` texture slot, and `Model::Draw` binds it and uploads `material.useNormalTexture`. The gap was in the shaders - the vertex shaders never read the tangent or built a TBN basis, and the fragment shaders never sampled the normal map, so surfaces got no detail lighting even with a normal map assigned.

This PR wires that last mile, backed by a tested math core, following the same staging used for the CSM (#236) and PCF (#237) P4 work: a headless, unit-tested core that the shaders mirror line for line.

## What is included

`src/render/NormalMapping.h` (header-only, `IKore::render`):

- `computeTangentBasis(positions, uvs)` - per-triangle tangent/bitangent from the standard edge/UV system, with a degenerate-UV guard (the "compute on load if absent" fallback; Assimp does this at import time).
- `orthonormalizeTangent(N, T)` - Gram-Schmidt the tangent against the normal, matching the vertex shader.
- `computeBitangent(N, T)` = `cross(N, T)`, and `bitangentSign()` for meshes with mirrored UVs.
- `unpackNormal(rgb)` = `rgb * 2 - 1`, and `transformNormalToWorld(T, B, N, n)` = `normalize(TBN * n)`.

Shaders (mirror the core):

- `phong.vert` and `phong_shadows.vert` now read `aTangent` (location 3), Gram-Schmidt it against the normal, and output a `mat3 TBN`.
- `phong.frag` and `phong_shadows.frag` sample and unpack the normal map and rotate it to world space when `material.useNormalTexture` is set; otherwise they keep the prior `normalize(Normal)`. A flat texel `(0.5, 0.5, 1.0)` unpacks to `(0, 0, 1)` and maps back to the geometric normal, so an absent or flat map is a no-op.

`main.cpp` pins `material.useNormalTexture` to `0.0` for its direct-draw primitives, so a value left over from a prior normal-mapped model draw cannot leak into geometry that has no tangents.

## Regression safety

Materials without a normal map take the unchanged `normalize(Normal)` path, so existing scenes render identically. The TBN varying is computed for every mesh but only consumed under the `useNormalTexture` branch (uniform control flow), so meshes without tangents are unaffected. The stale-uniform fix in `main.cpp` closes the one path that could otherwise have changed behavior once the flag is honored.

## Testing

`tests/test_normal_mapping.cpp` covers:

- `dot` / `cross` helpers (right-handedness);
- `computeTangentBasis` direction (+U -> tangent, +V -> bitangent), UV-rate scaling, an off-axis triangle, and the degenerate-UV guard;
- `orthonormalizeTangent` orthogonality and unit length;
- `computeBitangent` and `bitangentSign` (+1 / -1 for mirrored UVs);
- `unpackNormal` (flat and extremes);
- `transformNormalToWorld` (identity basis, the flat-map-equals-geometric-normal property proven with a rotated basis, unit length, and tilt direction);
- an end-to-end build-basis-then-perturb round trip confirming a flat map reproduces the geometric normal and T/B/N stay orthonormal.

Built and run locally under `-fsanitize=address,undefined` with `-Wall -Wextra -pedantic`; all cases pass, no sanitizer diagnostics. Registered as `test_normal_mapping` in CMake next to the other render tests.

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_normal_mapping.cpp -o test_normal_mapping && ./test_normal_mapping
All normal mapping tests passed.
```

## Scope and follow-up

Independent of the CSM (#236) and PCF (#237) P4 items. The Phong path (both the shadowed and non-shadowed variants, the engine's main lit path) now supports normal mapping end to end via real model materials. The point-light cubemap and the PBR showcase path (#234, currently uniform-driven and non-textured) can adopt the same shared core once they gain texture-based materials - that is the "(once available) PBR" part of the issue.

Since GLSL is not compiled in CI and the GL engine cannot run in this environment, the visual result (a normal-mapped surface showing correct detail lighting as the light moves, materials without a normal map unchanged) needs in-engine visual QA. The tangent-space math and the default-preserving wiring are verified here; the shaders mirror the tested core line for line.

## Notes

- CI note: the CodeQL "Analyze (c-cpp)" job builds the engine via cmake + make but does not run the unit tests, and does not compile GLSL. The test above was verified locally.