### PR TITLE
docs: ASCII-only punctuation; resolve the stranded strip-em-dashes branch (#243)

### DIFF
--- a/EXPANSION_IDEAS.md
+++ b/EXPANSION_IDEAS.md
@@ -1,9 +1,9 @@
-# IKore Engine — Expansion Ideas: Finding a Unique Identity
+# IKore Engine - Expansion Ideas: Finding a Unique Identity
 
 > **Purpose of this document.** IKore Engine is technically competent, but in its
 > current form it is hard to distinguish from the hundreds of other hobby
-> OpenGL/C++ ECS engines on GitHub. This document proposes a *point of view* —
-> a niche where IKore would be the obvious choice — and a concrete, phased plan
+> OpenGL/C++ ECS engines on GitHub. This document proposes a *point of view* -
+> a niche where IKore would be the obvious choice - and a concrete, phased plan
 > to get there, grounded in the code that already exists.
 
 ---
@@ -29,7 +29,7 @@
 
 - Terrain (deformation, blending, heightmaps), water/buoyancy, weather physics,
   destructibles, and the whole **"map translation" milestone**
-  (SVG→3D, procedural roads, OSM-style city generation, randomized object
+  (SVG->3D, procedural roads, OSM-style city generation, randomized object
   variation). These issues are marked *closed*, but `grep` finds **no surviving
   code** for terrain, water, weather, SVG, or heightmaps. They were planned and
   abandoned (or reverted).
@@ -37,7 +37,7 @@
 **What is entirely missing:**
 
 - **No editor / in-engine UI / tooling.** Every issue in "Milestone 7: UI &
-  Debugging" (#53–#63: FPS overlay, debug console, entity inspector, scene
+  Debugging" (#53-#63: FPS overlay, debug console, entity inspector, scene
   hierarchy viewer, input remapping, HUD/menus) is still **open**.
 - **No scripting layer** (no Lua / AngelScript / WASM). Everything is hard-coded C++.
 - **No PBR / modern rendering path** (it is classic Phong/Blinn forward shading).
@@ -46,11 +46,11 @@
 
 > IKore is a **general-purpose engine with no reason to exist** next to Godot,
 > Unreal, Bevy, or the next hobby engine. Every feature it has is a feature those
-> engines have, done better. To become interesting it needs a *thesis* — one
+> engines have, done better. To become interesting it needs a *thesis* - one
 > thing it does that mainstream engines do **not**.
 
-The good news: the **most distinctive idea in the project's own history — turning
-real-world / 2D data into living 3D worlds — was never actually built.** That is
+The good news: the **most distinctive idea in the project's own history - turning
+real-world / 2D data into living 3D worlds - was never actually built.** That is
 the gap to lean into.
 
 ---
@@ -60,7 +60,7 @@ the gap to lean into.
 Instead of competing as a general game engine, position IKore as a
 **world-from-data simulation engine**: feed it 2D/real-world inputs (floor plans,
 city maps, GIS data, tilemaps), and it produces a navigable, physically simulated
-3D world populated by autonomous agents — with the ability to pause, rewind,
+3D world populated by autonomous agents - with the ability to pause, rewind,
 replay, and export the simulation.
 
 This is a real, under-served niche (architectural walkthroughs, urban/traffic
@@ -79,22 +79,22 @@ the **foundations** they require, and ends with a concrete 8-week vertical slice
 
 ---
 
-## 3. Tier 1 — Flagship differentiator: the World-from-Data pipeline
+## 3. Tier 1 - Flagship differentiator: the World-from-Data pipeline
 
-**Goal:** `ikore import city.osm` (or `floorplan.svg`, or `level.tmx`) → a fully
+**Goal:** `ikore import city.osm` (or `floorplan.svg`, or `level.tmx`) -> a fully
 navigable 3D scene with walls, roads, props, collision, and a baked nav-mesh.
 
 ### Phases
 
-1. **SVG / vector floor plans → 3D interiors.**
+1. **SVG / vector floor plans -> 3D interiors.**
    Parse SVG paths; extrude walls to height; cut doors/windows from layer
    metadata; generate floor/ceiling geometry. Output entities through the
    existing scene graph + `MeshComponent`. (This was issue #71, never built.)
-2. **GeoJSON / OpenStreetMap → city blocks.**
+2. **GeoJSON / OpenStreetMap -> city blocks.**
    Buildings from footprint polygons (extrude by `height`/`levels` tags), roads
    from way geometry with curve smoothing and intersection stitching (issue #72),
    water/parks as flat textured regions.
-3. **Tilemaps (Tiled `.tmx`) → 3D levels.**
+3. **Tilemaps (Tiled `.tmx`) -> 3D levels.**
    Map tile layers to prefabs; object layers to entity spawns. The fastest path
    to a usable demo and the friendliest to game devs.
 4. **Procedural dressing.**
@@ -106,19 +106,19 @@ navigable 3D scene with walls, roads, props, collision, and a baked nav-mesh.
 ### Why this is the right flagship
 - It is the project's *own* original differentiator, currently unbuilt.
 - It immediately produces impressive, shareable demos ("I imported my city and
-  walked through it") — great for stars/visibility.
+  walked through it") - great for stars/visibility.
 - It reuses the scene graph, procedural mesh builders, and serialization that
   already work.
 - It creates a reason to choose IKore over Godot/Unreal for a whole class of
   users (GIS, architecture, simulation, viz).
 
 ### Rough effort
-SVG interiors: ~2–3 weeks. Tilemaps: ~1 week. GeoJSON/OSM: ~3–4 weeks.
+SVG interiors: ~2-3 weeks. Tilemaps: ~1 week. GeoJSON/OSM: ~3-4 weeks.
 Nav-mesh: ~2 weeks (or integrate Recast/Detour).
 
 ---
 
-## 4. Tier 2 — Supporting differentiators
+## 4. Tier 2 - Supporting differentiators
 
 ### 4A. Agent simulation at scale, with time control
 Turn the FSM `AIComponent` into a **simulation substrate**:
@@ -126,7 +126,7 @@ Turn the FSM `AIComponent` into a **simulation substrate**:
 - **Time control**: pause, step, variable speed, and **rewind/replay** via
   ring-buffered state snapshots (the serialization system is the seed).
 - **Scale**: thousands of agents (crowds, traffic, ecosystems). This *requires*
-  the data-oriented ECS in §5.1 — the current `shared_ptr`-per-component model
+  the data-oriented ECS in §5.1 - the current `shared_ptr`-per-component model
   will not hold thousands of agents at frame rate.
 - **Data export**: dump per-tick agent state to CSV/JSON for analysis.
 
@@ -135,7 +135,7 @@ reproducible, rewindable simulation of large populations.
 
 ### 4B. AI-native authoring and NPCs (the 2026 hook)
 - **Natural-language scene authoring**: "add a market square with 8 stalls and a
-  fountain" → the engine places entities via the World-from-Data primitives.
+  fountain" -> the engine places entities via the World-from-Data primitives.
 - **LLM-driven NPCs**: replace/augment the FSM with goal-oriented agents that
   have memory and emit/consume `EventSystem` events; behavior-tree fallback when
   offline. Use the latest Claude models (e.g. `claude-opus-4-8`) behind a thin,
@@ -156,12 +156,12 @@ draw for both competitive games and distributed simulation.
 
 ---
 
-## 5. Tier 3 — Foundations that unlock the above
+## 5. Tier 3 - Foundations that unlock the above
 
 These are not unique on their own, but the flagship cannot ship without them.
 
 ### 5.1 Data-oriented (archetype) ECS  *(highest-leverage foundation)*
-The current ECS stores each component behind a `shared_ptr` on the entity —
+The current ECS stores each component behind a `shared_ptr` on the entity -
 pointer-chasing, cache-unfriendly, and a hard ceiling on agent counts. Move to an
 **archetype/SoA storage** with system queries iterating contiguous arrays.
 The existing `ECSBenchmark` can prove the before/after numbers. This single change
@@ -184,8 +184,8 @@ An editor is table-stakes for anyone to *use* the world-building pipeline.
 
 ### 5.4 Rendering modernization *(optional, "catch-up" not "unique")*
 PBR materials + IBL, a clustered/deferred path, and basic GI. Worthwhile for
-visual credibility of imported worlds, but it does not differentiate on its own —
-prioritize it below Tiers 1–2.
+visual credibility of imported worlds, but it does not differentiate on its own -
+prioritize it below Tiers 1-2.
 
 ---
 
@@ -194,16 +194,16 @@ prioritize it below Tiers 1–2.
 Ship one end-to-end demo that no generic engine ships out of the box:
 
 > **"Import a real neighborhood from OpenStreetMap, walk through it, and watch
-> 500 autonomous pedestrians navigate it — then rewind time."**
+> 500 autonomous pedestrians navigate it - then rewind time."**
 
 | Weeks | Deliverable |
 |---|---|
-| 1–2 | Archetype ECS conversion of the hot path (§5.1); validate with `ECSBenchmark` |
-| 2–3 | Tilemap **or** SVG importer → scene graph entities (§3, smallest viable) |
-| 4–5 | GeoJSON/OSM building+road import; nav-mesh bake (§3) |
-| 5–6 | Deterministic fixed-step + 500 crowd agents on the nav-mesh (§4A) |
-| 6–7 | ImGui overlay: FPS, entity inspector, **rewind/replay** scrubber (§5.3, §4A) |
-| 7–8 | Polish, record a demo GIF, write a tutorial in the README |
+| 1-2 | Archetype ECS conversion of the hot path (§5.1); validate with `ECSBenchmark` |
+| 2-3 | Tilemap **or** SVG importer -> scene graph entities (§3, smallest viable) |
+| 4-5 | GeoJSON/OSM building+road import; nav-mesh bake (§3) |
+| 5-6 | Deterministic fixed-step + 500 crowd agents on the nav-mesh (§4A) |
+| 6-7 | ImGui overlay: FPS, entity inspector, **rewind/replay** scrubber (§5.3, §4A) |
+| 7-8 | Polish, record a demo GIF, write a tutorial in the README |
 
 That single demo is the elevator pitch the project currently lacks.
 
@@ -224,21 +224,21 @@ for any of the above to attract contributors:
 3. **Reconcile the issue tracker with reality.** Re-open (or honestly close with a
    note) the terrain/water/weather/map issues whose code is not in the tree, so
    the backlog reflects the actual state.
-4. **A `samples/` folder** with 2–3 runnable scenes, so a newcomer sees results in
+4. **A `samples/` folder** with 2-3 runnable scenes, so a newcomer sees results in
    one command.
 5. **FPS + entity-count overlay (#53, ImGui).** Smallest possible step toward the
    editor, and instantly useful.
 
 ---
 
-## 8. Summary — pick a lane
+## 8. Summary - pick a lane
 
 If IKore tries to be a better general-purpose engine, it loses. If it becomes
 **the engine that turns real-world and 2D data into living, rewindable, AI-driven
-3D simulations**, it occupies a niche the big engines ignore — and it does so by
+3D simulations**, it occupies a niche the big engines ignore - and it does so by
 *finishing the vision it already started* and *building on the systems it already
 has*.
 
-**Recommended order:** §5.1 archetype ECS → §3 one importer → §4A crowd + time
-control → §5.3 ImGui editor → then §4B AI-native layer and §4C netcode as the
+**Recommended order:** §5.1 archetype ECS -> §3 one importer -> §4A crowd + time
+control -> §5.3 ImGui editor -> then §4B AI-native layer and §4C netcode as the
 project matures. Start with the §6 vertical slice.

--- a/PHONE_GAME_CONCEPT.md
+++ b/PHONE_GAME_CONCEPT.md
@@ -1,12 +1,12 @@
-# Concept: "Doodle Dungeon" — turn hand-drawn floor plans into playable game maps
+# Concept: "Doodle Dungeon" - turn hand-drawn floor plans into playable game maps
 
 > A consumer mobile game built on IKore's **world-from-data** thesis
 > (see `EXPANSION_IDEAS.md`). The player draws a floor plan on paper, snaps a
 > photo, and seconds later is walking and playing inside their own drawing in 3D.
-> The drawing is not just geometry — drawn symbols are a tiny visual language that
+> The drawing is not just geometry - drawn symbols are a tiny visual language that
 > places doors, enemies, loot, and the exit.
 
-*(Working title only — other names: PaperWorlds, Sketch2World, Crayon Castle.)*
+*(Working title only - other names: PaperWorlds, Sketch2World, Crayon Castle.)*
 
 ---
 
@@ -17,7 +17,7 @@
 
 Everything in this concept serves that one 10-second loop:
 
-**Draw → Snap → Play → Share.**
+**Draw -> Snap -> Play -> Share.**
 
 The shareable artifact is unbeatable for social reach: a side-by-side of the
 **paper drawing** and the **3D level it became** is exactly the kind of clip that
@@ -27,9 +27,9 @@ travels on TikTok/Instagram/YouTube Shorts. The product markets itself.
 
 ## 2. Why this is genuinely unique
 
-- "Mario Maker for the real world" — user-generated levels, but the authoring tool
+- "Mario Maker for the real world" - user-generated levels, but the authoring tool
   is a **pencil and paper**, which everyone already has and enjoys.
-- Almost no competitor does **photo-of-a-drawing → 3D playable game**. (There are
+- Almost no competitor does **photo-of-a-drawing -> 3D playable game**. (There are
   coloring-page AR apps and floor-plan *measurement* apps, but not a *game* loop.)
 - Strong family / education angle: it rewards creativity and is safe, screen-light
   authoring (you draw on paper, not on a screen).
@@ -44,7 +44,7 @@ travels on TikTok/Instagram/YouTube Shorts. The product markets itself.
 The level is more than walls. A small set of easy-to-draw symbols becomes gameplay,
 so a child can author a full level with a pencil:
 
-| You draw… | It becomes… |
+| You draw... | It becomes... |
 |---|---|
 | Connected lines / closed shapes | Walls and rooms (extruded to 3D) |
 | A gap in a wall | A doorway / passage |
@@ -62,47 +62,47 @@ coin) and grow with the game's progression.
 
 ---
 
-## 4. What you actually *do* — game loop
+## 4. What you actually *do* - game loop
 
 A map is not a game, so pick a core verb. Recommended first mode, in priority order:
 
 1. **Top-down dungeon crawler** (twin-stick): explore your floor plan, grab coins,
    dodge/fight enemies, reach the exit. Easiest to make fun, reads well at any
-   drawing quality, classic and broadly appealing. **← start here.**
+   drawing quality, classic and broadly appealing. **<- start here.**
 2. **First/third-person explorer**: "walk inside your drawing." Highest wow-factor
    for the share clip; great as a secondary "tour" mode.
 3. **Stealth / hide-and-seek vs. AI agents**: leans on IKore's `AIComponent` +
    crowd simulation.
-4. **Tower defense**: enemies path through your rooms — leans on the nav-mesh.
+4. **Tower defense**: enemies path through your rooms - leans on the nav-mesh.
 5. **Async multiplayer**: publish your map, friends play it with a share code;
    leaderboards for fastest clear. Leans on `NetworkComponent`. This is the
    long-term retention engine (endless UGC).
 
 ---
 
-## 5. The hard core: hand-drawing → playable map (the moat)
+## 5. The hard core: hand-drawing -> playable map (the moat)
 
 This computer-vision pipeline is the make-or-break and the defensible IP. Stages:
 
 1. **Capture & rectify.** Detect the paper quad in the camera frame; perspective-
    warp to a clean top-down image (homography). Auto-crop, white-balance.
-2. **Binarize & clean.** Grayscale → adaptive threshold → denoise → deskew so a
+2. **Binarize & clean.** Grayscale -> adaptive threshold -> denoise -> deskew so a
    phone photo under any lighting becomes crisp black-on-white.
 3. **Vectorize walls.** Detect line segments (e.g. Hough transform) and/or trace
    contours; merge collinear segments; **snap to grid and to 0/45/90° angles** so
-   wobbly hand lines become clean architecture. Simplify with Douglas–Peucker.
+   wobbly hand lines become clean architecture. Simplify with Douglas-Peucker.
 4. **Build topology.** Close polygons into rooms; treat wall gaps as doorways;
    build a room-connectivity graph. Reject/repair unclosed or ambiguous regions.
-5. **Recognize symbols.** Classify the drawn icons (start/exit/enemy/coin/…). Start
+5. **Recognize symbols.** Classify the drawn icons (start/exit/enemy/coin/...). Start
    with simple shape heuristics + template matching; graduate to a small on-device
    CNN trained on crowdsourced doodles as data accumulates. **This is where ML and
-   the long-term data moat live** — every level players draw is training data.
+   the long-term data moat live** - every level players draw is training data.
 6. **Emit the scene.** Produce IKore's intermediate scene description (see §7),
    which the engine extrudes to 3D, populates with entities, and bakes a nav-mesh
    from.
 
 **De-risking order (critical):** do NOT start with messy camera input.
-- **Phase 0:** on-screen finger/stylus drawing → vectors are exact, no CV needed.
+- **Phase 0:** on-screen finger/stylus drawing -> vectors are exact, no CV needed.
   Proves the *game* loop immediately.
 - **Phase 1:** photo of a **clean, grid-paper, orthogonal** drawing.
 - **Phase 2:** robust to freehand, lighting, angle, and color.
@@ -112,18 +112,18 @@ Each phase is shippable and teaches you what real drawings look like.
 
 ## 6. The honest tension: IKore is a *desktop* engine
 
-IKore today is **C++ + desktop OpenGL** (GLFW, classic GL — verified: no OpenGL ES,
+IKore today is **C++ + desktop OpenGL** (GLFW, classic GL - verified: no OpenGL ES,
 no EGL, no Android/iOS, no touch input, no OpenCV). It cannot ship to phones as-is.
 There are three viable paths; the recommendation combines them:
 
 | Path | What it means | Verdict |
 |---|---|---|
 | **A. Port IKore to mobile** | Add an OpenGL ES 3.0 / Vulkan backend, touch input, Android (NDK) + iOS build | Real work; do it *after* the loop is proven |
-| **B. Extract the converter as a portable C++ library** | The IP is the *drawing→scene* pipeline, not the renderer. Ship it as a standalone lib usable from any mobile app/engine | **Smartest hedge** — value isn't locked to the renderer |
-| **C. Prototype on desktop first** | Mouse-draw or load-photo → extrude → play, all in the engine you already have | **Start here** — proves the magic in days, not months |
+| **B. Extract the converter as a portable C++ library** | The IP is the *drawing->scene* pipeline, not the renderer. Ship it as a standalone lib usable from any mobile app/engine | **Smartest hedge** - value isn't locked to the renderer |
+| **C. Prototype on desktop first** | Mouse-draw or load-photo -> extrude -> play, all in the engine you already have | **Start here** - proves the magic in days, not months |
 
-**Recommendation:** **C → B → A.** Prove the loop on desktop with what already
-exists; factor the drawing→scene converter into a clean library; only then invest
+**Recommendation:** **C -> B -> A.** Prove the loop on desktop with what already
+exists; factor the drawing->scene converter into a clean library; only then invest
 in the mobile renderer port (or pair the library with a mobile-native/Flutter/
 Unity shell if that ships faster).
 
@@ -136,33 +136,33 @@ reusable no matter which renderer wins.
 
 The desktop proof-of-concept (Phase 0) needs almost no new engine systems:
 
-- **Intermediate scene format** → reuse `SerializationData` / `JsonFormat`
+- **Intermediate scene format** -> reuse `SerializationData` / `JsonFormat`
   (`src/Serialization.h`). The converter outputs JSON; the engine loads it.
-- **Walls/floors** → `MeshComponent::createCube` / `createPlane`
+- **Walls/floors** -> `MeshComponent::createCube` / `createPlane`
   (`src/core/components/MeshComponent.h`) extruded along wall polylines.
-- **Scene assembly** → the existing scene graph (`SceneGraphSystem`) +
+- **Scene assembly** -> the existing scene graph (`SceneGraphSystem`) +
   entity/component system.
-- **Collision & movement** → `PhysicsComponent` (Bullet) for walls + a player body.
-- **Enemies** → `AIComponent` (patrol/chase already implemented).
-- **Sound/feel** → OpenAL `SoundComponent`; particles for coins/hits.
-- **Share/multiplayer (later)** → `NetworkComponent`.
+- **Collision & movement** -> `PhysicsComponent` (Bullet) for walls + a player body.
+- **Enemies** -> `AIComponent` (patrol/chase already implemented).
+- **Sound/feel** -> OpenAL `SoundComponent`; particles for coins/hits.
+- **Share/multiplayer (later)** -> `NetworkComponent`.
 
-The *new* code is the **drawing→scene converter** (§5) — which is also the
+The *new* code is the **drawing->scene converter** (§5) - which is also the
 flagship importer from `EXPANSION_IDEAS.md`. The game and the engine roadmap are
 the same project.
 
 ---
 
-## 8. MVP — the smallest thing that proves the magic
+## 8. MVP - the smallest thing that proves the magic
 
 **Desktop "Doodle Dungeon" PoC (Phase 0), buildable on current IKore:**
 
 1. A simple draw surface (mouse) on a grid: draw wall segments + place 4 symbols
    (start, exit, coin, enemy). *(Or: hand-author a small JSON level to start even faster.)*
-2. Converter: wall segments → wall polygons → 3D geometry; symbols → entity spawns;
+2. Converter: wall segments -> wall polygons -> 3D geometry; symbols -> entity spawns;
    write the JSON scene.
 3. Load the scene; spawn a player with collision; top-down camera.
-4. Core loop: move, collect coins, avoid one `AIComponent` enemy, reach the exit → "You win."
+4. Core loop: move, collect coins, avoid one `AIComponent` enemy, reach the exit -> "You win."
 5. A "tour mode" first-person camera for the wow-shot.
 
 If that loop is fun with a *mouse-drawn* box-and-line map, the camera/CV and mobile
@@ -174,9 +174,9 @@ work are justified. If it isn't, you've spent days, not months.
 
 | Phase | Scope | Outcome |
 |---|---|---|
-| **0. Desktop loop** | On-screen/JSON drawing → 3D → playable (MVP §8) | Proves the fun, reuses existing engine |
-| **1. Clean-photo CV** | Photo of grid/orthogonal drawing → vectors (§5 steps 1–4) | Proves "paper → game" with constrained input |
-| **2. Converter library** | Extract drawing→scene as portable C++ lib (Path B) | Reusable IP, testable in isolation |
+| **0. Desktop loop** | On-screen/JSON drawing -> 3D -> playable (MVP §8) | Proves the fun, reuses existing engine |
+| **1. Clean-photo CV** | Photo of grid/orthogonal drawing -> vectors (§5 steps 1-4) | Proves "paper -> game" with constrained input |
+| **2. Converter library** | Extract drawing->scene as portable C++ lib (Path B) | Reusable IP, testable in isolation |
 | **3. Mobile shell** | OpenGL ES backend + touch, or mobile-native shell around the lib | Runs on a phone |
 | **4. Symbol ML + robustness** | On-device symbol CNN; freehand/lighting robustness (§5 step 5) | Handles real kids' drawings |
 | **5. UGC & social** | Share codes, level browser, leaderboards (`NetworkComponent`) | Retention + viral loop |
@@ -185,12 +185,12 @@ work are justified. If it isn't, you've spent days, not months.
 
 ## 10. Top risks
 
-1. **CV robustness on real drawings** — biggest risk. Mitigate with the
-   Phase 0→2 ramp and grid-paper guidance; collect drawings as training data.
-2. **Mobile port cost** — mitigate with Path B/C (don't port until proven).
-3. **"Map ≠ game"** — mitigate by nailing one fun verb (top-down crawler) before
+1. **CV robustness on real drawings** - biggest risk. Mitigate with the
+   Phase 0->2 ramp and grid-paper guidance; collect drawings as training data.
+2. **Mobile port cost** - mitigate with Path B/C (don't port until proven).
+3. **"Map ≠ game"** - mitigate by nailing one fun verb (top-down crawler) before
    adding modes.
-4. **Scope creep** — the symbol set and game modes can balloon; ship the 4-symbol,
+4. **Scope creep** - the symbol set and game modes can balloon; ship the 4-symbol,
    one-mode MVP first.
 
 ---
@@ -199,6 +199,6 @@ work are justified. If it isn't, you've spent days, not months.
 
 The phone-game framing is the perfect consumer expression of the world-from-data
 thesis: it makes the technology *delightful and shareable*, and the make-or-break
-core (drawing → 3D scene) is **the same importer the engine needs anyway**. Start
+core (drawing -> 3D scene) is **the same importer the engine needs anyway**. Start
 with the desktop PoC (§8) on the engine that already exists, keep the converter
 renderer-agnostic, and only pay for mobile once the magic is proven.

--- a/PHONE_GAME_DESIGN.md
+++ b/PHONE_GAME_DESIGN.md
@@ -1,27 +1,27 @@
-# Doodle Dungeon — Deep Design & Market Analysis
+# Doodle Dungeon - Deep Design & Market Analysis
 
 > Companion to `PHONE_GAME_CONCEPT.md`. This document does the homework before any
 > code: it researches the competition, sharpens the wedge, specifies the full
 > drawing-symbol language, lays out a concrete game-design spec, and picks a
-> monetization model — all grounded in current market data (sources at the end).
+> monetization model - all grounded in current market data (sources at the end).
 
 ---
 
 ## 1. The sharpened wedge (read this first)
 
-The original pitch — "draw on paper, snap a photo, play your drawing" — is **not
+The original pitch - "draw on paper, snap a photo, play your drawing" - is **not
 novel**. At least three shipping products already do exactly that loop. **But every
 one of them produces a 2D game** (platformer / arcade / physics). Separately, "turn
-a floor plan into 3D" is a *solved* problem — but only in architecture/real-estate
+a floor plan into 3D" is a *solved* problem - but only in architecture/real-estate
 tools that produce **static visualizations, not games**.
 
-> **The white space nobody occupies: a hand-drawn *floor plan* → a *3D place you
+> **The white space nobody occupies: a hand-drawn *floor plan* -> a *3D place you
 > explore and play in*.** That intersection is precisely what a 3D engine like
 > IKore is built for, and it is invisible to both the 2D "draw-a-game" apps and the
 > non-game floor-plan tools.
 
 Reframe the product accordingly: **you are not drawing a *game*, you are drawing a
-*place*** — a dungeon, a house, a spaceship — and then living inside it in 3D.
+*place*** - a dungeon, a house, a spaceship - and then living inside it in 3D.
 That single word ("place," not "game") is the whole differentiation.
 
 A lucky bonus: **floor plans literally *are* dungeon maps.** "Rooms connected by
@@ -32,34 +32,34 @@ spatial structure of a floor plan maps onto a fun game with almost no translatio
 
 ## 2. Market & competitor research
 
-### 2.1 Category A — "draw your own game" apps (direct loop, but 2D)
+### 2.1 Category A - "draw your own game" apps (direct loop, but 2D)
 
 | Product | What it does | Model | Limit / opening |
 |---|---|---|---|
-| **Pixicade** (Abacus Brands) | Draw on paper → photo → 2D game. Templates: platformer, **maze**, slingshot, brick-breaker, 2-player. Sold as a physical marker **kit** for kids 6–12; award-winning (Newsweek STEM, Mom's Choice) | Physical kit + app, IAP ("snowflakes") | **2D only**; template-bound; some reviews cite confusing premium currency |
-| **Draw Your Game Infinite** (Korrisoft) | Draw on paper → photo → 2D physics platformer. **Color = behavior**: black static, red danger, green bouncy, blue movable | Free-to-play + IAP | **2D only**; fixed physics-platformer genre |
-| **DoodleMatic** | Draw → photo → playable 2D game; community sharing | App | **2D only** |
+| **Pixicade** (Abacus Brands) | Draw on paper -> photo -> 2D game. Templates: platformer, **maze**, slingshot, brick-breaker, 2-player. Sold as a physical marker **kit** for kids 6-12; award-winning (Newsweek STEM, Mom's Choice) | Physical kit + app, IAP ("snowflakes") | **2D only**; template-bound; some reviews cite confusing premium currency |
+| **Draw Your Game Infinite** (Korrisoft) | Draw on paper -> photo -> 2D physics platformer. **Color = behavior**: black static, red danger, green bouncy, blue movable | Free-to-play + IAP | **2D only**; fixed physics-platformer genre |
+| **DoodleMatic** | Draw -> photo -> playable 2D game; community sharing | App | **2D only** |
 
 **Key takeaways:**
-- The "snap a drawing and play it" loop is validated and *liked* — but it has
+- The "snap a drawing and play it" loop is validated and *liked* - but it has
   calcified around **2D arcade/physics**.
 - **Color-coding beats shape recognition.** Draw Your Game's 4-color language is a
-  deliberate CV-robustness choice — segmenting by color is far more reliable on
+  deliberate CV-robustness choice - segmenting by color is far more reliable on
   messy drawings than classifying hand-drawn shapes. **We should adopt this.**
-- **The physical kit (Pixicade) is both a revenue channel and a CV hack** —
+- **The physical kit (Pixicade) is both a revenue channel and a CV hack** -
   controlled marker colors and paper make recognition dramatically easier.
 
-### 2.2 Category B — floor plan → 3D (solved, but not games)
+### 2.2 Category B - floor plan -> 3D (solved, but not games)
 
 Polycam (LiDAR room scan), magicplan (AR corner detection), Planner 5D (AI room
-scan), floor-plan.ai and Coohom (**upload a photo of a hand-drawn sketch → 3D via
+scan), floor-plan.ai and Coohom (**upload a photo of a hand-drawn sketch -> 3D via
 auto-wall-detection**). These prove the conversion is **feasible today** and give
-us prior art to learn from — but they output **furniture-planning visualizations**,
+us prior art to learn from - but they output **furniture-planning visualizations**,
 not anything playable (no goals, enemies, movement, scoring, or sharing).
 
-### 2.3 Category C — sketch → 3D *asset* AI (adjacent)
+### 2.3 Category C - sketch -> 3D *asset* AI (adjacent)
 
-Meshy, Sloyd.ai ("drawing to dungeon"), Alpha3D, Adobe **Aqua** (kid-friendly 2D→3D
+Meshy, Sloyd.ai ("drawing to dungeon"), Alpha3D, Adobe **Aqua** (kid-friendly 2D->3D
 with AR). These make 3D **objects/models**, not navigable **spaces**. Useful later
 as a way to turn doodled *props* into meshes; not a competitor to the core loop.
 
@@ -68,15 +68,15 @@ as a way to turn doodled *props* into meshes; not a competitor to the core loop.
 - **UGC + sharing is a proven engine.** Super Mario Maker had **7M+ user courses
   played 600M+ times by 2016**, with a simple "stars" approval mechanic driving
   organic, word-of-mouth marketing. Our share-a-map loop targets the same dynamic.
-- **Kids creative-STEM has real commercial pull** — Pixicade's awards and retail
-  presence show parents pay for "creativity → play" products.
+- **Kids creative-STEM has real commercial pull** - Pixicade's awards and retail
+  presence show parents pay for "creativity -> play" products.
 
 ### 2.5 The competitive map (where we sit)
 
 ```
             2D / arcade            3D / spatial
           ┌──────────────────┬──────────────────────┐
- GAME     │ Pixicade,        │   ★ DOODLE DUNGEON ★  │  ← empty quadrant
+ GAME     │ Pixicade,        │   ★ DOODLE DUNGEON ★  │  <- empty quadrant
  (play)   │ Draw Your Game,  │   (our wedge)         │
           │ DoodleMatic      │                       │
           ├──────────────────┼──────────────────────┤
@@ -87,7 +87,7 @@ as a way to turn doodled *props* into meshes; not a competitor to the core loop.
 
 **Primary threat:** an incumbent (esp. Pixicade, which already has a "Maze Maker")
 adds a 3D mode. **Our moat against that:** a 3D engine purpose-built for
-world-from-data, a floor-plan-native symbol language, and a UGC community — i.e.
+world-from-data, a floor-plan-native symbol language, and a UGC community - i.e.
 depth they'd have to rebuild. Speed and focus matter.
 
 ---
@@ -96,19 +96,19 @@ depth they'd have to rebuild. Speed and focus matter.
 
 Two viable audiences; they imply different art, tone, and **monetization**:
 
-| | **Kids 6–12 (creative/STEM)** | **Teens/Adults (UGC dungeon-makers)** |
+| | **Kids 6-12 (creative/STEM)** | **Teens/Adults (UGC dungeon-makers)** |
 |---|---|---|
 | Hook | "Your drawing comes to life in 3D" | "Sketch a dungeon, share it, top the leaderboard" |
 | Tone/art | Bright, friendly, safe | Stylized dungeon/roguelite |
 | Distribution | Apple **Kids Category**, retail kit | Standard F2P, social/UGC virality |
-| Monetization | **Premium / kit / parent-gated** (ads largely banned — see §6) | **Hybrid F2P** (ads + IAP) viable |
+| Monetization | **Premium / kit / parent-gated** (ads largely banned - see §6) | **Hybrid F2P** (ads + IAP) viable |
 | Compliance | Heavy (COPPA/GDPR-K) | Standard |
 
 **Recommendation:** launch for **teens/adults first** (the "dungeon-maker" framing).
 Reasons: monetization is far less constrained (§6), UGC virality is stronger in that
 demographic, and the dungeon aesthetic makes "floor plan = level" feel intentional
 rather than mundane. Add a **Kids Mode + physical kit** as a second act once the
-core loop and CV are proven — that's where Pixicade's playbook (and revenue) lives,
+core loop and CV are proven - that's where Pixicade's playbook (and revenue) lives,
 but it carries the compliance burden.
 
 ---
@@ -119,7 +119,7 @@ but it carries the compliance burden.
 1. **A child can draw every symbol** with a single pen, first try.
 2. **Robust to CV before clever.** Prefer features that survive a blurry photo.
 3. **Unambiguous.** No two symbols collide after line-simplification.
-4. **Progressive.** Start with ~5 symbols; unlock more as the player levels up — this
+4. **Progressive.** Start with ~5 symbols; unlock more as the player levels up - this
    doubles as onboarding (you can't be overwhelmed by a vocabulary you haven't
    unlocked yet).
 
@@ -139,18 +139,18 @@ it isn't.
 
 ### 4.3 The vocabulary
 
-**Tier 1 — taught in the first 60 seconds (everyone starts here):**
+**Tier 1 - taught in the first 60 seconds (everyone starts here):**
 
 | Draw | Color | Becomes |
 |---|---|---|
 | Lines / closed shapes | Black | Walls + rooms (extruded to 3D) |
-| Gap in a wall | — | Doorway / passage |
+| Gap in a wall | - | Doorway / passage |
 | `S` or a star | Green | Player start |
 | `X` or a flag | Green | Exit / goal |
 | Small filled dot | Green | Coin / collectible |
 | Spiky blob | Red | Basic enemy spawn |
 
-**Tier 2 — unlocked by playing:**
+**Tier 2 - unlocked by playing:**
 
 | Draw | Color | Becomes |
 |---|---|---|
@@ -161,42 +161,42 @@ it isn't.
 | `+` | Green | Health pickup |
 | Spiral | Blue | Teleporter (pairs nearest two) |
 
-**Tier 3 — advanced authoring:**
+**Tier 3 - advanced authoring:**
 
 | Draw | Color | Becomes |
 |---|---|---|
-| Number `1`–`3` in a room | Black | **Floor height / elevation** (verticality — multi-storey!) |
+| Number `1`-`3` in a room | Black | **Floor height / elevation** (verticality - multi-storey!) |
 | Hatched region | Black | Stairs/ramp between heights |
 | Circle with a face | Blue | NPC (gives a line of text / quest) |
 | Box outline | Blue | Pushable crate (physics) |
 | `~` region | Blue | Water (swim/slow) |
 
 > **Verticality (Tier 3) is a stealth differentiator.** Because IKore is true 3D,
-> writing a small "2" in a room can raise it a storey — something *no* 2D
+> writing a small "2" in a room can raise it a storey - something *no* 2D
 > competitor can express. A flat floor plan becomes a multi-level space.
 
 ### 4.4 Drawing rules & CV-robustness aids
 - **Guide paper.** Offer a free printable (and the §6 physical kit) with a faint grid
-  and a color legend — massively improves recognition, like Pixicade's kit.
+  and a color legend - massively improves recognition, like Pixicade's kit.
 - **Snap-to-grid + angle-snapping** turns wobbly lines into clean architecture.
 - **Confidence + repair UI.** If a symbol is ambiguous, the app shows its
-  interpretation as editable icons *before* play ("we found 3 enemies and 2 coins —
+  interpretation as editable icons *before* play ("we found 3 enemies and 2 coins -
   tap to fix"). Never fail silently; turn correction into part of the fun.
-- **Graceful defaults.** Unknown red mark → basic enemy; unknown green → coin;
-  unclosed black region → best-effort wall with a highlighted warning.
+- **Graceful defaults.** Unknown red mark -> basic enemy; unknown green -> coin;
+  unclosed black region -> best-effort wall with a highlighted warning.
 
 ---
 
 ## 5. Game-design spec
 
 ### 5.1 Core fantasy
-> "I designed this place, and now I'm *inside* it — and so is everyone I share it with."
+> "I designed this place, and now I'm *inside* it - and so is everyone I share it with."
 
 ### 5.2 Core loops
-- **Micro (seconds–minutes):** Draw → scan → **review/fix symbols** → play → tweak the
-  paper → re-scan. Fast iteration is the addiction.
-- **Macro (sessions):** Play → earn XP → **unlock new symbols/themes/characters** →
-  author more ambitious maps → **publish & get stars** → climb leaderboards.
+- **Micro (seconds-minutes):** Draw -> scan -> **review/fix symbols** -> play -> tweak the
+  paper -> re-scan. Fast iteration is the addiction.
+- **Macro (sessions):** Play -> earn XP -> **unlock new symbols/themes/characters** ->
+  author more ambitious maps -> **publish & get stars** -> climb leaderboards.
 
 ### 5.3 Primary mode: 3D dungeon crawl (ship this first)
 - **Camera:** over-the-shoulder / adjustable top-down-3D. Reads clearly regardless of
@@ -210,30 +210,30 @@ First-person **Tour mode** (the money shot for share clips) · **Stealth/escape*
 `AIComponent` agents · **Tower defense** (enemies path your corridors) · **Race/
 time-attack** (leaderboard fuel) · **Co-op/async multiplayer** via share codes.
 
-### 5.5 Difficulty — *derived from the drawing*
+### 5.5 Difficulty - *derived from the drawing*
 No difficulty slider; the map *is* the difficulty. Derive a star rating from
 enemy density, path length, hazard coverage, and key/lock depth, and surface it so
 authors can self-balance ("this map is rated ★★★★☆ Brutal").
 
 ### 5.6 Meta-progression & retention
-- **XP & symbol unlocks** (Tier 1→3) give a reason to keep playing and authoring.
+- **XP & symbol unlocks** (Tier 1->3) give a reason to keep playing and authoring.
 - **Themes/skins** (Dungeon, Haunted House, Spaceship, Neon City) reskin the *same*
-  geometry — cheap content, strong personalization, natural IAP.
+  geometry - cheap content, strong personalization, natural IAP.
 - **UGC + "stars"** (proven by Mario Maker): publish maps, browse by Hot/New/Top, award
   stars, follow creators.
-- **Weekly drawing prompts/challenges** ("draw a castle") → curated feed → fresh
+- **Weekly drawing prompts/challenges** ("draw a castle") -> curated feed -> fresh
   content engine without us building levels.
-- **Share code + side-by-side clip** (paper ↔ 3D) as the built-in virality hook.
+- **Share code + side-by-side clip** (paper <-> 3D) as the built-in virality hook.
 
 ### 5.7 Onboarding
 First run ships a **pre-printed trace sheet**: the player traces a tiny 3-room map,
-scans it, and is playing in <90 seconds — guaranteeing the magic moment lands before
+scans it, and is playing in <90 seconds - guaranteeing the magic moment lands before
 they face a blank page.
 
 ### 5.8 The biggest design risk (state it plainly)
 **A real floor plan is not automatically a fun level.** Mitigations: (a) the symbol
 language injects game content (enemies/loot/goals/keys) onto any space; (b) the
-converter *embellishes* — themed lighting, props, verticality; (c) the **dungeon
+converter *embellishes* - themed lighting, props, verticality; (c) the **dungeon
 framing** makes rooms-and-corridors a feature, not a bug; (d) the difficulty
 rating + fix-up UI nudge authors toward playable layouts. **This must be validated
 in the desktop PoC before any mobile spend.**
@@ -242,11 +242,11 @@ in the desktop PoC before any mobile spend.**
 
 ## 6. Monetization
 
-### 6.1 Benchmarks (2025–2026)
-- **Hybrid-casual ARPDAU ≈ $0.15–0.50**, *4–7× higher than hypercasual* ($0.03–0.08);
+### 6.1 Benchmarks (2025-2026)
+- **Hybrid-casual ARPDAU ≈ $0.15-0.50**, *4-7× higher than hypercasual* ($0.03-0.08);
   casual target ≈ $0.80; Party/Match genres reach the highest ARPU ($4.90 / $2.99).
-- **Rewarded video = ~62% of mobile-game ad revenue**, with 2–3× the engagement of
-  interstitials — the *only* ad format players tolerate.
+- **Rewarded video = ~62% of mobile-game ad revenue**, with 2-3× the engagement of
+  interstitials - the *only* ad format players tolerate.
 - Hybrid-casual typically runs a **~45/55 IAP/ads split**; hybrid IAP grew ~100% YoY
   (>$345M H1 2025).
 
@@ -258,12 +258,12 @@ demands separate consent to share kids' data with advertisers; **AppLovin stoppe
 serving ads to COPPA users in Jan 2025**. Best practice for kids' apps is to **avoid
 in-game ads entirely** and monetize via premium/subscription/parent-gated IAP.
 
-### 6.3 Recommended model — by audience
+### 6.3 Recommended model - by audience
 
 **Teens/adults (primary launch):** **hybrid free-to-play.**
 - **Rewarded video only** (never forced interstitials mid-creation): optional "watch
   to unlock a theme for a day," "revive," "extra map slot."
-- **IAP, cosmetic & convenience — never pay-to-win:** theme/skin packs, character
+- **IAP, cosmetic & convenience - never pay-to-win:** theme/skin packs, character
   skins, symbol-style packs, extra cloud map slots, "remove ads."
 - **Optional subscription** ("Architect's Pass"): all themes, unlimited cloud maps,
   early symbols, creator analytics.
@@ -284,7 +284,7 @@ skippable and clearly labeled, COPPA/GDPR-K compliance designed in from day one.
 | Risk | Severity | Mitigation |
 |---|---|---|
 | "Is exploring a floor plan actually fun?" | **High** | Validate in desktop PoC first (§5.8) |
-| CV robustness on real drawings | **High** | Color-coding (§4.2), guide paper/kit, confidence+repair UI, Phase 0→2 ramp |
+| CV robustness on real drawings | **High** | Color-coding (§4.2), guide paper/kit, confidence+repair UI, Phase 0->2 ramp |
 | Incumbent (Pixicade) adds 3D | Medium | Move fast; depth via 3D engine + verticality + UGC moat |
 | Mobile port cost (IKore is desktop) | Medium | Prove on desktop; keep converter renderer-agnostic (see concept doc) |
 | Kids-compliance overhead | Medium | Launch adult-first; add kids mode deliberately later |
@@ -299,15 +299,15 @@ only *constrains the design* of that core:
 - Input model = **color-class + shape-subtype** (§4.2), not shape-only.
 - Output = a **3D, optionally multi-storey** scene (verticality from Tier-3 symbols).
 - Success metric for the PoC = **"is the resulting 3D space fun to move through?"**
-  (§5.8) — the make-or-break question, answered cheaply before any mobile spend.
+  (§5.8) - the make-or-break question, answered cheaply before any mobile spend.
 
 ---
 
 ## 9. Sources
 
 - Draw-a-game apps: [Draw Your Game Infinite (Google Play)](https://play.google.com/store/apps/details?id=com.korrisoft.draw.your.game), [Pixicade (App Store)](https://apps.apple.com/us/app/pixicade-game-creator/id1532289517), [Pixicade (Abacus Brands)](https://www.abacusbrands.com/products/pixicade), [DoodleMatic review](https://btr.michaelkwan.com/2020/12/09/doodlematic-review/), [Pixicade review (GeekDad)](https://geekdad.com/2021/02/games-from-pixicade-are-as-unlimited-as-your-imagination/)
-- Floor plan → 3D (incl. hand-drawn): [floor-plan.ai](https://floor-plan.ai/floor-plan-to-3d), [Coohom](https://www.coohom.com/article/convert-2d-floor-plan-to-3d-model-free-online), [Polycam](https://poly.cam/floor-plans), [magicplan](https://magicplan.app/blog/room-scan-cad), [Planner 5D](https://planner5d.com/ai)
-- Sketch → 3D assets: [Sloyd.ai "drawing to dungeon"](https://www.sloyd.ai/blog/from-drawing-to-dungeon-turn-fantasy-sketches-into-3d-maps), [Meshy sketch-to-3D](https://www.meshy.ai/blog/sketch-to-3d), [Adobe Aqua](https://aqua.adobe.com/learn/3d-drawing-apps)
+- Floor plan -> 3D (incl. hand-drawn): [floor-plan.ai](https://floor-plan.ai/floor-plan-to-3d), [Coohom](https://www.coohom.com/article/convert-2d-floor-plan-to-3d-model-free-online), [Polycam](https://poly.cam/floor-plans), [magicplan](https://magicplan.app/blog/room-scan-cad), [Planner 5D](https://planner5d.com/ai)
+- Sketch -> 3D assets: [Sloyd.ai "drawing to dungeon"](https://www.sloyd.ai/blog/from-drawing-to-dungeon-turn-fantasy-sketches-into-3d-maps), [Meshy sketch-to-3D](https://www.meshy.ai/blog/sketch-to-3d), [Adobe Aqua](https://aqua.adobe.com/learn/3d-drawing-apps)
 - UGC market validation: [Super Mario Maker (Wikipedia)](https://en.wikipedia.org/wiki/Super_Mario_Maker), [Why Mario Maker is the perfect UGC tool (Lurkit)](https://www.lurkit.gg/blog/why-nintendos-mario-maker-is-the-perfect-ugc-marketing-tool)
 - Monetization benchmarks: [Hybrid casual 2026 guide (Game Growth Advisor)](https://gamegrowthadvisor.com/blog/2026-04-16-hybrid-casual-game-design-strategy-2026/), [ARPDAU by genre (Juego)](https://www.juegostudio.com/blog/arpdau-benchmarks-by-game-genre), [Tenjin Ad Monetization 2026](https://tenjin.com/blog/ad-mon-gaming-2026/)
 - Kids monetization & compliance: [Monetization for kids apps & COPPA (Openback)](https://openback.com/blog/monetization-for-kids-apps-how-to-be-profitable-and-coppa-compliant/), [Ad monetization in kids games (GameBiz)](https://www.gamebizconsulting.com/blog/ad-monetization-in-kids-games-and-apps-how-to-do-it-right), [COPPA 2025 guide (Promise Legal)](https://blog.promise.legal/startup-central/coppa-compliance-in-2025-a-practical-guide-for-tech-edtech-and-kids-apps/), [COPPA/GDPR-K for kids' games (Fish in a Bottle)](https://www.fishinabottle.com/blog/what-does-coppa-and-gdpr-k-compliance-mean-for-childrens-games-fish-in-a-bottle)


### PR DESCRIPTION
## Summary

Closes #243. Cleanup.

The `claude/strip-em-dashes` branch (commit `c77ab9d`, "docs: replace em/en dashes and unicode arrows with ASCII") was never opened as a PR and had gone stale, since the docs it touched have changed on `main`. This PR resolves that.

**Decision:** ASCII-only typographic punctuation is the desired house style (consistent with the rest of the project), so the branch's intent is applied - but freshly, on top of current `main`, rather than rebasing the outdated one-commit branch. The stale `claude/strip-em-dashes` branch is deleted separately so no dangling unmerged branch remains.

## What changed

Across `EXPANSION_IDEAS.md`, `PHONE_GAME_CONCEPT.md`, and `PHONE_GAME_DESIGN.md`:

- em dash and en dash -> `-` (spaced breaks like `geometry - drawn`, and numeric ranges like `2-3 weeks`, `2025-2026`)
- right / left / both arrows -> `->`, `<-`, `<->` (e.g. `Draw -> Snap -> Play`, `SVG->3D`)
- horizontal ellipsis -> `...`

`README.md` is already pure ASCII on current `main`, so it is untouched (the stale branch's README edits are obsolete).

Purely documentation; no code or behavior changes.

## Deliberately retained

Glyphs that are not dashes or arrows and carry meaning or are intentional are kept, matching the branch's stated scope:

- the section sign used for section cross-references (the author uses it freely, including in the issue text);
- the box-drawing ASCII-art architecture diagram in `PHONE_GAME_DESIGN.md` (converting it would mangle the diagram);
- the star rating glyphs and math symbols (degree, approximately-equal, not-equal, multiplication, middle dot).

If full ASCII-only (including these) is wanted, that is a straightforward follow-up.

## Verification

A scan confirms every em dash, en dash, and arrow (and the ellipsis) is gone from the three docs; the only remaining non-ASCII are the intentionally-retained glyphs listed above. Diff is balanced (134 insertions / 134 deletions), i.e. in-place substitutions with no content added or removed.

## Acceptance criteria

- The branch is either merged (via PR) or deleted; no dangling unmerged branches: this PR carries the content, and `claude/strip-em-dashes` is deleted alongside it.