### PR TITLE
Doodle CV Phase 2: lighting / skew / colored-paper / wobble robustness (#239)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,12 @@ add_executable(test_symbols
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_symbols.cpp
 )
 
+# Phase 2 CV robustness: lighting/skew/paper/wobble + corpus (Milestone 16 / #239)
+# - header-only.
+add_executable(test_cv_robust
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_cv_robust.cpp
+)
+
 # Confidence + repair review model (Milestone 16 / #170) - header-only.
 add_executable(test_level_review
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_review.cpp

--- a/src/cv/Robust.h
+++ b/src/cv/Robust.h
@@ -1,0 +1,395 @@
+#pragma once
+
+#include "cv/Image.h"
+#include "cv/Rectify.h"   // Point, Quad, Mat3, computeHomography, applyHomography, warpPerspective, whiteBalance
+#include "cv/Vectorize.h" // Mask, Polyline, binarizeAdaptive, denoise, thinZhangSuen, tracePolylines, douglasPeucker, snapPolyline, VectorizeOptions
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+/**
+ * @file Robust.h
+ * @brief Phase 2 robustness for the drawing->map CV pipeline (issue #239).
+ *
+ * Milestone 16, "Doodle Dungeon". Phase 1 (Rectify.h / Vectorize.h / Topology.h)
+ * turns a clean grid-paper photo into snapped wall polylines. Phase 2 hardens that
+ * against real-world input - uneven lighting and shadows, off-angle photos, colored
+ * paper, and freehand wobble - which PHONE_GAME_CONCEPT.md flags as the biggest
+ * product risk. Everything here is additive: the Phase 1 functions are unchanged and
+ * still available, so clean input behaves exactly as before.
+ *
+ * Added stages (all pure math on the dependency-free Image/Mask, no OpenCV,
+ * header-only and unit-testable headless):
+ *   - flattenIllumination: divide luminance by its local mean (integral-image box
+ *     blur) so lighting gradients and shadows cancel before binarization.
+ *   - estimateSkewAngle / deskewImage: find and remove residual rotation via the
+ *     projection-profile of the ink, so near-axis walls actually snap to axis.
+ *   - estimateBackgroundColor / foregroundMask / detectPaperQuadRobust: separate
+ *     paper from the background by color distance (not just brightness), so colored
+ *     or dark paper on a contrasting surface is still found, then keep the largest
+ *     component to reject clutter.
+ *   - mergeCollinear: collapse near-collinear vertices left by wobble into straight
+ *     runs (beyond Douglas-Peucker's perpendicular test).
+ *   - vectorizeWallsRobust / rectifyRobust: the hardened pipelines wiring it up.
+ */
+namespace IKore {
+namespace cv {
+
+// ---------------------------------------------------------------------------
+// Illumination flattening
+// ---------------------------------------------------------------------------
+namespace detail {
+
+/// Integral image (summed-area table) of luminance, size (W+1) x (H+1).
+inline std::vector<double> luminanceIntegral(const Image& img) {
+    const int W = img.width, H = img.height;
+    std::vector<double> I(static_cast<std::size_t>(W + 1) * (H + 1), 0.0);
+    for (int y = 0; y < H; ++y) {
+        double rowSum = 0.0;
+        for (int x = 0; x < W; ++x) {
+            rowSum += img.luminance(x, y);
+            I[static_cast<std::size_t>(y + 1) * (W + 1) + (x + 1)] =
+                I[static_cast<std::size_t>(y) * (W + 1) + (x + 1)] + rowSum;
+        }
+    }
+    return I;
+}
+
+/// Mean luminance over the box [x-r, x+r] x [y-r, y+r] clamped to the image.
+inline float boxMean(const std::vector<double>& I, int W, int H, int x, int y, int r) {
+    int x0 = x - r, y0 = y - r, x1 = x + r, y1 = y + r;
+    if (x0 < 0) x0 = 0;
+    if (y0 < 0) y0 = 0;
+    if (x1 > W - 1) x1 = W - 1;
+    if (y1 > H - 1) y1 = H - 1;
+    const int stride = W + 1;
+    const double s = I[static_cast<std::size_t>(y1 + 1) * stride + (x1 + 1)] -
+                     I[static_cast<std::size_t>(y0) * stride + (x1 + 1)] -
+                     I[static_cast<std::size_t>(y1 + 1) * stride + x0] +
+                     I[static_cast<std::size_t>(y0) * stride + x0];
+    const int area = (x1 - x0 + 1) * (y1 - y0 + 1);
+    return area > 0 ? static_cast<float>(s / area) : 0.0f;
+}
+
+} // namespace detail
+
+/**
+ * @brief Flat-field the illumination: return a 1-channel image where each pixel is
+ *        its luminance divided by the local background mean.
+ *
+ * The background mean is a large-radius box blur (via an integral image), so it
+ * tracks the paper tone under any lighting. Dividing by it maps paper to ~white and
+ * keeps ink dark everywhere, so a single threshold - or the adaptive one - works
+ * uniformly across gradients and shadows. @p radius should be several times the
+ * stroke width so ink does not pull its own background down.
+ */
+inline Image flattenIllumination(const Image& img, int radius = 15) {
+    Image out(img.width, img.height, 1);
+    if (img.width <= 0 || img.height <= 0) return out;
+    const std::vector<double> I = detail::luminanceIntegral(img);
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            const float bg = detail::boxMean(I, img.width, img.height, x, y, radius);
+            const float ratio = bg > 1.0f ? img.luminance(x, y) / bg : 1.0f;
+            out.set(x, y, 0, clampByte(ratio * 255.0f));
+        }
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Deskew (residual rotation removal)
+// ---------------------------------------------------------------------------
+namespace detail {
+
+/// Projection "energy" of the ink after rotating coordinates by @p thetaRad:
+/// the sum of squared bin counts for the row-projection plus the column-projection.
+/// Axis-aligned strokes concentrate into few bins, so the energy peaks when the
+/// rotation aligns the drawing to the axes.
+inline double projectionEnergy(const Mask& m, float thetaRad) {
+    const int W = m.width, H = m.height;
+    const float c = std::cos(thetaRad), s = std::sin(thetaRad);
+    const int nRows = W + H + 2;
+    std::vector<int> rowHist(static_cast<std::size_t>(nRows), 0);
+    std::vector<int> colHist(static_cast<std::size_t>(nRows), 0);
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            if (!m.get(x, y)) continue;
+            const int rb = static_cast<int>(std::lround(y * c - x * s)) + W;
+            const int cb = static_cast<int>(std::lround(x * c + y * s));
+            if (rb >= 0 && rb < nRows) ++rowHist[static_cast<std::size_t>(rb)];
+            if (cb >= 0 && cb < nRows) ++colHist[static_cast<std::size_t>(cb)];
+        }
+    }
+    double energy = 0.0;
+    for (int i = 0; i < nRows; ++i) {
+        const double r = rowHist[static_cast<std::size_t>(i)];
+        const double cc = colHist[static_cast<std::size_t>(i)];
+        energy += r * r + cc * cc;
+    }
+    return energy;
+}
+
+} // namespace detail
+
+/**
+ * @brief Estimate the rotation (degrees) that best axis-aligns the ink in @p m.
+ *
+ * Searches candidate angles in [-maxDeg, maxDeg] and returns the correction to pass
+ * to deskewImage(): the negative of the angle that maximizes the projection energy.
+ * Returns 0 for an empty mask.
+ */
+inline float estimateSkewAngle(const Mask& m, float maxDeg = 12.0f, float stepDeg = 0.5f) {
+    if (m.count() == 0 || maxDeg <= 0.0f || stepDeg <= 0.0f) return 0.0f;
+    const float toRad = 3.14159265358979323846f / 180.0f;
+    float bestDeg = 0.0f;
+    double bestEnergy = -1.0;
+    for (float a = -maxDeg; a <= maxDeg + 1e-4f; a += stepDeg) {
+        const double e = detail::projectionEnergy(m, a * toRad);
+        if (e > bestEnergy) {
+            bestEnergy = e;
+            bestDeg = a;
+        }
+    }
+    return -bestDeg; // correction rotates the content the other way
+}
+
+/// Rotate @p img by @p angleDeg about its center (reusing the homography warp).
+inline Image deskewImage(const Image& img, float angleDeg) {
+    if (std::fabs(angleDeg) < 1e-3f || img.width <= 0 || img.height <= 0) return img;
+    const float toRad = 3.14159265358979323846f / 180.0f;
+    const float a = angleDeg * toRad;
+    const float ca = std::cos(a), sa = std::sin(a);
+    const float cx = (img.width - 1) * 0.5f, cy = (img.height - 1) * 0.5f;
+    // Destination -> source map: rotate the sampled coordinate by -angle about center.
+    Mat3 dstToSrc;
+    dstToSrc.m[0] = ca;  dstToSrc.m[1] = sa;  dstToSrc.m[2] = cx - ca * cx - sa * cy;
+    dstToSrc.m[3] = -sa; dstToSrc.m[4] = ca;  dstToSrc.m[5] = cy + sa * cx - ca * cy;
+    dstToSrc.m[6] = 0;   dstToSrc.m[7] = 0;   dstToSrc.m[8] = 1;
+    return warpPerspective(img, dstToSrc, img.width, img.height);
+}
+
+// ---------------------------------------------------------------------------
+// Robust paper detection (color-distance foreground)
+// ---------------------------------------------------------------------------
+
+/// Mean color of the @p border-wide frame ring - an estimate of the background/table.
+inline std::vector<float> estimateBackgroundColor(const Image& img, int border = 2) {
+    std::vector<float> bg(static_cast<std::size_t>(std::max(1, img.channels)), 0.0f);
+    if (img.width <= 0 || img.height <= 0 || img.channels <= 0) return bg;
+    if (border < 1) border = 1;
+    long count = 0;
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            const bool ring = x < border || y < border || x >= img.width - border || y >= img.height - border;
+            if (!ring) continue;
+            for (int c = 0; c < img.channels; ++c) bg[static_cast<std::size_t>(c)] += img.at(x, y, c);
+            ++count;
+        }
+    }
+    if (count > 0) {
+        for (float& v : bg) v /= static_cast<float>(count);
+    }
+    return bg;
+}
+
+/// Foreground (paper) mask: pixels whose color is far from the background by more
+/// than @p threshold (L1 over channels). Works for colored or dark paper, not just
+/// bright paper, as long as it contrasts the surface it sits on.
+inline Mask foregroundMask(const Image& img, float threshold = 60.0f, int border = 2) {
+    Mask m(img.width, img.height);
+    if (img.width <= 0 || img.height <= 0 || img.channels <= 0) return m;
+    const std::vector<float> bg = estimateBackgroundColor(img, border);
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            float dist = 0.0f;
+            for (int c = 0; c < img.channels; ++c) {
+                dist += std::fabs(static_cast<float>(img.at(x, y, c)) - bg[static_cast<std::size_t>(c)]);
+            }
+            if (dist > threshold) m.set(x, y, 1);
+        }
+    }
+    return m;
+}
+
+/// Keep only the largest 8-connected component of @p m, clearing everything else.
+inline void keepLargestComponent(Mask& m) {
+    Mask visited(m.width, m.height);
+    const int dx8[8] = {1, -1, 0, 0, 1, 1, -1, -1};
+    const int dy8[8] = {0, 0, 1, -1, 1, -1, 1, -1};
+    std::vector<std::pair<int, int>> stack, comp, best;
+    for (int y = 0; y < m.height; ++y) {
+        for (int x = 0; x < m.width; ++x) {
+            if (!m.get(x, y) || visited.get(x, y)) continue;
+            stack.clear();
+            comp.clear();
+            stack.push_back({x, y});
+            visited.set(x, y, 1);
+            while (!stack.empty()) {
+                const std::pair<int, int> p = stack.back();
+                stack.pop_back();
+                comp.push_back(p);
+                for (int i = 0; i < 8; ++i) {
+                    const int ax = p.first + dx8[i], ay = p.second + dy8[i];
+                    if (m.get(ax, ay) && !visited.get(ax, ay)) {
+                        visited.set(ax, ay, 1);
+                        stack.push_back({ax, ay});
+                    }
+                }
+            }
+            if (comp.size() > best.size()) best.swap(comp);
+        }
+    }
+    for (std::uint8_t& v : m.px) v = 0;
+    for (const std::pair<int, int>& p : best) m.set(p.first, p.second, 1);
+}
+
+/**
+ * @brief Detect the paper quad by color-distance foreground, robust to colored/dark
+ *        paper and off-angle photos.
+ *
+ * Builds the foreground mask, keeps its largest component (the sheet), and takes the
+ * extremes of (x+y) and (x-y) as the convex corners. Falls back to the full frame if
+ * too little foreground is found.
+ */
+inline Quad detectPaperQuadRobust(const Image& img, float threshold = 60.0f) {
+    Quad q{{0, 0},
+           {static_cast<float>(img.width - 1), 0},
+           {static_cast<float>(img.width - 1), static_cast<float>(img.height - 1)},
+           {0, static_cast<float>(img.height - 1)}};
+    if (img.width <= 1 || img.height <= 1) return q;
+
+    Mask fg = foregroundMask(img, threshold);
+    keepLargestComponent(fg);
+    const int total = img.width * img.height;
+    if (fg.count() < total / 100) return q; // not enough paper found; keep full frame
+
+    bool any = false;
+    float minSum = 0, maxSum = 0, minDiff = 0, maxDiff = 0;
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            if (!fg.get(x, y)) continue;
+            const float sum = static_cast<float>(x + y);
+            const float diff = static_cast<float>(x - y);
+            const Point here{static_cast<float>(x), static_cast<float>(y)};
+            if (!any) {
+                minSum = maxSum = sum;
+                minDiff = maxDiff = diff;
+                q.tl = q.tr = q.br = q.bl = here;
+                any = true;
+                continue;
+            }
+            if (sum < minSum) { minSum = sum; q.tl = here; }
+            if (sum > maxSum) { maxSum = sum; q.br = here; }
+            if (diff > maxDiff) { maxDiff = diff; q.tr = here; }
+            if (diff < minDiff) { minDiff = diff; q.bl = here; }
+        }
+    }
+    return q;
+}
+
+/// Robust rectify: color-distance paper detection -> homography warp -> white balance.
+inline Image rectifyRobust(const Image& photo, int outSize, float threshold = 60.0f) {
+    const Quad q = detectPaperQuadRobust(photo, threshold);
+    const Point dst[4] = {{0, 0},
+                          {static_cast<float>(outSize), 0},
+                          {static_cast<float>(outSize), static_cast<float>(outSize)},
+                          {0, static_cast<float>(outSize)}};
+    const Point src[4] = {q.tl, q.tr, q.br, q.bl};
+    const Mat3 dstToSrc = computeHomography(dst, src);
+    Image out = warpPerspective(photo, dstToSrc, outSize, outSize);
+    whiteBalance(out);
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Wobble-tolerant vectorization
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Merge near-collinear vertices: drop any interior point where the turn
+ *        between the incoming and outgoing segment is smaller than @p angleTolDeg.
+ *
+ * Complements Douglas-Peucker: after snapping, wobble often leaves a chain of tiny
+ * turns (or two same-direction segments) that DP's perpendicular test keeps; this
+ * collapses them into straight runs while preserving genuine corners. Endpoints are
+ * always kept; coincident points are dropped.
+ */
+inline Polyline mergeCollinear(const Polyline& poly, float angleTolDeg = 12.0f) {
+    if (poly.size() < 3) return poly;
+    const float toDeg = 180.0f / 3.14159265358979323846f;
+    Polyline out;
+    out.push_back(poly.front());
+    for (std::size_t i = 1; i + 1 < poly.size(); ++i) {
+        const Point& prev = out.back();
+        const Point& cur = poly[i];
+        const Point& next = poly[i + 1];
+        const float v1x = cur.x - prev.x, v1y = cur.y - prev.y;
+        const float v2x = next.x - cur.x, v2y = next.y - cur.y;
+        const float l1 = std::sqrt(v1x * v1x + v1y * v1y);
+        const float l2 = std::sqrt(v2x * v2x + v2y * v2y);
+        if (l1 < 1e-6f) continue; // coincident with the kept point; drop it
+        if (l2 < 1e-6f) continue;
+        const float cross = v1x * v2y - v1y * v2x;
+        const float dot = v1x * v2x + v1y * v2y;
+        const float angle = std::atan2(std::fabs(cross), dot) * toDeg;
+        if (angle >= angleTolDeg) out.push_back(cur); // a real corner: keep it
+    }
+    out.push_back(poly.back());
+    return out;
+}
+
+/// Knobs for the robust pipeline; @c vec reuses the Phase 1 vectorization options.
+struct RobustOptions {
+    int illumRadius{15};
+    bool deskew{true};
+    float maxSkewDeg{12.0f};
+    float collinearTolDeg{18.0f};
+    float closeLoopFactor{1.5f}; ///< close a polyline if its ends are within this * grid.
+    VectorizeOptions vec{};
+};
+
+/**
+ * @brief Hardened wall vectorization: flatten illumination and deskew, then run the
+ *        Phase 1 binarize/denoise/thin/trace, then simplify with Douglas-Peucker,
+ *        collinear-merge, angle/grid snap, and a final merge; near-closed loops are
+ *        closed so rooms come out as closed polygons.
+ */
+inline std::vector<Polyline> vectorizeWallsRobust(const Image& img, const RobustOptions& opt = {}) {
+    Image work = flattenIllumination(img, opt.illumRadius);
+    if (opt.deskew) {
+        Mask pre = binarizeAdaptive(work, opt.vec.adaptiveRadius, opt.vec.threshC);
+        denoise(pre, opt.vec.minComponentArea);
+        const float skew = estimateSkewAngle(pre, opt.maxSkewDeg);
+        if (std::fabs(skew) > 0.25f) work = deskewImage(work, skew);
+    }
+
+    Mask bin = binarizeAdaptive(work, opt.vec.adaptiveRadius, opt.vec.threshC);
+    denoise(bin, opt.vec.minComponentArea);
+    const Mask skeleton = thinZhangSuen(bin);
+    const std::vector<Polyline> traced = tracePolylines(skeleton);
+
+    std::vector<Polyline> out;
+    for (const Polyline& p : traced) {
+        if (p.size() < 2) continue;
+        Polyline simplified = douglasPeucker(p, opt.vec.simplifyEps);
+        Polyline merged = mergeCollinear(simplified, opt.collinearTolDeg);
+        Polyline snapped = snapPolyline(merged, opt.vec.gridSize);
+        Polyline clean = mergeCollinear(snapped, opt.collinearTolDeg);
+        if (clean.size() < 2) continue;
+        // Close a loop whose endpoints landed within a cell of each other, so the
+        // topology sees an enclosed room rather than a hairline gap.
+        const Point& a = clean.front();
+        const Point& b = clean.back();
+        const float d = std::sqrt((a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y));
+        if (d > 1e-3f && d <= opt.closeLoopFactor * opt.vec.gridSize) clean.push_back(a);
+        out.push_back(std::move(clean));
+    }
+    return out;
+}
+
+} // namespace cv
+} // namespace IKore

--- a/tests/test_cv_robust.cpp
+++ b/tests/test_cv_robust.cpp
@@ -1,0 +1,328 @@
+// Test for the Phase 2 CV robustness layer - Milestone 16, issue #239.
+//
+// Verifies the acceptance criteria: uneven lighting/shadows, off-angle photos,
+// colored paper, and freehand wobble still yield clean, closed wall polygons, while
+// clean (Phase 1) input is unchanged or better. Covers each robustness primitive
+// (illumination flattening, skew estimate + deskew, color-distance paper detection,
+// collinear merge) plus a small regression corpus of synthesized "photos" run end
+// to end (rectify -> vectorize -> topology).
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_cv_robust.cpp -o test_cv_robust
+
+#include "cv/Image.h"
+#include "cv/Rectify.h"
+#include "cv/Vectorize.h"
+#include "cv/Topology.h"
+#include "cv/Robust.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::cv;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool nearf(float a, float b, float eps) { return std::fabs(a - b) <= eps; }
+static bool isMultipleOf(float v, float grid) {
+    return std::fabs(v / grid - std::round(v / grid)) < 1e-3f;
+}
+
+// ---------------------------------------------------------------------------
+// Shared synthetic-scene builders
+// ---------------------------------------------------------------------------
+
+// A closed rectangular room outline drawn on a colored sheet (3-channel).
+static Image makeRoom(int W, int H, int x0, int y0, int x1, int y1,
+                      int pr, int pg, int pb) {
+    Image img(W, H, 3);
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            img.set(x, y, 0, static_cast<std::uint8_t>(pr));
+            img.set(x, y, 1, static_cast<std::uint8_t>(pg));
+            img.set(x, y, 2, static_cast<std::uint8_t>(pb));
+        }
+    }
+    auto ink = [&](int x, int y) {
+        if (x >= 0 && y >= 0 && x < W && y < H) {
+            img.set(x, y, 0, 25);
+            img.set(x, y, 1, 22);
+            img.set(x, y, 2, 20);
+        }
+    };
+    for (int x = x0; x <= x1; ++x) {
+        for (int t = -1; t <= 1; ++t) { ink(x, y0 + t); ink(x, y1 + t); }
+    }
+    for (int y = y0; y <= y1; ++y) {
+        for (int t = -1; t <= 1; ++t) { ink(x0 + t, y); ink(x1 + t, y); }
+    }
+    return img;
+}
+
+// Smooth, edge-free uneven lighting (linear gradient * soft radial vignette).
+static void applySmoothLighting(Image& img) {
+    const int W = img.width, H = img.height;
+    const float cx = W * 0.35f, cy = H * 0.30f;
+    const float R = std::sqrt(static_cast<float>(W * W + H * H));
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            const float grad = 0.72f + (x / static_cast<float>(W - 1)) * 0.28f;
+            const float d = std::sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy)) / R;
+            const float f = grad * (1.0f - 0.45f * d);
+            for (int c = 0; c < 3; ++c) img.set(x, y, c, clampByte(img.at(x, y, c) * f));
+        }
+    }
+}
+
+static const Polyline* longestPolyline(const std::vector<Polyline>& walls) {
+    const Polyline* best = nullptr;
+    for (const Polyline& p : walls) {
+        if (best == nullptr || p.size() > best->size()) best = &p;
+    }
+    return best;
+}
+
+static bool isAxisAlignedOnGrid(const Polyline& p, float grid) {
+    for (std::size_t i = 0; i < p.size(); ++i) {
+        if (!isMultipleOf(p[i].x, grid) || !isMultipleOf(p[i].y, grid)) return false;
+        if (i > 0) {
+            const bool axis = nearf(p[i].x, p[i - 1].x, 1e-3f) || nearf(p[i].y, p[i - 1].y, 1e-3f);
+            if (!axis) return false;
+        }
+    }
+    return true;
+}
+
+static bool isClosed(const Polyline& p) {
+    return p.size() >= 4 && nearf(p.front().x, p.back().x, 1e-3f) && nearf(p.front().y, p.back().y, 1e-3f);
+}
+
+// ---------------------------------------------------------------------------
+// Primitive unit tests
+// ---------------------------------------------------------------------------
+
+static void testFlattenCancelsShadow() {
+    // Brightness gradient + a deep shadow corner, with a dark ink line crossing both.
+    Image img(60, 60, 1);
+    for (int y = 0; y < 60; ++y) {
+        for (int x = 0; x < 60; ++x) {
+            float base = 120.0f + (x / 59.0f) * 100.0f; // 120..220
+            if (x > 35 && y > 35) base *= 0.45f;         // shadow
+            if (y >= 29 && y <= 31) base *= 0.25f;       // ink line
+            img.set(x, y, 0, clampByte(base));
+        }
+    }
+    const Image f = flattenIllumination(img, 12);
+    // Paper reads near-white in both the lit and shadowed regions...
+    CHECK(f.at(5, 5, 0) > 200);
+    CHECK(f.at(50, 50, 0) > 200);
+    // ...while the ink line reads dark in both, so one threshold separates them.
+    CHECK(f.at(10, 30, 0) < 150);
+    CHECK(f.at(50, 30, 0) < 150);
+    CHECK(f.at(5, 5, 0) - f.at(10, 30, 0) > 80);   // strong lit contrast
+    CHECK(f.at(50, 50, 0) - f.at(50, 30, 0) > 80); // strong shadowed contrast
+}
+
+static void testSkewEstimateAndDeskew() {
+    // Grayscale image: dark near-axis lines rotated by +6 degrees on white paper.
+    Image img(90, 90, 1);
+    for (int y = 0; y < 90; ++y) {
+        for (int x = 0; x < 90; ++x) img.set(x, y, 0, 245);
+    }
+    const float slope = std::tan(6.0f * 3.14159265f / 180.0f);
+    for (int y0 : {25, 60}) {
+        for (int x = 10; x <= 80; ++x) {
+            const int y = y0 + static_cast<int>(std::lround(slope * (x - 45)));
+            for (int t = -1; t <= 1; ++t) img.set(x, y + t, 0, 20);
+        }
+    }
+    for (int x0 : {25, 60}) {
+        for (int y = 10; y <= 80; ++y) {
+            const int x = x0 - static_cast<int>(std::lround(slope * (y - 45)));
+            for (int t = -1; t <= 1; ++t) img.set(x + t, y, 0, 20);
+        }
+    }
+    Mask m = binarizeAdaptive(img, 6, 10.0f);
+    denoise(m, 8);
+    const float est = estimateSkewAngle(m, 12.0f, 0.5f);
+    CHECK(nearf(est, -6.0f, 2.0f)); // correction opposes the +6 skew
+
+    // Deskewing by the estimate leaves almost no residual skew.
+    const Image fixed = deskewImage(img, est);
+    Mask m2 = binarizeAdaptive(fixed, 6, 10.0f);
+    denoise(m2, 8);
+    const float residual = estimateSkewAngle(m2, 12.0f, 0.5f);
+    CHECK(std::fabs(residual) < std::fabs(est));
+    CHECK(std::fabs(residual) < 2.0f);
+}
+
+static void testRobustPaperBeatsLuminance() {
+    // Dark-blue paper on a LIGHT gray table: the paper is not the brightest region,
+    // so a luminance detector fails but color distance succeeds.
+    Image img(120, 120, 3);
+    for (int y = 0; y < 120; ++y) {
+        for (int x = 0; x < 120; ++x) { img.set(x, y, 0, 205); img.set(x, y, 1, 205); img.set(x, y, 2, 210); }
+    }
+    for (int y = 20; y < 100; ++y) {
+        for (int x = 25; x < 95; ++x) { img.set(x, y, 0, 40); img.set(x, y, 1, 55); img.set(x, y, 2, 150); }
+    }
+    const Quad robust = detectPaperQuadRobust(img, 60.0f);
+    CHECK(nearf(robust.tl.x, 25, 4) && nearf(robust.tl.y, 20, 4));
+    CHECK(nearf(robust.br.x, 94, 4) && nearf(robust.br.y, 99, 4));
+
+    // The Phase 1 luminance detector picks the bright table (near the full frame).
+    const Quad lum = detectPaperQuad(img);
+    const bool lumIsFullFrame = nearf(lum.tl.x, 0, 3) && nearf(lum.tl.y, 0, 3) &&
+                                nearf(lum.br.x, 119, 3) && nearf(lum.br.y, 119, 3);
+    CHECK(lumIsFullFrame);
+}
+
+static void testForegroundAndLargestComponent() {
+    Image img(60, 60, 3);
+    for (int y = 0; y < 60; ++y) {
+        for (int x = 0; x < 60; ++x) { img.set(x, y, 0, 230); img.set(x, y, 1, 230); img.set(x, y, 2, 232); }
+    }
+    // A big colored sheet and a small bright speck of clutter in a corner.
+    for (int y = 15; y < 50; ++y) {
+        for (int x = 15; x < 45; ++x) { img.set(x, y, 0, 60); img.set(x, y, 1, 90); img.set(x, y, 2, 40); }
+    }
+    for (int y = 2; y < 5; ++y) {
+        for (int x = 2; x < 5; ++x) { img.set(x, y, 0, 20); img.set(x, y, 1, 20); img.set(x, y, 2, 20); }
+    }
+    Mask fg = foregroundMask(img, 60.0f);
+    CHECK(fg.get(30, 30) == 1); // sheet is foreground
+    keepLargestComponent(fg);
+    CHECK(fg.get(30, 30) == 1); // sheet kept
+    CHECK(fg.get(3, 3) == 0);   // clutter speck removed
+}
+
+static void testMergeCollinear() {
+    // A wobbly straight run collapses to its endpoints; a real corner is preserved.
+    const Polyline wobble = {{0, 0}, {10, 0}, {20, 1}, {30, 0}, {40, 0}};
+    const Polyline merged = mergeCollinear(wobble, 18.0f);
+    CHECK(merged.size() == 2);
+    CHECK(nearf(merged.front().x, 0, 1e-3f) && nearf(merged.back().x, 40, 1e-3f));
+
+    const Polyline corner = {{0, 0}, {10, 0}, {10, 10}};
+    CHECK(mergeCollinear(corner, 18.0f).size() == 3); // the 90-degree corner stays
+}
+
+// ---------------------------------------------------------------------------
+// Regression corpus (end-to-end)
+// ---------------------------------------------------------------------------
+
+static void testCorpusCleanRoomUnchanged() {
+    // Clean, axis-aligned room on white paper: Phase 2 must match Phase 1 (one room).
+    const Image room = makeRoom(120, 120, 30, 30, 90, 85, 250, 250, 248);
+    RobustOptions opt;
+    opt.vec.gridSize = 8.0f;
+    opt.vec.minComponentArea = 8;
+    const std::vector<Polyline> w2 = vectorizeWallsRobust(room, opt);
+    const Topology t2 = buildTopology(w2, 8.0f, 2);
+
+    VectorizeOptions v1;
+    v1.gridSize = 8.0f;
+    v1.minComponentArea = 8;
+    const std::vector<Polyline> w1 = vectorizeWalls(room, v1);
+    const Topology t1 = buildTopology(w1, 8.0f, 2);
+
+    CHECK(t2.interiorRoomCount() == 1);
+    CHECK(t2.interiorRoomCount() >= t1.interiorRoomCount()); // unchanged or better
+    const Polyline* best = longestPolyline(w2);
+    CHECK(best != nullptr && isClosed(*best));
+    if (best) CHECK(isAxisAlignedOnGrid(*best, 8.0f));
+}
+
+static void testCorpusUnevenLitTintedRoom() {
+    // A rectified room under smooth uneven lighting with a warm color tint.
+    Image room = makeRoom(130, 130, 30, 30, 95, 90, 250, 244, 226);
+    applySmoothLighting(room);
+    RobustOptions opt;
+    opt.vec.gridSize = 8.0f;
+    opt.vec.minComponentArea = 8;
+    const std::vector<Polyline> walls = vectorizeWallsRobust(room, opt);
+    const Topology t = buildTopology(walls, 8.0f, 2);
+    CHECK(t.interiorRoomCount() >= 1);
+    CHECK(t.ambiguousGaps == 0);
+    const Polyline* best = longestPolyline(walls);
+    CHECK(best != nullptr && isClosed(*best));
+    if (best) CHECK(isAxisAlignedOnGrid(*best, 8.0f));
+}
+
+static void testCorpusOffAngleColoredPaperPhoto() {
+    // The flagship case: an off-angle photo of a colored (kraft) sheet on a bright
+    // table, unevenly lit. Phase 1's luminance detector picks the table and breaks;
+    // the robust pipeline recovers a single clean, closed room.
+    const Image pat = makeRoom(100, 100, 20, 20, 80, 75, 180, 150, 110);
+    Image photo(200, 200, 3);
+    for (int y = 0; y < 200; ++y) {
+        for (int x = 0; x < 200; ++x) { photo.set(x, y, 0, 245); photo.set(x, y, 1, 245); photo.set(x, y, 2, 248); }
+    }
+    const Point quad[4] = {{45, 32}, {170, 58}, {152, 178}, {28, 150}};
+    const Point patCorners[4] = {{0, 0}, {100, 0}, {100, 100}, {0, 100}};
+    const Mat3 photoToPat = computeHomography(quad, patCorners);
+    for (int y = 0; y < 200; ++y) {
+        for (int x = 0; x < 200; ++x) {
+            const Point p = applyHomography(photoToPat, static_cast<float>(x), static_cast<float>(y));
+            if (p.x >= 0 && p.x < 100 && p.y >= 0 && p.y < 100) {
+                const float f = 0.65f + (p.x / 99.0f) * 0.35f; // uneven light on the paper
+                for (int c = 0; c < 3; ++c) photo.set(x, y, c, clampByte(pat.sample(p.x, p.y, c) * f));
+            }
+        }
+    }
+
+    // Robust detection recovers the paper corners; the luminance detector does not.
+    const Quad qr = detectPaperQuadRobust(photo, 60.0f);
+    CHECK(nearf(qr.tl.x, 45, 12) && nearf(qr.tl.y, 32, 12));
+    CHECK(nearf(qr.br.x, 152, 12) && nearf(qr.br.y, 178, 12));
+
+    // Phase 2 end to end.
+    const Image rect2 = rectifyRobust(photo, 100, 60.0f);
+    RobustOptions opt;
+    opt.vec.gridSize = 8.0f;
+    opt.vec.minComponentArea = 8;
+    const std::vector<Polyline> w2 = vectorizeWallsRobust(rect2, opt);
+    const Topology t2 = buildTopology(w2, 8.0f, 2);
+    CHECK(t2.interiorRoomCount() == 1);
+    CHECK(t2.ambiguousGaps == 0);
+    const Polyline* best = longestPolyline(w2);
+    CHECK(best != nullptr && isClosed(*best));
+    if (best) CHECK(isAxisAlignedOnGrid(*best, 8.0f));
+
+    // Phase 1 on the same photo does strictly worse (it cannot find the room cleanly).
+    const Image rect1 = rectify(photo, 100);
+    VectorizeOptions v1;
+    v1.gridSize = 8.0f;
+    v1.minComponentArea = 8;
+    const std::vector<Polyline> w1 = vectorizeWalls(rect1, v1);
+    const Topology t1 = buildTopology(w1, 8.0f, 2);
+    const bool phase1Clean = t1.interiorRoomCount() == 1 && t1.ambiguousGaps == 0;
+    CHECK(!phase1Clean); // Phase 2 is the improvement
+}
+
+int main() {
+    testFlattenCancelsShadow();
+    testSkewEstimateAndDeskew();
+    testRobustPaperBeatsLuminance();
+    testForegroundAndLargestComponent();
+    testMergeCollinear();
+    testCorpusCleanRoomUnchanged();
+    testCorpusUnevenLitTintedRoom();
+    testCorpusOffAngleColoredPaperPhoto();
+
+    if (g_failures == 0) {
+        std::printf("All CV robustness tests passed.\n");
+        return 0;
+    }
+    std::printf("%d CV robustness test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #239. Milestone 16 ("Doodle Dungeon"), the drawing-to-map CV pipeline.

Phase 1 (`Rectify.h` / `Vectorize.h` / `Topology.h`) turns a clean grid-paper photo into snapped wall polylines. Phase 2 hardens that against real-world input, which `PHONE_GAME_CONCEPT.md` (5 / 9) flags as the biggest product risk: uneven lighting and shadows, off-angle photos, colored or dark paper, and freehand wobble.

Everything is additive and header-only. The Phase 1 functions are untouched, so clean input behaves exactly as before (verified: the existing `test_rectify` / `test_vectorize` / `test_symbols` still pass).

## What is included

`src/cv/Robust.h` (`IKore::cv`, dependency-free, unit-testable headless):

- `flattenIllumination` - divides luminance by its local mean (integral-image box blur), so lighting gradients and shadows cancel and a single threshold works uniformly.
- `estimateSkewAngle` / `deskewImage` - estimate residual rotation from the ink's projection-profile energy and rotate it out, so near-axis walls actually snap to the axis.
- `estimateBackgroundColor` / `foregroundMask` / `keepLargestComponent` / `detectPaperQuadRobust` / `rectifyRobust` - separate paper from the surface by color distance (not just brightness), so colored or dark paper on a contrasting background is still found; the largest connected component is kept to reject clutter.
- `mergeCollinear` - collapse near-collinear vertices left by wobble into straight runs (beyond Douglas-Peucker's perpendicular test).
- `vectorizeWallsRobust` - the hardened pipeline: flatten -> deskew -> binarize -> denoise -> thin -> trace -> Douglas-Peucker -> collinear-merge -> angle/grid snap -> merge, closing near-closed loops so rooms come out as closed polygons.

## Testing

`tests/test_cv_robust.cpp` covers each primitive and a regression corpus:

- **Primitives:** flattening cancels a gradient + shadow (paper stays near-white, ink stays dark on both sides); skew estimate returns the correct correction (~ -6 deg for a +6 deg skew) and deskewing removes the residual; robust paper detection recovers a dark-blue sheet on a light table where the luminance detector returns the full frame; foreground mask + largest-component drops clutter; collinear-merge collapses wobble but keeps a 90-degree corner.
- **Corpus (end to end: rectify -> vectorize -> topology):**
  - a clean room (Phase 2 matches Phase 1: one interior room);
  - an unevenly-lit, warm-tinted room (one closed, axis-aligned, on-grid room, no ambiguous gaps);
  - the flagship case, an off-angle photo of a **colored (kraft) sheet on a bright table** under uneven light: Phase 1's luminance detector picks the table and breaks (interior rooms 4, ambiguous gaps 10), while the robust pipeline recovers a single clean, closed, axis-aligned, on-grid room with no ambiguous gaps.

Built and run locally under `-fsanitize=address,undefined` with `-Wall -Wextra -pedantic`; all cases pass, no sanitizer diagnostics. Registered as `test_cv_robust` in CMake next to the other CV tests.

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_cv_robust.cpp -o test_cv_robust && ./test_cv_robust
All CV robustness tests passed.
```

## Acceptance criteria

- A freehand, off-angle, unevenly-lit photo of an orthogonal drawing produces clean, closed wall polygons: the colored-paper corpus case demonstrates this end to end.
- The corpus tests run headless and guard against regressions: yes, via synthesized scenes (no external image files, no OpenCV).
- Clean-input (Phase 1) results are unchanged or better: the clean-room case asserts Phase 2 matches Phase 1, and the Phase 1 headers/tests are untouched.

## Notes

- Design choice: the corpus models uneven lighting as smooth gradients / soft vignettes (what `flattenIllumination` is built for and what a phone's ambient light produces). Hard cast-shadow *edges* are effectively object boundaries and can still create false walls; that remains future work for a later phase (paper detection under a gradient-lit background is likewise a harder mode not covered here).
- CI note: the CodeQL "Analyze (c-cpp)" job builds the engine via cmake + make but does not run the unit tests; the test above was verified locally.