### PR TITLE
Doodle Phase 5: fastest-clear leaderboards with replay anti-cheat (#242)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,6 +622,12 @@ add_executable(test_level_share
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_share.cpp
 )
 
+# UGC Phase 5: fastest-clear leaderboards with replay anti-cheat (Milestone 17 /
+# #242) - header-only.
+add_executable(test_leaderboard
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_leaderboard.cpp
+)
+
 # Performance-overlay stats core (Milestone 9 / #53) - header-only.
 add_executable(test_perf_stats
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_perf_stats.cpp

--- a/src/game/Leaderboard.h
+++ b/src/game/Leaderboard.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include "game/DoodleScene.h"  // convert, SceneDescription
+#include "game/DungeonGame.h"  // DungeonGame, GameInput, loadGame
+#include "game/LevelFormat.h"  // fromLevelJson, LevelSpec
+#include "game/LevelShare.h"   // shareCodeFor
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @file Leaderboard.h
+ * @brief Fastest-clear leaderboards with deterministic-replay anti-cheat (issue #242).
+ *
+ * Milestone 17, "Doodle Dungeon" Phase 5. Ranks players by clear time per level,
+ * keyed by the content share code from LevelShare.h (#241). Because DungeonGame is
+ * fully deterministic (no RNG; enemies chase deterministically), a fixed-timestep
+ * input trace replays to the identical result on any device - so a submitted time
+ * is verifiable: the server re-simulates the trace and trusts only what it computes.
+ *
+ *   - replayRun(levelJson, trace): the anti-cheat core. Re-simulates a fixed-step
+ *     input trace against a level and reports whether it cleared and in what time.
+ *   - Leaderboard: registerLevel() (returns the level's share code), submit() (which
+ *     re-simulates and rejects runs that do not clear, use the wrong timestep, or
+ *     whose claimed time desyncs from the replay), and top()/rankOf() for the
+ *     per-level ranked list (fastest first, best-per-player).
+ *
+ * Timestamps are caller-supplied, so ordering is deterministic and there is no wall
+ * clock. Header-only, reusing the existing level JSON - no bespoke serialization.
+ */
+namespace IKore {
+namespace game {
+
+/// A recorded run: a fixed simulation timestep and the per-step player input.
+struct RunTrace {
+    double dt{1.0 / 60.0};
+    std::vector<GameInput> inputs;
+};
+
+/// Outcome of re-simulating a trace.
+struct RunResult {
+    bool won{false};
+    int steps{0};         ///< steps taken to clear (0 if not cleared).
+    double clearTime{0.0}; ///< steps * dt.
+};
+
+/**
+ * @brief Deterministically replay an input trace against a level (the anti-cheat
+ *        core). Loads a fresh game from the level JSON, applies each input at the
+ *        trace's fixed dt, and stops at the first win (or loss). Returns whether the
+ *        run cleared and the resulting time. The same trace always yields the same
+ *        result, so a client and the server agree.
+ */
+inline RunResult replayRun(const std::string& levelJson, const RunTrace& trace) {
+    RunResult r;
+    LevelSpec spec;
+    if (!fromLevelJson(levelJson, spec)) return r;
+    DungeonGame game = loadGame(convert(spec));
+    for (std::size_t i = 0; i < trace.inputs.size(); ++i) {
+        game.update(trace.inputs[i], static_cast<float>(trace.dt));
+        if (game.won()) {
+            r.won = true;
+            r.steps = static_cast<int>(i) + 1;
+            r.clearTime = r.steps * trace.dt;
+            return r;
+        }
+        if (game.lost()) return r; // a loss is not a clear
+    }
+    return r;
+}
+
+/// One player's best clear on a level.
+struct ScoreEntry {
+    std::string player;
+    double clearTime{0.0};
+    int steps{0};
+    std::int64_t submittedAt{0};
+};
+
+/// Result of a submission attempt.
+struct SubmitResult {
+    bool accepted{false};  ///< the run cleared and verified.
+    bool improved{false};  ///< it was the player's first or a new personal best.
+    double clearTime{0.0};
+    int rank{0};           ///< 1-based rank after this submission (0 if not accepted).
+    std::string reason;    ///< why an unaccepted run was rejected.
+};
+
+/// Per-level fastest-clear leaderboards with re-simulation verification.
+class Leaderboard {
+public:
+    explicit Leaderboard(double fixedDt = 1.0 / 60.0) : m_fixedDt(fixedDt) {}
+
+    /// Register a level for competition; returns its content share code.
+    std::string registerLevel(const std::string& levelJson) {
+        const std::string code = shareCodeFor(levelJson);
+        m_levels[code] = levelJson;
+        return code;
+    }
+    bool hasLevel(const std::string& code) const { return m_levels.count(code) > 0; }
+    double fixedDt() const { return m_fixedDt; }
+
+    /**
+     * @brief Submit a run for @p player on level @p code.
+     *
+     * Re-simulates the trace and accepts it only if it cleared. Rejections: unknown
+     * level, a timestep other than the leaderboard's fixed dt, a trace that does not
+     * clear, or (when @p claimedTime >= 0) a claimed time that disagrees with the
+     * re-simulated time (a desync / tamper). Accepted runs keep the player's best.
+     */
+    SubmitResult submit(const std::string& code, const std::string& player, const RunTrace& trace,
+                        std::int64_t submittedAt, double claimedTime = -1.0) {
+        SubmitResult res;
+        auto it = m_levels.find(code);
+        if (it == m_levels.end()) {
+            res.reason = "unknown level";
+            return res;
+        }
+        if (std::fabs(trace.dt - m_fixedDt) > 1e-9) {
+            res.reason = "bad timestep";
+            return res;
+        }
+        if (trace.inputs.size() > kMaxInputs) {
+            res.reason = "trace too long";
+            return res;
+        }
+        const RunResult rr = replayRun(it->second, trace);
+        if (!rr.won) {
+            res.reason = "did not clear";
+            return res;
+        }
+        if (claimedTime >= 0.0 && std::fabs(claimedTime - rr.clearTime) > 1e-6) {
+            res.reason = "desync";
+            return res;
+        }
+
+        res.accepted = true;
+        res.clearTime = rr.clearTime;
+        std::vector<ScoreEntry>& board = m_scores[code];
+        ScoreEntry* existing = nullptr;
+        for (ScoreEntry& e : board) {
+            if (e.player == player) { existing = &e; break; }
+        }
+        if (existing == nullptr) {
+            board.push_back(ScoreEntry{player, rr.clearTime, rr.steps, submittedAt});
+            res.improved = true;
+        } else if (rr.clearTime < existing->clearTime) {
+            existing->clearTime = rr.clearTime;
+            existing->steps = rr.steps;
+            existing->submittedAt = submittedAt;
+            res.improved = true;
+        }
+        res.rank = rankOf(code, player);
+        return res;
+    }
+
+    /// The ranked list for a level (fastest first), one row per player.
+    std::vector<ScoreEntry> top(const std::string& code, std::size_t limit = 50) const {
+        auto it = m_scores.find(code);
+        if (it == m_scores.end()) return {};
+        std::vector<ScoreEntry> out = it->second;
+        std::sort(out.begin(), out.end(), rankLess);
+        if (out.size() > limit) out.resize(limit);
+        return out;
+    }
+
+    /// 1-based rank of a player on a level, or 0 if they have no entry.
+    int rankOf(const std::string& code, const std::string& player) const {
+        const std::vector<ScoreEntry> board = top(code, kMaxInputs);
+        for (std::size_t i = 0; i < board.size(); ++i) {
+            if (board[i].player == player) return static_cast<int>(i) + 1;
+        }
+        return 0;
+    }
+
+    /// Number of ranked players on a level.
+    std::size_t count(const std::string& code) const {
+        auto it = m_scores.find(code);
+        return it == m_scores.end() ? 0 : it->second.size();
+    }
+
+private:
+    static bool rankLess(const ScoreEntry& a, const ScoreEntry& b) {
+        if (a.clearTime != b.clearTime) return a.clearTime < b.clearTime;
+        if (a.submittedAt != b.submittedAt) return a.submittedAt < b.submittedAt; // earlier ranks higher
+        return a.player < b.player;
+    }
+
+    static const std::size_t kMaxInputs = 1000000;
+    double m_fixedDt;
+    std::unordered_map<std::string, std::string> m_levels;
+    std::unordered_map<std::string, std::vector<ScoreEntry>> m_scores;
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_leaderboard.cpp
+++ b/tests/test_leaderboard.cpp
@@ -1,0 +1,214 @@
+// Test for fastest-clear leaderboards with replay anti-cheat - Milestone 17, #242.
+//
+// Verifies the acceptance criteria: a completed run produces a verifiable time that
+// re-simulates to the same result, the per-level ranked list is correct, and
+// invalid/desynced submissions are rejected. A greedy "client" plays each level to
+// produce a real input trace; the leaderboard re-simulates it to verify.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_leaderboard.cpp -o test_leaderboard
+
+#include "doodle/Doodle.h"
+#include "game/Leaderboard.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// A room with a player, one coin, and an exit (no enemy, so a greedy path clears).
+static std::string makeLevelJson() {
+    doodle::LevelSpec s;
+    s.walls.push_back(doodle::Wall{{{10, 0, 10}, {40, 0, 10}, {40, 0, 40}, {10, 0, 40}, {10, 0, 10}}});
+    s.symbols.push_back(doodle::Symbol{"player", doodle::Vec3{15, 0, 15}, 0.0f});
+    s.symbols.push_back(doodle::Symbol{"coin", doodle::Vec3{25, 0, 25}, 0.0f});
+    s.symbols.push_back(doodle::Symbol{"exit", doodle::Vec3{34, 0, 34}, 0.0f});
+    return doodle::saveLevel(s);
+}
+
+// A greedy client: each step move toward the nearest uncollected coin, else the
+// exit. Records the input trace that a real player's run would produce.
+static RunTrace playGreedy(const std::string& json, double dt, int maxSteps) {
+    RunTrace tr;
+    tr.dt = dt;
+    LevelSpec spec;
+    doodle::loadLevel(json, spec);
+    DungeonGame g = loadGame(convert(spec));
+    for (int step = 0; step < maxSteps && g.status == GameStatus::Playing; ++step) {
+        ecs::Vec3 target = g.exitPosition;
+        double best = 1e30;
+        for (const Coin& c : g.coins) {
+            if (c.collected) continue;
+            const double d = std::hypot(c.position.x - g.playerPosition.x, c.position.z - g.playerPosition.z);
+            if (d < best) { best = d; target = c.position; }
+        }
+        const GameInput in{target.x - g.playerPosition.x, target.z - g.playerPosition.z};
+        tr.inputs.push_back(in);
+        g.update(in, static_cast<float>(dt));
+    }
+    return tr;
+}
+
+// Prepend n idle frames to a trace, producing a valid-but-slower run.
+static RunTrace padded(const RunTrace& base, int idleFrames) {
+    RunTrace tr;
+    tr.dt = base.dt;
+    for (int i = 0; i < idleFrames; ++i) tr.inputs.push_back(GameInput{0.0f, 0.0f});
+    for (const GameInput& in : base.inputs) tr.inputs.push_back(in);
+    return tr;
+}
+
+static void testReplayIsDeterministicAndVerifiable() {
+    const std::string json = makeLevelJson();
+    const RunTrace tr = playGreedy(json, 1.0 / 60.0, 5000);
+
+    const RunResult a = replayRun(json, tr);
+    const RunResult b = replayRun(json, tr);
+    CHECK(a.won);
+    CHECK(a.steps > 0);
+    CHECK(std::fabs(a.clearTime - a.steps * tr.dt) < 1e-9);
+    // Same trace -> same result (the verifiable-time property).
+    CHECK(a.won == b.won && a.steps == b.steps && a.clearTime == b.clearTime);
+
+    // A trace that never reaches the exit does not clear.
+    RunTrace stuck;
+    stuck.dt = tr.dt;
+    for (int i = 0; i < 10; ++i) stuck.inputs.push_back(GameInput{-1.0f, -1.0f}); // into a corner
+    CHECK(!replayRun(json, stuck).won);
+
+    // Unparseable level never clears.
+    CHECK(!replayRun("not json", tr).won);
+}
+
+static void testRegisterUsesContentCode() {
+    Leaderboard lb;
+    const std::string json = makeLevelJson();
+    const std::string code = lb.registerLevel(json);
+    CHECK(code == shareCodeFor(json)); // keyed by the #241 share code
+    CHECK(lb.hasLevel(code));
+    CHECK(!lb.hasLevel("DD-0000000000000"));
+}
+
+static void testSubmitRankAndVerifiableTime() {
+    Leaderboard lb;
+    const std::string json = makeLevelJson();
+    const std::string code = lb.registerLevel(json);
+
+    const RunTrace fast = playGreedy(json, lb.fixedDt(), 5000);
+    const RunTrace slow = padded(fast, 40);
+    const double fastTime = replayRun(json, fast).clearTime;
+    const double slowTime = replayRun(json, slow).clearTime;
+    CHECK(slowTime > fastTime);
+
+    // Submit with a correct claimed time (verified against the replay).
+    const SubmitResult a = lb.submit(code, "alice", fast, 100, fastTime);
+    CHECK(a.accepted && a.improved);
+    CHECK(std::fabs(a.clearTime - fastTime) < 1e-9); // recorded time == re-simulated time
+    CHECK(a.rank == 1);
+
+    const SubmitResult b = lb.submit(code, "bob", slow, 200);
+    CHECK(b.accepted);
+    CHECK(b.rank == 2);
+
+    // Ranked list: fastest first, one row per player.
+    const std::vector<ScoreEntry> board = lb.top(code);
+    CHECK(board.size() == 2);
+    CHECK(board[0].player == "alice" && board[1].player == "bob");
+    CHECK(board[0].clearTime < board[1].clearTime);
+    // The recorded top time equals what the trace re-simulates to.
+    CHECK(std::fabs(board[0].clearTime - fastTime) < 1e-9);
+    CHECK(lb.count(code) == 2);
+    CHECK(lb.rankOf(code, "bob") == 2);
+    CHECK(lb.rankOf(code, "nobody") == 0);
+}
+
+static void testBestPerPlayer() {
+    Leaderboard lb;
+    const std::string json = makeLevelJson();
+    const std::string code = lb.registerLevel(json);
+    const RunTrace fast = playGreedy(json, lb.fixedDt(), 5000);
+    const RunTrace slow = padded(fast, 40);
+
+    // A player's slower run first, then a faster personal best.
+    const SubmitResult first = lb.submit(code, "cara", slow, 100);
+    CHECK(first.accepted && first.improved);
+    const double slowTime = first.clearTime;
+
+    const SubmitResult better = lb.submit(code, "cara", fast, 200);
+    CHECK(better.accepted && better.improved);       // new personal best
+    CHECK(better.clearTime < slowTime);
+    CHECK(lb.count(code) == 1);                       // still one row for the player
+    CHECK(std::fabs(lb.top(code)[0].clearTime - better.clearTime) < 1e-9);
+
+    // A subsequent slower run is accepted but does not replace the best.
+    const SubmitResult worse = lb.submit(code, "cara", slow, 300);
+    CHECK(worse.accepted && !worse.improved);
+    CHECK(std::fabs(lb.top(code)[0].clearTime - better.clearTime) < 1e-9);
+    CHECK(lb.count(code) == 1);
+}
+
+static void testAntiCheatRejections() {
+    Leaderboard lb;
+    const std::string json = makeLevelJson();
+    const std::string code = lb.registerLevel(json);
+    const RunTrace fast = playGreedy(json, lb.fixedDt(), 5000);
+    const double fastTime = replayRun(json, fast).clearTime;
+
+    // Unknown level.
+    const SubmitResult unknown = lb.submit("DD-0000000000000", "eve", fast, 10);
+    CHECK(!unknown.accepted && unknown.reason == "unknown level");
+
+    // Wrong timestep (a time-scaling cheat).
+    RunTrace badDt = fast;
+    badDt.dt = 1.0 / 30.0;
+    const SubmitResult dt = lb.submit(code, "eve", badDt, 10);
+    CHECK(!dt.accepted && dt.reason == "bad timestep");
+
+    // A trace that does not clear the level.
+    RunTrace noClear;
+    noClear.dt = lb.fixedDt();
+    for (int i = 0; i < 5; ++i) noClear.inputs.push_back(GameInput{-1.0f, -1.0f});
+    const SubmitResult stuck = lb.submit(code, "eve", noClear, 10);
+    CHECK(!stuck.accepted && stuck.reason == "did not clear");
+
+    // A claimed time that disagrees with the re-simulation (tamper / desync).
+    const SubmitResult desync = lb.submit(code, "eve", fast, 10, fastTime + 1.0);
+    CHECK(!desync.accepted && desync.reason == "desync");
+
+    // None of the rejected runs made it onto the board.
+    CHECK(lb.count(code) == 0);
+    CHECK(lb.top(code).empty());
+
+    // A correctly claimed time is still accepted (sanity that the check is two-sided).
+    const SubmitResult ok = lb.submit(code, "eve", fast, 20, fastTime);
+    CHECK(ok.accepted);
+    CHECK(lb.count(code) == 1);
+}
+
+int main() {
+    testReplayIsDeterministicAndVerifiable();
+    testRegisterUsesContentCode();
+    testSubmitRankAndVerifiableTime();
+    testBestPerPlayer();
+    testAntiCheatRejections();
+
+    if (g_failures == 0) {
+        std::printf("All leaderboard tests passed.\n");
+        return 0;
+    }
+    std::printf("%d leaderboard test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #242. Milestone 17 ("Doodle Dungeon") Phase 5, the competitive retention loop.

Ranks players by clear time per level, keyed by the content share code from `LevelShare.h` (#241). `DungeonGame` is fully deterministic (no RNG; enemies chase deterministically), so a fixed-timestep input trace replays to the identical result - which makes a submitted time verifiable by re-simulation. Additive and header-only; no existing files change.

## What is included

`src/game/Leaderboard.h`:

- `RunTrace` / `replayRun(levelJson, trace)` - the anti-cheat core. `replayRun` loads a fresh game from the level JSON, applies each input at the trace's fixed dt, and reports whether it cleared and in what time. The same trace always yields the same result, so client and server agree.
- `Leaderboard`:
  - `registerLevel(json)` - returns the level's share code (`shareCodeFor`, the #241 content code).
  - `submit(code, player, trace, submittedAt, claimedTime = -1)` - re-simulates the trace and accepts it only if it cleared. Rejections: unknown level, a timestep other than the leaderboard's fixed dt (a time-scaling cheat), a trace that does not clear, or a `claimedTime` that disagrees with the re-simulated time (tamper / desync). Accepted runs keep the player's personal best.
  - `top(code, limit)` / `rankOf(code, player)` / `count(code)` - the per-level ranked list, fastest first, one row per player. Timestamps are caller-supplied, so ordering is deterministic with no wall clock.

## Testing

`tests/test_leaderboard.cpp` drives it with a greedy "client" that actually plays each level (moving toward the nearest coin, then the exit) to produce a real input trace, then submits it:

- **Deterministic / verifiable replay** - the same trace re-simulates to the same result; `clearTime == steps * dt`; a trace that never reaches the exit and an unparseable level both report not-cleared.
- **Content-code key** - `registerLevel` returns `shareCodeFor(json)`.
- **Submit + rank** - a fast and a slow run rank fastest-first; the recorded top time equals the re-simulated time; `count` / `rankOf` correct.
- **Best-per-player** - a faster personal best replaces the old one (still one row); a later slower run is accepted but does not replace the best.
- **Anti-cheat rejections** - unknown level, bad timestep, did-not-clear, and desync are each rejected with a reason, and none of the rejected runs reach the board; a correctly claimed time is still accepted (the check is two-sided).

Built and run locally under `-fsanitize=address,undefined` with `-Wall -Wextra -pedantic`; all cases pass, no sanitizer diagnostics. Registered as `test_leaderboard` in CMake.

```
g++ -std=c++17 -Wall -Wextra -pedantic -fsanitize=address,undefined -g -I src tests/test_leaderboard.cpp -o test_leaderboard && ./test_leaderboard
All leaderboard tests passed.
```

## Acceptance criteria

- A completed run produces a verifiable time that re-simulates to the same result: yes, `replayRun` is deterministic and the recorded score equals the re-simulated time.
- Per-level ranked list displays correctly: yes, `top()` (fastest first, best-per-player) with `rankOf`/`count`.
- Invalid/desynced submissions are rejected: yes, the four rejection paths above.

## Notes

- Builds on the share-codes/UGC work (#241): the leaderboard key is the same content-addressed code, so a shared level and its leaderboard line up.
- The anti-cheat is authoritative-by-replay: the server trusts only what re-simulating the trace produces, so a client cannot submit a faster time than its own inputs actually achieve, a mismatched level (content-addressed code), or a scaled timestep.
- CI note: the CodeQL "Analyze (c-cpp)" job builds the engine via cmake + make but does not run the unit tests; the test above was verified locally.