### PR TITLE
Sweep TODO/FIXME markers: triage, clarify, and track real work (#244)

### DIFF
--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -305,8 +305,8 @@ std::unique_ptr<Mesh> Model::processMesh(aiMesh* mesh, const aiScene* scene) {
         // Extract bone data
         extractBoneWeightForVertices(animatedVertices, mesh, scene);
         
-        // Convert animated vertices to regular vertices for now
-        // TODO: Create AnimatedMesh class for proper animated vertex handling
+        // Flatten animated vertices to static Vertex for now; a dedicated AnimatedMesh
+        // that preserves bone IDs/weights for GPU skinning is tracked in #260.
         for (const auto& animVertex : animatedVertices) {
             Vertex vertex;
             vertex.position = animVertex.position;

--- a/src/ParticleSystem.cpp
+++ b/src/ParticleSystem.cpp
@@ -341,9 +341,8 @@ void ParticleSystem::updateCPU(float deltaTime) {
 }
 
 void ParticleSystem::updateGPU(float deltaTime) {
-    // GPU update using compute shaders
-    // This is a placeholder for future implementation
-    updateCPU(deltaTime); // Fallback to CPU for now
+    // GPU compute-shader particle update is tracked in #259; use the CPU path for now.
+    updateCPU(deltaTime);
 }
 
 void ParticleSystem::emitParticles(float deltaTime) {

--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -367,8 +367,7 @@ void SSAOEffect::render(GLuint inputTexture, GLuint outputFramebuffer) {
     glBindFramebuffer(GL_FRAMEBUFFER, outputFramebuffer);
     glDisable(GL_DEPTH_TEST);
     
-    // For now, just pass through the input texture
-    // TODO: Implement full SSAO when G-buffer is available
+    // Passthrough for now: full SSAO needs a G-buffer (depth + normals). Tracked in #259.
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, inputTexture);
     renderQuad();
@@ -416,8 +415,8 @@ void SSAOEffect::renderSSAO(GLuint /*colorTexture*/, GLuint depthTexture, GLuint
     
     // Apply SSAO to final image
     glBindFramebuffer(GL_FRAMEBUFFER, outputFramebuffer);
-    // TODO: Combine SSAO with lighting calculation
-    
+    // Combining the SSAO term with the lit image is part of the G-buffer work in #259.
+
     glEnable(GL_DEPTH_TEST);
 }
 

--- a/src/ShadowMap.cpp
+++ b/src/ShadowMap.cpp
@@ -350,8 +350,8 @@ void ShadowMapManager::removeShadowMap(int lightIndex) {
 }
 
 void ShadowMapManager::updateShadowMaps() {
-    // This method can be used for any per-frame updates if needed
-    // Currently just a placeholder for future enhancements
+    // Per-frame hook for shadow-map bookkeeping; intentionally empty, since the
+    // current single-pass shadow setup needs no per-frame update here.
 }
 
 void ShadowMapManager::setShadowQuality(float quality) {

--- a/src/audio/AmbientSoundZone.cpp
+++ b/src/audio/AmbientSoundZone.cpp
@@ -77,14 +77,12 @@ AmbientSoundZone* AmbientSoundZoneManager::findBestZone() {
 }
 
 void AmbientSoundZoneManager::transitionToZone(AmbientSoundZone* newZone, float /* deltaTime */) {
-    // For now, we just update the current zone pointer
-    // TODO: Implement smooth audio transitions when AudioSystem3D supports streaming ambient audio
+    // For now we just swap the current zone pointer; cross-faded transitions need
+    // streaming ambient audio, tracked in #258.
     currentZone = newZone;
-    
+
     if (newZone) {
-        // Calculate volume based on position for debugging
-        // TODO: When ambient audio streaming is implemented in AudioSystem3D,
-        // we'll use this volume calculation for playback
+        // Once streaming ambient audio lands (#258), this per-position volume drives playback.
         [[maybe_unused]] float volume = newZone->getVolumeAtPosition(listenerPosition);
     }
 }

--- a/src/audio/OpenALAudioEngine.cpp
+++ b/src/audio/OpenALAudioEngine.cpp
@@ -688,12 +688,11 @@ namespace IKore {
     void OpenALAudioEngine::updateStreamingSources() {
         std::lock_guard<std::mutex> lock(m_audioMutex);
         
-        // Update streaming sources (placeholder for full streaming implementation)
+        // Full buffer queue/unqueue streaming is tracked in #258.
         for (uint32_t sourceId : m_streamingSources) {
             auto it = m_audioSources.find(sourceId);
             if (it != m_audioSources.end()) {
-                // In a full implementation, this would handle buffer queuing/unqueuing
-                // for continuous streaming audio
+                // Continuous-streaming buffer management goes here (see #258).
             }
         }
     }
@@ -752,24 +751,22 @@ namespace IKore {
     }
 
     bool OpenALAudioEngine::loadOGG(const std::string& filename, AudioBuffer& buffer) {
-        // Placeholder for OGG Vorbis loading
-        // In a full implementation, this would use libvorbis
+        // OGG Vorbis decoding is not built in (needs libvorbis). Tracked in #258.
         #ifdef HAVE_VORBIS
-        // OGG Vorbis loading implementation would go here
+        // OGG Vorbis decode goes here (see #258).
         #endif
-        
-        m_lastError = "OGG format not yet implemented";
+
+        m_lastError = "OGG format not supported";
         return false;
     }
 
     bool OpenALAudioEngine::loadMP3(const std::string& filename, AudioBuffer& buffer) {
-        // Placeholder for MP3 loading
-        // In a full implementation, this would use libsndfile or similar
+        // MP3 decoding is not built in (needs libsndfile or a decoder). Tracked in #258.
         #ifdef HAVE_LIBSNDFILE
-        // MP3 loading implementation would go here
+        // MP3 decode goes here (see #258).
         #endif
-        
-        m_lastError = "MP3 format not yet implemented";
+
+        m_lastError = "MP3 format not supported";
         return false;
     }
 
@@ -1047,11 +1044,13 @@ namespace IKore {
     }
 
     void OpenALAudioEngine::setDopplerFactor(float factor) {
-        // Fallback stub
+        // No-op in fallback mode (OpenAL unavailable).
+        (void)factor;
     }
 
     void OpenALAudioEngine::setSpeedOfSound(float speed) {
-        // Fallback stub
+        // No-op in fallback mode (OpenAL unavailable).
+        (void)speed;
     }
 
     size_t OpenALAudioEngine::getActiveSourceCount() const {

--- a/src/audio/OpenALAudioEngine.h
+++ b/src/audio/OpenALAudioEngine.h
@@ -227,7 +227,7 @@ namespace IKore {
         ALCdevice* m_device;
         ALCcontext* m_context;
 #else
-        // Fallback placeholders when OpenAL is not available
+        // Fallback state used when OpenAL is not available
         void* m_device;
         void* m_context;
 #endif

--- a/src/core/EntityDebugSystem.cpp
+++ b/src/core/EntityDebugSystem.cpp
@@ -355,20 +355,18 @@ namespace IKore {
     }
 
     void EntityDebugSystem::renderDebugText(const std::string& text, [[maybe_unused]] float x, [[maybe_unused]] float y, [[maybe_unused]] const glm::vec4& color) {
-        // This is a placeholder implementation
-        // In a real implementation, you would use your rendering system to draw text
-        // For now, we'll just log the text if needed
+        // On-screen debug text is not wired to a text renderer yet (tracked in #259);
+        // log the first request so the call path stays visible.
         static bool firstCall = true;
         if (firstCall) {
-            LOG_INFO("EntityDebugSystem: Text rendering not implemented yet. Would display: " + text);
+            LOG_INFO("EntityDebugSystem: debug text rendering pending (see #259). Would display: " + text);
             firstCall = false;
         }
     }
 
     void EntityDebugSystem::renderDebugBackground([[maybe_unused]] float x, [[maybe_unused]] float y, [[maybe_unused]] float width, [[maybe_unused]] float height) {
-        // This is a placeholder implementation
-        // In a real implementation, you would render a semi-transparent background quad
-        // This keeps the interface ready for when rendering is implemented
+        // The debug background quad needs a renderer hookup (tracked in #259);
+        // the interface is kept ready.
     }
 
     float EntityDebugSystem::getCurrentTimeMs() const {

--- a/src/core/components/AnimationComponent.cpp
+++ b/src/core/components/AnimationComponent.cpp
@@ -497,10 +497,9 @@ namespace IKore {
     }
 
     void AnimationComponent::updateRootMotion(float deltaTime) {
-        // Simplified root motion implementation
-        // In practice, you'd extract root bone movement from the animation
+        // Root motion currently yields no delta; extracting the root-bone movement
+        // from the active animation is tracked in #260.
         if (m_currentState.animation && m_currentState.playing) {
-            // This is a placeholder - real implementation would extract root bone delta
             m_rootMotionDelta = glm::mat4(1.0f);
         }
     }

--- a/src/core/components/SoundComponent.cpp
+++ b/src/core/components/SoundComponent.cpp
@@ -257,8 +257,7 @@ namespace IKore {
             return false;
         }
 
-        // For now, create a simple sine wave as placeholder
-        // This would be replaced with actual file loading
+        // Generates a test tone for now; real audio-file decoding is tracked in #258.
         std::vector<short> samples;
         const int sampleRate = 44100;
         const int duration = 1; // 1 second


### PR DESCRIPTION
## Summary

Closes #244. Cleanup.

Triaged every `TODO` / `FIXME` / "not yet implemented" / placeholder / stub marker under `src/` (the `toDouble` hits a case-insensitive grep reports are the function name, not markers). After this PR the sweep grep finds **no real markers**, and every deferred item points at a tracking issue.

## Triage outcome

**Real remaining work -> filed focused tracking issues, referenced in-place** (instead of bare TODOs):

- **#258 - Audio:** OGG/MP3 decode, streaming buffer queue/unqueue, ambient-zone cross-fades, and `SoundComponent` file decoding. (`OpenALAudioEngine.cpp`, `AmbientSoundZone.cpp`, `SoundComponent.cpp`)
- **#259 - Renderer features:** full SSAO via a G-buffer, GPU particle compute update, and on-screen debug text/background. (`PostProcessor.cpp`, `ParticleSystem.cpp`, `EntityDebugSystem.cpp`)
- **#260 - Skeletal animation:** a dedicated `AnimatedMesh` vertex path (skinning data currently flattened away) and real root-motion extraction. (`Model.cpp`, `AnimationComponent.cpp`)

**Not real work -> reworded so they stop reading as unfinished:**

- `ShadowMapManager::updateShadowMaps` is an intentionally-empty per-frame hook, not a placeholder - the comment now says so.
- `setDopplerFactor` / `setSpeedOfSound` are genuine no-ops in the OpenAL-absent fallback path; labeled as no-ops (and the unused params are cast to void).
- The OpenAL fallback member comment no longer says "placeholder".
- The OGG/MP3 runtime error strings now read "not supported" rather than "not yet implemented".

## Verification

```
$ grep -rniE 'TODO|FIXME|not yet implemented|unimplemented' src/ | grep -v toDouble
(none)
$ grep -rniE '\b(TODO|FIXME|XXX|HACK)\b|not implemented|placeholder|\bstub\b' src/ | grep -v toDouble
(none)
```

Every deferred marker now carries a `#258` / `#259` / `#260` reference at the code site.

## Notes

- Comment and string-literal changes only - no logic changes, so behavior is unchanged. (The `(void)param;` additions just silence unused-parameter warnings on the fallback no-ops.)
- Scope kept to the marker sweep: two pre-existing degree-sign glyphs in unrelated `EntityDebugSystem` debug strings were left as-is rather than mixing an unrelated ASCII change into this PR.
- CI note: the CodeQL "Analyze (c-cpp)" job builds these engine files via cmake + make; there are no unit tests for this change since it is comments/strings only.