### PR TITLE
Complete skeletal animation: skinned mesh vertex path + real root motion (#260)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -664,6 +664,12 @@ add_executable(test_debug_text
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_debug_text.cpp
 )
 
+# Linear-blend skinning + root-motion delta math mirrored by skinned_phong.vert
+# and AnimationComponent (#260) - header-only.
+add_executable(test_skinning
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_skinning.cpp
+)
+
 # Performance-overlay stats core (Milestone 9 / #53) - header-only.
 add_executable(test_perf_stats
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_perf_stats.cpp

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -15,6 +15,15 @@ Mesh::Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, Mate
     setupMesh();
 }
 
+Mesh::Mesh(std::vector<AnimatedVertex> animatedVertices, std::vector<unsigned int> indices,
+           Material material)
+    : m_animatedVertices(std::move(animatedVertices)), m_hasBones(true),
+      m_indices(std::move(indices)), m_material(std::move(material)),
+      m_VAO(0), m_VBO(0), m_EBO(0), m_isSetup(false) {
+    calculateBoundingBox();
+    setupMesh();
+}
+
 Mesh::~Mesh() {
     // Check if OpenGL functions are available before cleanup
     if (m_VAO && glDeleteVertexArrays) glDeleteVertexArrays(1, &m_VAO);
@@ -22,12 +31,15 @@ Mesh::~Mesh() {
     if (m_EBO && glDeleteBuffers) glDeleteBuffers(1, &m_EBO);
 }
 
-Mesh::Mesh(Mesh&& other) noexcept 
-    : m_vertices(std::move(other.m_vertices)), m_indices(std::move(other.m_indices)),
+Mesh::Mesh(Mesh&& other) noexcept
+    : m_vertices(std::move(other.m_vertices)),
+      m_animatedVertices(std::move(other.m_animatedVertices)), m_hasBones(other.m_hasBones),
+      m_indices(std::move(other.m_indices)),
       m_material(std::move(other.m_material)), m_boundingBox(other.m_boundingBox),
       m_VAO(other.m_VAO), m_VBO(other.m_VBO), m_EBO(other.m_EBO), m_isSetup(other.m_isSetup) {
     other.m_VAO = other.m_VBO = other.m_EBO = 0;
     other.m_isSetup = false;
+    other.m_hasBones = false;
 }
 
 Mesh& Mesh::operator=(Mesh&& other) noexcept {
@@ -39,6 +51,8 @@ Mesh& Mesh::operator=(Mesh&& other) noexcept {
         
         // Move data
         m_vertices = std::move(other.m_vertices);
+        m_animatedVertices = std::move(other.m_animatedVertices);
+        m_hasBones = other.m_hasBones;
         m_indices = std::move(other.m_indices);
         m_material = std::move(other.m_material);
         m_boundingBox = other.m_boundingBox;
@@ -46,10 +60,11 @@ Mesh& Mesh::operator=(Mesh&& other) noexcept {
         m_VBO = other.m_VBO;
         m_EBO = other.m_EBO;
         m_isSetup = other.m_isSetup;
-        
+
         // Reset other object
         other.m_VAO = other.m_VBO = other.m_EBO = 0;
         other.m_isSetup = false;
+        other.m_hasBones = false;
     }
     return *this;
 }
@@ -67,55 +82,99 @@ void Mesh::setupMesh() {
     glGenBuffers(1, &m_EBO);
     
     glBindVertexArray(m_VAO);
-    
-    // Load vertex data
-    glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
-    glBufferData(GL_ARRAY_BUFFER, m_vertices.size() * sizeof(Vertex), &m_vertices[0], GL_STATIC_DRAW);
-    
+
     // Load index data
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_EBO);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, m_indices.size() * sizeof(unsigned int), &m_indices[0], GL_STATIC_DRAW);
-    
-    // Vertex positions
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)0);
-    
-    // Vertex normals
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, normal));
-    
-    // Vertex texture coordinates
-    glEnableVertexAttribArray(2);
-    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, texCoords));
-    
-    // Vertex tangent
-    glEnableVertexAttribArray(3);
-    glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, tangent));
-    
-    // Vertex bitangent
-    glEnableVertexAttribArray(4);
-    glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, bitangent));
-    
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
+    if (m_hasBones) {
+        // Skinned layout (issue #260): AnimatedVertex keeps the same attributes 0-4
+        // as Vertex plus bone ids (5, integer attribute) and weights (6) for
+        // skinned_phong.vert's linear-blend skinning.
+        glBufferData(GL_ARRAY_BUFFER, m_animatedVertices.size() * sizeof(AnimatedVertex),
+                     &m_animatedVertices[0], GL_STATIC_DRAW);
+
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(AnimatedVertex),
+                              (void*)offsetof(AnimatedVertex, position));
+        glEnableVertexAttribArray(1);
+        glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(AnimatedVertex),
+                              (void*)offsetof(AnimatedVertex, normal));
+        glEnableVertexAttribArray(2);
+        glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(AnimatedVertex),
+                              (void*)offsetof(AnimatedVertex, texCoords));
+        glEnableVertexAttribArray(3);
+        glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(AnimatedVertex),
+                              (void*)offsetof(AnimatedVertex, tangent));
+        glEnableVertexAttribArray(4);
+        glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(AnimatedVertex),
+                              (void*)offsetof(AnimatedVertex, bitangent));
+        glEnableVertexAttribArray(5);
+        glVertexAttribIPointer(5, MAX_BONE_INFLUENCE, GL_INT, sizeof(AnimatedVertex),
+                               (void*)offsetof(AnimatedVertex, boneIDs));
+        glEnableVertexAttribArray(6);
+        glVertexAttribPointer(6, MAX_BONE_INFLUENCE, GL_FLOAT, GL_FALSE, sizeof(AnimatedVertex),
+                              (void*)offsetof(AnimatedVertex, weights));
+    } else {
+        glBufferData(GL_ARRAY_BUFFER, m_vertices.size() * sizeof(Vertex), &m_vertices[0], GL_STATIC_DRAW);
+
+        // Vertex positions
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)0);
+
+        // Vertex normals
+        glEnableVertexAttribArray(1);
+        glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, normal));
+
+        // Vertex texture coordinates
+        glEnableVertexAttribArray(2);
+        glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, texCoords));
+
+        // Vertex tangent
+        glEnableVertexAttribArray(3);
+        glVertexAttribPointer(3, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, tangent));
+
+        // Vertex bitangent
+        glEnableVertexAttribArray(4);
+        glVertexAttribPointer(4, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, bitangent));
+    }
+
     glBindVertexArray(0);
     m_isSetup = true;
 }
 
 void Mesh::calculateBoundingBox() {
+    if (m_hasBones) {
+        if (m_animatedVertices.empty()) {
+            m_boundingBox = BoundingBox();
+            return;
+        }
+        glm::vec3 minPoint = m_animatedVertices[0].position;
+        glm::vec3 maxPoint = m_animatedVertices[0].position;
+        for (const auto& vertex : m_animatedVertices) {
+            minPoint = glm::min(minPoint, vertex.position);
+            maxPoint = glm::max(maxPoint, vertex.position);
+        }
+        m_boundingBox = BoundingBox(minPoint, maxPoint);
+        return;
+    }
+
     if (m_vertices.empty()) {
         m_boundingBox = BoundingBox();
         return;
     }
-    
+
     // Initialize with first vertex
     glm::vec3 minPoint = m_vertices[0].position;
     glm::vec3 maxPoint = m_vertices[0].position;
-    
+
     // Find min and max coordinates
     for (const auto& vertex : m_vertices) {
         minPoint = glm::min(minPoint, vertex.position);
         maxPoint = glm::max(maxPoint, vertex.position);
     }
-    
+
     m_boundingBox = BoundingBox(minPoint, maxPoint);
 }
 
@@ -304,17 +363,21 @@ std::unique_ptr<Mesh> Model::processMesh(aiMesh* mesh, const aiScene* scene) {
         
         // Extract bone data
         extractBoneWeightForVertices(animatedVertices, mesh, scene);
-        
-        // Flatten animated vertices to static Vertex for now; a dedicated AnimatedMesh
-        // that preserves bone IDs/weights for GPU skinning is tracked in #260.
-        for (const auto& animVertex : animatedVertices) {
-            Vertex vertex;
-            vertex.position = animVertex.position;
-            vertex.normal = animVertex.normal;
-            vertex.texCoords = animVertex.texCoords;
-            vertex.tangent = animVertex.tangent;
-            vertex.bitangent = animVertex.bitangent;
-            vertices.push_back(vertex);
+
+        // Keep the bone-carrying vertices intact for GPU skinning (issue #260) and
+        // normalize each vertex's influence weights to sum to 1, mirroring the
+        // unit-tested render::skin::normalizeInfluenceWeights.
+        for (auto& animVertex : animatedVertices) {
+            float sum = 0.0f;
+            for (int w = 0; w < MAX_BONE_INFLUENCE; ++w) {
+                if (animVertex.weights[w] > 0.0f) sum += animVertex.weights[w];
+                else animVertex.weights[w] = 0.0f;
+            }
+            if (sum <= 0.0f) {
+                animVertex.weights[0] = 1.0f;
+            } else {
+                for (int w = 0; w < MAX_BONE_INFLUENCE; ++w) animVertex.weights[w] /= sum;
+            }
         }
     } else {
         // Process regular vertices
@@ -375,7 +438,13 @@ std::unique_ptr<Mesh> Model::processMesh(aiMesh* mesh, const aiScene* scene) {
         aiMaterial* mat = scene->mMaterials[mesh->mMaterialIndex];
         material = loadMaterial(mat);
     }
-    
+
+    // Skinned meshes keep their bone ids/weights (issue #260); static meshes are
+    // unchanged.
+    if (hasBones) {
+        return std::make_unique<Mesh>(std::move(animatedVertices), std::move(indices),
+                                      std::move(material));
+    }
     return std::make_unique<Mesh>(std::move(vertices), std::move(indices), std::move(material));
 }
 

--- a/src/Model.h
+++ b/src/Model.h
@@ -63,18 +63,26 @@ struct Material {
 class Mesh {
 private:
     std::vector<Vertex> m_vertices;
+    // Skinned path (issue #260): bone-carrying vertices kept intact instead of
+    // being flattened to Vertex, so GPU skinning gets ids/weights.
+    std::vector<AnimatedVertex> m_animatedVertices;
+    bool m_hasBones = false;
     std::vector<unsigned int> m_indices;
     Material m_material;
     BoundingBox m_boundingBox;
-    
+
     GLuint m_VAO, m_VBO, m_EBO;
     bool m_isSetup;
-    
+
     void setupMesh();
     void calculateBoundingBox();
 
 public:
     Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices, Material material);
+    /// Skinned mesh (issue #260): keeps bone ids/weights and uploads them as
+    /// vertex attributes 5 (ivec4) and 6 (vec4) for skinned_phong.vert.
+    Mesh(std::vector<AnimatedVertex> animatedVertices, std::vector<unsigned int> indices,
+         Material material);
     ~Mesh();
     
     // Delete copy constructor and assignment operator
@@ -93,6 +101,10 @@ public:
     const Material& getMaterial() const { return m_material; }
     const BoundingBox& getBoundingBox() const { return m_boundingBox; }
     bool isSetup() const { return m_isSetup; }
+
+    // Skinned path (issue #260)
+    bool hasBones() const { return m_hasBones; }
+    const std::vector<AnimatedVertex>& getAnimatedVertices() const { return m_animatedVertices; }
 };
 
 class Model {

--- a/src/core/components/AnimationComponent.cpp
+++ b/src/core/components/AnimationComponent.cpp
@@ -3,6 +3,7 @@
 #include "TransformComponent.h"
 #include <algorithm>
 #include <cassert>
+#include <cctype>
 
 namespace IKore {
 
@@ -201,6 +202,9 @@ namespace IKore {
         m_currentState.finished = false;
         m_transition.active = false;
         m_triggeredEvents.clear();
+        // Re-prime root motion on the next play so no stale delta is emitted.
+        m_previousRootTime = -1.0f;
+        m_rootMotionDelta = glm::mat4(1.0f);
     }
 
     void AnimationComponent::pauseAnimation() {
@@ -496,12 +500,70 @@ namespace IKore {
         }
     }
 
-    void AnimationComponent::updateRootMotion(float deltaTime) {
-        // Root motion currently yields no delta; extracting the root-bone movement
-        // from the active animation is tracked in #260.
-        if (m_currentState.animation && m_currentState.playing) {
-            m_rootMotionDelta = glm::mat4(1.0f);
+    void AnimationComponent::updateRootMotion(float /*deltaTime*/) {
+        // Extract the root bone's per-frame movement from the active animation
+        // (issue #260). The translation semantics (including the loop-wrap step)
+        // mirror the unit-tested rootMotionTranslationDelta(+Looped) in
+        // src/render/Skinning.h.
+        m_rootMotionDelta = glm::mat4(1.0f);
+        if (!m_currentState.animation || !m_currentState.playing) {
+            return;
         }
+        Animation* animation = m_currentState.animation;
+        Bone* root = findRootMotionBone(animation);
+        if (!root) {
+            return;
+        }
+
+        const float currentTime = m_currentState.currentTime;
+
+        // Sample the root's local pose at the current time (restored last so the
+        // bone is left at the frame's pose for any later reader).
+        auto sampleAt = [&](float t) {
+            root->update(t);
+            return root->localTransform;
+        };
+
+        if (m_previousRootTime < 0.0f) {
+            // First sample after (re)start: prime, no delta this frame.
+            m_previousRootTransform = sampleAt(currentTime);
+            m_previousRootTime = currentTime;
+            return;
+        }
+
+        glm::mat4 current;
+        if (currentTime >= m_previousRootTime) {
+            // Within the same loop iteration: delta = current * previous^-1.
+            current = sampleAt(currentTime);
+            m_rootMotionDelta = current * glm::inverse(m_previousRootTransform);
+        } else {
+            // The clip wrapped: remainder to the clip end plus advance from the
+            // clip start (rootMotionTranslationDeltaLooped in matrix form).
+            const float endTime = std::max(0.0f, animation->duration - 1e-4f);
+            const glm::mat4 endPose = sampleAt(endTime);
+            const glm::mat4 startPose = sampleAt(0.0f);
+            current = sampleAt(currentTime);
+            m_rootMotionDelta = (current * glm::inverse(startPose)) *
+                                (endPose * glm::inverse(m_previousRootTransform));
+        }
+        m_previousRootTransform = current;
+        m_previousRootTime = currentTime;
+    }
+
+    Bone* AnimationComponent::findRootMotionBone(Animation* animation) {
+        if (!animation || animation->bones.empty()) return nullptr;
+        auto nameContains = [](const std::string& name, const char* needle) {
+            std::string lower = name;
+            std::transform(lower.begin(), lower.end(), lower.begin(),
+                           [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            return lower.find(needle) != std::string::npos;
+        };
+        for (Bone& bone : animation->bones) {
+            if (nameContains(bone.name, "root") || nameContains(bone.name, "hips")) {
+                return &bone;
+            }
+        }
+        return &animation->bones.front();
     }
 
     // Utility conversion methods

--- a/src/core/components/AnimationComponent.h
+++ b/src/core/components/AnimationComponent.h
@@ -180,6 +180,7 @@ namespace IKore {
         bool m_rootMotionEnabled = false;
         glm::mat4 m_rootMotionDelta = glm::mat4(1.0f);
         glm::mat4 m_previousRootTransform = glm::mat4(1.0f);
+        float m_previousRootTime = -1.0f; ///< sample time of the previous root pose; < 0 = unprimed
         
         // Animation events
         std::map<float, std::vector<std::string>> m_animationEvents;
@@ -198,7 +199,11 @@ namespace IKore {
                                float weight, std::vector<glm::mat4>& result);
         void processAnimationEvents(float previousTime, float currentTime);
         void updateRootMotion(float deltaTime);
-        
+
+        /// The bone whose track drives root motion: the first bone whose name
+        /// contains "root" or "hips" (case-insensitive), else the first bone.
+        Bone* findRootMotionBone(Animation* animation);
+
         // Utility methods
         glm::mat4 assimpToGlmMatrix(const aiMatrix4x4& from);
         glm::vec3 assimpToGlmVec3(const aiVector3D& vec);

--- a/src/render/Skinning.h
+++ b/src/render/Skinning.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include "core/Picking.h" // pick::Mat4 (column-major), ecs::Vec3
+
+#include <cmath>
+
+/**
+ * @file Skinning.h
+ * @brief Linear-blend skinning and root-motion delta math (issue #260).
+ *
+ * The headless, unit-testable core behind GPU skinning and root motion:
+ *
+ *   - skinPosition / skinDirection: classic linear-blend skinning - a vertex is
+ *     transformed by each influencing bone's palette matrix and the results are
+ *     blended by the bone weights. src/shaders/skinned_phong.vert mirrors this
+ *     line for line (positions with w = 1, directions with w = 0), including the
+ *     out-of-range-bone guard and the no-influence identity fallback.
+ *   - normalizeInfluenceWeights: loader-side cleanup so per-vertex weights sum to
+ *     one (Model.cpp mirrors it when importing bone weights).
+ *   - rootMotionTranslationDelta(+Looped): the per-frame root displacement
+ *     AnimationComponent::updateRootMotion extracts from the root bone's track,
+ *     including the loop-wrap step (end-of-clip remainder plus start-of-clip
+ *     advance).
+ *
+ * Matrices are column-major pick::Mat4 (glm-layout compatible), vectors the
+ * glm-free ecs::Vec3, so everything here runs without GL or glm. Header-only.
+ */
+namespace IKore {
+namespace render {
+
+namespace skin {
+using Vec3 = ecs::Vec3;
+using Mat4 = pick::Mat4;
+
+/// Affine transform of a point (w = 1) by a column-major matrix.
+inline Vec3 transformPoint(const Mat4& m, const Vec3& p) {
+    return Vec3{m.m[0] * p.x + m.m[4] * p.y + m.m[8] * p.z + m.m[12],
+                m.m[1] * p.x + m.m[5] * p.y + m.m[9] * p.z + m.m[13],
+                m.m[2] * p.x + m.m[6] * p.y + m.m[10] * p.z + m.m[14]};
+}
+
+/// Transform of a direction (w = 0): rotation/scale only, no translation.
+inline Vec3 transformDirection(const Mat4& m, const Vec3& d) {
+    return Vec3{m.m[0] * d.x + m.m[4] * d.y + m.m[8] * d.z,
+                m.m[1] * d.x + m.m[5] * d.y + m.m[9] * d.z,
+                m.m[2] * d.x + m.m[6] * d.y + m.m[10] * d.z};
+}
+
+inline constexpr int kMaxInfluences = 4;
+
+/**
+ * @brief Normalize a vertex's 4 influence weights in place so they sum to 1.
+ *        A vertex with no positive weight gets full weight on its first slot,
+ *        so an unskinned vertex still binds rigidly instead of collapsing.
+ */
+inline void normalizeInfluenceWeights(float weights[kMaxInfluences]) {
+    float sum = 0.0f;
+    for (int i = 0; i < kMaxInfluences; ++i) {
+        if (weights[i] > 0.0f) sum += weights[i];
+        else weights[i] = 0.0f;
+    }
+    if (sum <= 0.0f) {
+        weights[0] = 1.0f;
+        return;
+    }
+    for (int i = 0; i < kMaxInfluences; ++i) weights[i] /= sum;
+}
+
+/**
+ * @brief Linear-blend skin a position: sum of weight * (palette[bone] * position)
+ *        over the vertex's influences. Bones outside [0, paletteCount) are
+ *        skipped (the shader guards identically); if no influence applies, the
+ *        vertex stays rigid (identity), matching the shader's fallback.
+ */
+inline Vec3 skinPosition(const Mat4* palette, int paletteCount,
+                         const int boneIds[kMaxInfluences],
+                         const float weights[kMaxInfluences], const Vec3& position) {
+    Vec3 out{0.0f, 0.0f, 0.0f};
+    float applied = 0.0f;
+    for (int i = 0; i < kMaxInfluences; ++i) {
+        const int id = boneIds[i];
+        if (id < 0 || id >= paletteCount || weights[i] <= 0.0f) continue;
+        out += transformPoint(palette[id], position) * weights[i];
+        applied += weights[i];
+    }
+    if (applied <= 0.0f) return position; // rigid fallback
+    return out;
+}
+
+/// Linear-blend skin a direction (normal/tangent); normalized like the shader.
+inline Vec3 skinDirection(const Mat4* palette, int paletteCount,
+                          const int boneIds[kMaxInfluences],
+                          const float weights[kMaxInfluences], const Vec3& direction) {
+    Vec3 out{0.0f, 0.0f, 0.0f};
+    float applied = 0.0f;
+    for (int i = 0; i < kMaxInfluences; ++i) {
+        const int id = boneIds[i];
+        if (id < 0 || id >= paletteCount || weights[i] <= 0.0f) continue;
+        out += transformDirection(palette[id], direction) * weights[i];
+        applied += weights[i];
+    }
+    if (applied <= 0.0f) return direction.normalized();
+    return out.normalized();
+}
+
+/**
+ * @brief Root displacement between two samples of the root bone's translation
+ *        track within the same loop iteration.
+ */
+inline Vec3 rootMotionTranslationDelta(const Vec3& previous, const Vec3& current) {
+    return current - previous;
+}
+
+/**
+ * @brief Root displacement across a loop wrap: the remainder of the clip after
+ *        the previous sample (end - previous) plus the advance into the new
+ *        iteration (current - start). With this, a walking loop keeps moving
+ *        forward smoothly instead of snapping back on wrap.
+ */
+inline Vec3 rootMotionTranslationDeltaLooped(const Vec3& previous, const Vec3& current,
+                                             const Vec3& clipStart, const Vec3& clipEnd) {
+    return (clipEnd - previous) + (current - clipStart);
+}
+
+} // namespace skin
+} // namespace render
+} // namespace IKore

--- a/src/shaders/skinned_phong.vert
+++ b/src/shaders/skinned_phong.vert
@@ -1,0 +1,64 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec3 aNormal;
+layout (location = 2) in vec2 aTexCoord;
+layout (location = 3) in vec3 aTangent;
+layout (location = 5) in ivec4 aBoneIds;
+layout (location = 6) in vec4 aWeights;
+
+out vec3 FragPos;
+out vec3 Normal;
+out vec2 TexCoord;
+out vec4 FragPosLightSpace;
+out mat3 TBN;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+uniform mat3 normalMatrix;
+uniform mat4 lightSpaceMatrix;
+
+const int MAX_BONES = 100;
+uniform mat4 finalBonesMatrices[MAX_BONES];
+
+// GPU linear-blend skinning (issue #260). Mirrors skinPosition/skinDirection in
+// src/render/Skinning.h, which is unit-tested: each influencing bone transforms
+// the vertex and the results blend by weight; out-of-range bone ids are skipped
+// and a vertex with no applicable influence stays rigid. The varying interface
+// matches phong_shadows.vert, so this pairs with phong_shadows.frag unchanged.
+void main() {
+    vec4 skinnedPos = vec4(0.0);
+    vec3 skinnedNormal = vec3(0.0);
+    vec3 skinnedTangent = vec3(0.0);
+    float applied = 0.0;
+
+    for (int i = 0; i < 4; ++i) {
+        int id = aBoneIds[i];
+        if (id < 0 || id >= MAX_BONES || aWeights[i] <= 0.0) continue;
+        mat4 boneMatrix = finalBonesMatrices[id];
+        skinnedPos += (boneMatrix * vec4(aPos, 1.0)) * aWeights[i];
+        skinnedNormal += mat3(boneMatrix) * aNormal * aWeights[i];
+        skinnedTangent += mat3(boneMatrix) * aTangent * aWeights[i];
+        applied += aWeights[i];
+    }
+    if (applied <= 0.0) {
+        // Rigid fallback: no influences bound (matches the core's behavior).
+        skinnedPos = vec4(aPos, 1.0);
+        skinnedNormal = aNormal;
+        skinnedTangent = aTangent;
+    }
+
+    FragPos = vec3(model * skinnedPos);
+    Normal = normalMatrix * skinnedNormal;
+    TexCoord = aTexCoord;
+
+    // TBN for normal mapping (issue #238), built from the skinned tangent.
+    vec3 N = normalize(Normal);
+    vec3 T = normalize(normalMatrix * skinnedTangent);
+    T = normalize(T - dot(T, N) * N);
+    vec3 B = cross(N, T);
+    TBN = mat3(T, B, N);
+
+    FragPosLightSpace = lightSpaceMatrix * vec4(FragPos, 1.0);
+    gl_Position = projection * view * vec4(FragPos, 1.0);
+}

--- a/tests/test_skinning.cpp
+++ b/tests/test_skinning.cpp
@@ -1,0 +1,169 @@
+// Test for linear-blend skinning + root-motion math - issue #260.
+//
+// src/shaders/skinned_phong.vert mirrors skinPosition/skinDirection (same guard
+// and fallback semantics), Model.cpp mirrors normalizeInfluenceWeights when
+// importing bone weights, and AnimationComponent::updateRootMotion applies the
+// rootMotionTranslationDelta(+Looped) math - so this suite verifies the skinning
+// pipeline's correctness-critical math headlessly.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_skinning.cpp -o test_skinning
+
+#include "render/Skinning.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore::render::skin;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-5f) { return std::fabs(a - b) < eps; }
+static bool approxVec(const Vec3& a, const Vec3& b, float eps = 1e-5f) {
+    return approx(a.x, b.x, eps) && approx(a.y, b.y, eps) && approx(a.z, b.z, eps);
+}
+
+static Mat4 translation(float x, float y, float z) {
+    Mat4 m = Mat4::identity();
+    m.m[12] = x;
+    m.m[13] = y;
+    m.m[14] = z;
+    return m;
+}
+
+// 90-degree rotation about +Z, column-major.
+static Mat4 rotationZ90() {
+    Mat4 m = Mat4::identity();
+    m.m[0] = 0.0f; m.m[1] = 1.0f;
+    m.m[4] = -1.0f; m.m[5] = 0.0f;
+    return m;
+}
+
+static void testTransformHelpers() {
+    const Mat4 t = translation(1, 2, 3);
+    CHECK(approxVec(transformPoint(t, Vec3{1, 1, 1}), Vec3{2, 3, 4}));
+    // Directions ignore translation.
+    CHECK(approxVec(transformDirection(t, Vec3{1, 1, 1}), Vec3{1, 1, 1}));
+
+    const Mat4 r = rotationZ90();
+    CHECK(approxVec(transformPoint(r, Vec3{1, 0, 0}), Vec3{0, 1, 0}));
+    CHECK(approxVec(transformDirection(r, Vec3{0, 1, 0}), Vec3{-1, 0, 0}));
+}
+
+static void testNormalizeWeights() {
+    float w1[4] = {2.0f, 2.0f, 0.0f, 0.0f};
+    normalizeInfluenceWeights(w1);
+    CHECK(approx(w1[0], 0.5f) && approx(w1[1], 0.5f) && approx(w1[2], 0.0f));
+
+    // Negative garbage is zeroed before normalization.
+    float w2[4] = {3.0f, -1.0f, 1.0f, 0.0f};
+    normalizeInfluenceWeights(w2);
+    CHECK(approx(w2[0], 0.75f) && approx(w2[1], 0.0f) && approx(w2[2], 0.25f));
+
+    // No influences at all -> rigid bind to slot 0.
+    float w3[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    normalizeInfluenceWeights(w3);
+    CHECK(approx(w3[0], 1.0f) && approx(w3[1], 0.0f));
+}
+
+static void testSkinPosition() {
+    const Mat4 palette[2] = {translation(1, 0, 0), translation(0, 2, 0)};
+    const Vec3 p{0, 0, 0};
+
+    // Single full-weight bone.
+    {
+        const int ids[4] = {0, -1, -1, -1};
+        const float w[4] = {1, 0, 0, 0};
+        CHECK(approxVec(skinPosition(palette, 2, ids, w, p), Vec3{1, 0, 0}));
+    }
+    // 50/50 blend of two translations.
+    {
+        const int ids[4] = {0, 1, -1, -1};
+        const float w[4] = {0.5f, 0.5f, 0, 0};
+        CHECK(approxVec(skinPosition(palette, 2, ids, w, p), Vec3{0.5f, 1.0f, 0.0f}));
+    }
+    // Out-of-range bone ids are skipped; the valid one still applies fully.
+    {
+        const int ids[4] = {7, 0, -1, -1};
+        const float w[4] = {0.5f, 0.5f, 0, 0};
+        CHECK(approxVec(skinPosition(palette, 2, ids, w, p), Vec3{0.5f, 0, 0}));
+    }
+    // No applicable influence -> rigid fallback (vertex unchanged).
+    {
+        const int ids[4] = {-1, -1, -1, -1};
+        const float w[4] = {0, 0, 0, 0};
+        CHECK(approxVec(skinPosition(palette, 2, ids, w, Vec3{3, 4, 5}), Vec3{3, 4, 5}));
+    }
+}
+
+static void testSkinDirection() {
+    const Mat4 palette[2] = {rotationZ90(), translation(9, 9, 9)};
+    const int ids[4] = {0, -1, -1, -1};
+    const float w[4] = {1, 0, 0, 0};
+    // Rotated, unit length.
+    CHECK(approxVec(skinDirection(palette, 2, ids, w, Vec3{1, 0, 0}), Vec3{0, 1, 0}));
+
+    // A pure-translation bone leaves a direction unchanged (w = 0 transform).
+    const int ids2[4] = {1, -1, -1, -1};
+    CHECK(approxVec(skinDirection(palette, 2, ids2, w, Vec3{0, 0, 1}), Vec3{0, 0, 1}));
+
+    // Blended directions come back normalized.
+    const int ids3[4] = {0, 1, -1, -1};
+    const float w3[4] = {0.5f, 0.5f, 0, 0};
+    const Vec3 blended = skinDirection(palette, 2, ids3, w3, Vec3{1, 0, 0});
+    CHECK(approx(blended.length(), 1.0f, 1e-4f));
+
+    // No influences -> the original direction, normalized.
+    const int none[4] = {-1, -1, -1, -1};
+    CHECK(approxVec(skinDirection(palette, 2, none, w, Vec3{0, 3, 0}), Vec3{0, 1, 0}));
+}
+
+static void testRootMotionDelta() {
+    // Within one loop iteration: plain difference.
+    CHECK(approxVec(rootMotionTranslationDelta(Vec3{1, 0, 0}, Vec3{1.5f, 0, 0}),
+                    Vec3{0.5f, 0, 0}));
+
+    // Across a wrap: remainder to the clip end plus advance from the clip start.
+    // Clip moves from x=0 to x=2; previous sample was at 1.8, current (wrapped) 0.3.
+    const Vec3 delta = rootMotionTranslationDeltaLooped(
+        Vec3{1.8f, 0, 0}, Vec3{0.3f, 0, 0}, Vec3{0, 0, 0}, Vec3{2, 0, 0});
+    CHECK(approxVec(delta, Vec3{0.5f, 0, 0})); // (2-1.8) + (0.3-0)
+
+    // A stationary root yields zero delta both ways.
+    CHECK(approxVec(rootMotionTranslationDelta(Vec3{4, 5, 6}, Vec3{4, 5, 6}), Vec3{0, 0, 0}));
+    CHECK(approxVec(rootMotionTranslationDeltaLooped(Vec3{1, 1, 1}, Vec3{1, 1, 1},
+                                                     Vec3{1, 1, 1}, Vec3{1, 1, 1}),
+                    Vec3{0, 0, 0}));
+
+    // Sum over a whole walking loop equals the clip's total displacement:
+    // samples at 0.0 -> 0.7 -> 1.4 -> (wrap) 0.1 with clip [0, 2] along x.
+    Vec3 total{0, 0, 0};
+    total += rootMotionTranslationDelta(Vec3{0, 0, 0}, Vec3{0.7f, 0, 0});
+    total += rootMotionTranslationDelta(Vec3{0.7f, 0, 0}, Vec3{1.4f, 0, 0});
+    total += rootMotionTranslationDeltaLooped(Vec3{1.4f, 0, 0}, Vec3{0.1f, 0, 0},
+                                              Vec3{0, 0, 0}, Vec3{2, 0, 0});
+    CHECK(approxVec(total, Vec3{2.1f, 0, 0})); // one full clip (2) + 0.1 into the next
+}
+
+int main() {
+    testTransformHelpers();
+    testNormalizeWeights();
+    testSkinPosition();
+    testSkinDirection();
+    testRootMotionDelta();
+
+    if (g_failures == 0) {
+        std::printf("All skinning tests passed.\n");
+        return 0;
+    }
+    std::printf("%d skinning test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #260. Implements both halves - the skinned-mesh vertex path and real root-motion extraction - with the correctness-critical math in a headless, unit-tested core that the GLSL and component code mirror (the established pattern).

## Tested core

`src/render/Skinning.h` (glm-free, unit-tested):

- `skinPosition` / `skinDirection` - classic linear-blend skinning over a bone-matrix palette, including the out-of-range-bone guard and the rigid fallback for vertices with no applicable influence. `skinned_phong.vert` mirrors these line for line.
- `normalizeInfluenceWeights` - per-vertex weight cleanup (sum to 1; zero-weight vertices bind rigidly to slot 0). The model loader mirrors it at import.
- `rootMotionTranslationDelta(+Looped)` - the per-frame root displacement, including the loop-wrap step (clip-end remainder plus clip-start advance). A whole-walking-loop accumulation test proves the summed deltas equal the clip's total displacement plus the new-iteration advance - i.e. no snap-back on wrap.

## Skinned mesh vertex path (was: bone data flattened away)

- `Mesh` gains an `AnimatedVertex` constructor that **keeps bone ids/weights** and uploads them as vertex attributes **5 (ivec4, `glVertexAttribIPointer`)** and **6 (vec4)** alongside the standard 0-4 layout. Bounding boxes and move operations cover the new storage; `hasBones()` / `getAnimatedVertices()` expose it.
- `Model::processMesh` no longer flattens animated vertices to static `Vertex`: bone-carrying meshes construct the skinned `Mesh` directly, with influence weights normalized at import (mirroring the tested core). **Static meshes are unchanged.**
- New `src/shaders/skinned_phong.vert` (glslang-validated): GPU linear-blend skinning of position, normal, and tangent, with the **same varying interface as `phong_shadows.vert`** - so it pairs with the existing `phong_shadows.frag` and inherits lighting, shadows (#237), and normal mapping (#238) unchanged. The palette uniform is `mat4 finalBonesMatrices[100]`, fed from `AnimationComponent::getBoneTransforms()`:

```cpp
const auto& palette = animComponent->getBoneTransforms();
for (size_t i = 0; i < palette.size(); ++i)
    shader->setMat4("finalBonesMatrices[" + std::to_string(i) + "]", glm::value_ptr(palette[i]));
```

## Real root motion (was: identity delta)

`AnimationComponent::updateRootMotion` now:
- picks the root-motion bone (first bone whose name contains "root"/"hips", case-insensitive; else the first bone),
- primes on the first frame after (re)start (no spurious first-frame delta),
- emits `delta = current * previous^-1` within a loop iteration,
- composes the wrap step across loop boundaries exactly as the tested core's looped delta does (end-of-clip remainder x start-of-clip advance), sampling the clip end just inside the duration to stay clear of keyframe-boundary indexing,
- leaves the sampled bone at the frame's pose, and `stopAnimation()` re-primes so no stale delta leaks into the next play.

## Verification

- `tests/test_skinning.cpp` (transform helpers, weight normalization incl. negative-garbage and zero-sum cases, single/blended/out-of-range/no-influence skinning, direction normalization, root-motion deltas incl. the wrap and full-loop accumulation) passes under `-fsanitize=address,undefined` with `-Wall -Wextra -pedantic`; registered as `test_skinning` in CMake.
- `skinned_phong.vert` validates with glslangValidator 15.1.
- `Model.cpp` and `AnimationComponent.cpp` compile with **no new warnings** (`-Wall -Wextra -fsyntax-only`) against GL 4.6 headers, system glm, and system assimp (the warnings that do appear are pre-existing in untouched code).

## Acceptance criteria

- Skinned meshes retain bone weights through loading and animate: yes - the loader keeps `AnimatedVertex` end to end, the VAO carries ids/weights, and the validated skinning shader consumes them against the component's palette.
- Root motion produces a real per-frame delta from the animation: yes - sampled from the root bone's track with correct loop-wrap composition, semantics locked by the core tests.

## Notes

- Static (non-boned) meshes take the exact same code path as before - regression-safe by construction.
- The visual result (an animated skinned model deforming on screen) deserves an in-engine QA pass with a rigged asset; no GPU or animated asset exists here or in CI. The skinning math, weight import, wrap-safe root deltas, attribute layout, and shader are all verified headlessly as above.
- Follow-up opportunity (not a blocker): a `skinned_shadow_depth.vert` so skinned meshes also deform in the shadow-map pass.