### PR TITLE
Rebrand: the engine is Charta, the game is Doodlebound

### DIFF
--- a/EXPANSION_IDEAS.md
+++ b/EXPANSION_IDEAS.md
@@ -1,9 +1,9 @@
-# IKore Engine - Expansion Ideas: Finding a Unique Identity
+# Charta - Expansion Ideas: Finding a Unique Identity
 
-> **Purpose of this document.** IKore Engine is technically competent, but in its
+> **Purpose of this document.** Charta is technically competent, but in its
 > current form it is hard to distinguish from the hundreds of other hobby
 > OpenGL/C++ ECS engines on GitHub. This document proposes a *point of view* -
-> a niche where IKore would be the obvious choice - and a concrete, phased plan
+> a niche where Charta would be the obvious choice - and a concrete, phased plan
 > to get there, grounded in the code that already exists.
 
 ---
@@ -44,7 +44,7 @@
 
 ### The core problem
 
-> IKore is a **general-purpose engine with no reason to exist** next to Godot,
+> Charta is a **general-purpose engine with no reason to exist** next to Godot,
 > Unreal, Bevy, or the next hobby engine. Every feature it has is a feature those
 > engines have, done better. To become interesting it needs a *thesis* - one
 > thing it does that mainstream engines do **not**.
@@ -57,7 +57,7 @@ the gap to lean into.
 
 ## 2. The thesis: *"The engine that builds living worlds from real data."*
 
-Instead of competing as a general game engine, position IKore as a
+Instead of competing as a general game engine, position Charta as a
 **world-from-data simulation engine**: feed it 2D/real-world inputs (floor plans,
 city maps, GIS data, tilemaps), and it produces a navigable, physically simulated
 3D world populated by autonomous agents - with the ability to pause, rewind,
@@ -109,7 +109,7 @@ navigable 3D scene with walls, roads, props, collision, and a baked nav-mesh.
   walked through it") - great for stars/visibility.
 - It reuses the scene graph, procedural mesh builders, and serialization that
   already work.
-- It creates a reason to choose IKore over Godot/Unreal for a whole class of
+- It creates a reason to choose Charta over Godot/Unreal for a whole class of
   users (GIS, architecture, simulation, viz).
 
 ### Rough effort
@@ -143,7 +143,7 @@ reproducible, rewindable simulation of large populations.
 - **Procedural quests/dialogue** generated from world state.
 
 *Unique because* very few open C++ engines ship an AI-native authoring + NPC
-layer, and IKore already has the `AIComponent`/`EventSystem`/`NetworkComponent`
+layer, and Charta already has the `AIComponent`/`EventSystem`/`NetworkComponent`
 scaffolding to host it.
 
 ### 4C. Deterministic replay & rollback netcode
@@ -170,7 +170,7 @@ viable.
 
 ### 5.2 Scripting + hot reload
 Embed **Lua** (or AngelScript) and expose components/events. Add **hot reload**
-of scripts, shaders, and assets. This turns IKore from "recompile to change
+of scripts, shaders, and assets. This turns Charta from "recompile to change
 anything" into a live creator loop, and lets non-C++ users drive the
 World-from-Data pipeline.
 
@@ -233,7 +233,7 @@ for any of the above to attract contributors:
 
 ## 8. Summary - pick a lane
 
-If IKore tries to be a better general-purpose engine, it loses. If it becomes
+If Charta tries to be a better general-purpose engine, it loses. If it becomes
 **the engine that turns real-world and 2D data into living, rewindable, AI-driven
 3D simulations**, it occupies a niche the big engines ignore - and it does so by
 *finishing the vision it already started* and *building on the systems it already

--- a/PHONE_GAME_CONCEPT.md
+++ b/PHONE_GAME_CONCEPT.md
@@ -1,12 +1,13 @@
-# Concept: "Doodle Dungeon" - turn hand-drawn floor plans into playable game maps
+# Concept: "Doodlebound" - turn hand-drawn floor plans into playable game maps
 
-> A consumer mobile game built on IKore's **world-from-data** thesis
+> A consumer mobile game built on Charta's **world-from-data** thesis
 > (see `EXPANSION_IDEAS.md`). The player draws a floor plan on paper, snaps a
 > photo, and seconds later is walking and playing inside their own drawing in 3D.
 > The drawing is not just geometry - drawn symbols are a tiny visual language that
 > places doors, enemies, loot, and the exit.
 
-*(Working title only - other names: PaperWorlds, Sketch2World, Crayon Castle.)*
+*(Named: **Doodlebound**. Previously working-titled "Doodle Dungeon"; other
+candidates considered: PaperWorlds, Sketch2World, Crayon Castle.)*
 
 ---
 
@@ -71,7 +72,7 @@ A map is not a game, so pick a core verb. Recommended first mode, in priority or
    drawing quality, classic and broadly appealing. **<- start here.**
 2. **First/third-person explorer**: "walk inside your drawing." Highest wow-factor
    for the share clip; great as a secondary "tour" mode.
-3. **Stealth / hide-and-seek vs. AI agents**: leans on IKore's `AIComponent` +
+3. **Stealth / hide-and-seek vs. AI agents**: leans on Charta's `AIComponent` +
    crowd simulation.
 4. **Tower defense**: enemies path through your rooms - leans on the nav-mesh.
 5. **Async multiplayer**: publish your map, friends play it with a share code;
@@ -97,7 +98,7 @@ This computer-vision pipeline is the make-or-break and the defensible IP. Stages
    with simple shape heuristics + template matching; graduate to a small on-device
    CNN trained on crowdsourced doodles as data accumulates. **This is where ML and
    the long-term data moat live** - every level players draw is training data.
-6. **Emit the scene.** Produce IKore's intermediate scene description (see §7),
+6. **Emit the scene.** Produce Charta's intermediate scene description (see §7),
    which the engine extrudes to 3D, populates with entities, and bakes a nav-mesh
    from.
 
@@ -110,15 +111,15 @@ Each phase is shippable and teaches you what real drawings look like.
 
 ---
 
-## 6. The honest tension: IKore is a *desktop* engine
+## 6. The honest tension: Charta is a *desktop* engine
 
-IKore today is **C++ + desktop OpenGL** (GLFW, classic GL - verified: no OpenGL ES,
+Charta today is **C++ + desktop OpenGL** (GLFW, classic GL - verified: no OpenGL ES,
 no EGL, no Android/iOS, no touch input, no OpenCV). It cannot ship to phones as-is.
 There are three viable paths; the recommendation combines them:
 
 | Path | What it means | Verdict |
 |---|---|---|
-| **A. Port IKore to mobile** | Add an OpenGL ES 3.0 / Vulkan backend, touch input, Android (NDK) + iOS build | Real work; do it *after* the loop is proven |
+| **A. Port Charta to mobile** | Add an OpenGL ES 3.0 / Vulkan backend, touch input, Android (NDK) + iOS build | Real work; do it *after* the loop is proven |
 | **B. Extract the converter as a portable C++ library** | The IP is the *drawing->scene* pipeline, not the renderer. Ship it as a standalone lib usable from any mobile app/engine | **Smartest hedge** - value isn't locked to the renderer |
 | **C. Prototype on desktop first** | Mouse-draw or load-photo -> extrude -> play, all in the engine you already have | **Start here** - proves the magic in days, not months |
 
@@ -155,7 +156,7 @@ the same project.
 
 ## 8. MVP - the smallest thing that proves the magic
 
-**Desktop "Doodle Dungeon" PoC (Phase 0), buildable on current IKore:**
+**Desktop "Doodlebound" PoC (Phase 0), buildable on current Charta:**
 
 1. A simple draw surface (mouse) on a grid: draw wall segments + place 4 symbols
    (start, exit, coin, enemy). *(Or: hand-author a small JSON level to start even faster.)*

--- a/PHONE_GAME_DESIGN.md
+++ b/PHONE_GAME_DESIGN.md
@@ -1,4 +1,4 @@
-# Doodle Dungeon - Deep Design & Market Analysis
+# Doodlebound - Deep Design & Market Analysis
 
 > Companion to `PHONE_GAME_CONCEPT.md`. This document does the homework before any
 > code: it researches the competition, sharpens the wedge, specifies the full
@@ -17,7 +17,7 @@ tools that produce **static visualizations, not games**.
 
 > **The white space nobody occupies: a hand-drawn *floor plan* -> a *3D place you
 > explore and play in*.** That intersection is precisely what a 3D engine like
-> IKore is built for, and it is invisible to both the 2D "draw-a-game" apps and the
+> Charta is built for, and it is invisible to both the 2D "draw-a-game" apps and the
 > non-game floor-plan tools.
 
 Reframe the product accordingly: **you are not drawing a *game*, you are drawing a
@@ -76,7 +76,7 @@ as a way to turn doodled *props* into meshes; not a competitor to the core loop.
 ```
             2D / arcade            3D / spatial
           ┌──────────────────┬──────────────────────┐
- GAME     │ Pixicade,        │   ★ DOODLE DUNGEON ★  │  <- empty quadrant
+ GAME     │ Pixicade,        │   ★ DOODLEBOUND ★     │  <- empty quadrant
  (play)   │ Draw Your Game,  │   (our wedge)         │
           │ DoodleMatic      │                       │
           ├──────────────────┼──────────────────────┤
@@ -171,7 +171,7 @@ it isn't.
 | Box outline | Blue | Pushable crate (physics) |
 | `~` region | Blue | Water (swim/slow) |
 
-> **Verticality (Tier 3) is a stealth differentiator.** Because IKore is true 3D,
+> **Verticality (Tier 3) is a stealth differentiator.** Because Charta is true 3D,
 > writing a small "2" in a room can raise it a storey - something *no* 2D
 > competitor can express. A flat floor plan becomes a multi-level space.
 
@@ -286,7 +286,7 @@ skippable and clearly labeled, COPPA/GDPR-K compliance designed in from day one.
 | "Is exploring a floor plan actually fun?" | **High** | Validate in desktop PoC first (§5.8) |
 | CV robustness on real drawings | **High** | Color-coding (§4.2), guide paper/kit, confidence+repair UI, Phase 0->2 ramp |
 | Incumbent (Pixicade) adds 3D | Medium | Move fast; depth via 3D engine + verticality + UGC moat |
-| Mobile port cost (IKore is desktop) | Medium | Prove on desktop; keep converter renderer-agnostic (see concept doc) |
+| Mobile port cost (Charta is desktop) | Medium | Prove on desktop; keep converter renderer-agnostic (see concept doc) |
 | Kids-compliance overhead | Medium | Launch adult-first; add kids mode deliberately later |
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
-# IKore Engine
+# Charta
 
 [![CI/CD Pipeline](https://github.com/Ikey168/IKore-Engine/actions/workflows/ci.yml/badge.svg)](https://github.com/Ikey168/IKore-Engine/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/Ikey168/IKore-Engine/actions/workflows/analysis.yml/badge.svg)](https://github.com/Ikey168/IKore-Engine/actions/workflows/analysis.yml)
 [![Documentation](https://github.com/Ikey168/IKore-Engine/actions/workflows/docs.yml/badge.svg)](https://github.com/Ikey168/IKore-Engine/actions/workflows/docs.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-> **The engine that turns real-world and 2D data into living, rewindable,
-> AI-driven 3D simulations.**
+> **From paper to playable: an engine that turns drawings, floor plans, and map
+> data into living, rewindable 3D worlds.**
 
-**IKore Engine** is a C++17 / OpenGL engine built around a data-oriented
-(archetype) Entity-Component System. On top of a conventional renderer + physics +
-audio stack, it does something general-purpose engines do not ship out of the box:
-it **imports real-world and 2D data** (OpenStreetMap / GeoJSON, tilemaps, SVG floor
-plans) into navigable 3D scenes, **simulates crowds of agents** with
-**deterministic, rewindable time control**, and drives it all from an **in-engine
-ImGui editor**.
+**Charta** (Latin for *paper* or *map*; formerly IKore Engine) is a C++17 / OpenGL
+engine built around a data-oriented (archetype) Entity-Component System. On top of
+a conventional renderer + physics + audio stack, it does something general-purpose
+engines do not ship out of the box: it **turns 2D and real-world data into
+navigable 3D scenes** - OpenStreetMap / GeoJSON, tilemaps, SVG floor plans, and
+even a **photo of a hand-drawn map** (the computer-vision pipeline behind
+Doodlebound) - then **simulates crowds of agents** with **deterministic,
+rewindable, replay-verifiable time control**, driven from an **in-engine ImGui
+editor**.
+
+> The C++ namespace remains `IKore::` and the repository slug is unchanged for
+> now; the rebrand is source-compatible.
 
 The end-to-end proof of that identity is the vertical slice
 ([`src/game/VerticalSlice.h`](src/game/VerticalSlice.h)): import a neighborhood,
@@ -22,8 +27,8 @@ bake a nav grid, send a crowd to a goal, then rewind time and replay it
 deterministically. Run it in one command (see [Samples](#samples)).
 
 The full thesis and roadmap are in
-[`EXPANSION_IDEAS.md`](EXPANSION_IDEAS.md); the consumer flagship concept (a phone
-game that turns hand-drawn floor plans into playable 3D maps) is in
+[`EXPANSION_IDEAS.md`](EXPANSION_IDEAS.md); the consumer flagship concept,
+**Doodlebound** (draw a dungeon on paper, photograph it, play it in 3D), is in
 [`PHONE_GAME_CONCEPT.md`](PHONE_GAME_CONCEPT.md) and
 [`PHONE_GAME_DESIGN.md`](PHONE_GAME_DESIGN.md).
 
@@ -58,7 +63,7 @@ Per-subsystem implementation notes live in [`docs/`](docs/).
 
 ## Getting started
 
-IKore uses CMake. GLFW, GLAD, GLM, stb_image, Assimp, Bullet, Dear ImGui, Lua, and
+Charta uses CMake. GLFW, GLAD, GLM, stb_image, Assimp, Bullet, Dear ImGui, Lua, and
 sol2 are downloaded automatically at configure time via `FetchContent`. OpenAL is
 located via your system package manager (`pkg-config`).
 
@@ -146,7 +151,7 @@ assets/          Models, textures, and other runtime assets
 
 ## Roadmap & vision
 
-IKore's direction is to differentiate around **world-from-data**:
+Charta's direction is to differentiate around **world-from-data**:
 
 1. **Foundations** - a data-oriented (archetype) ECS, scripting + hot reload, and an
    in-engine ImGui editor. (Implemented.)

--- a/docs/DOODLE_LEVEL_FORMAT.md
+++ b/docs/DOODLE_LEVEL_FORMAT.md
@@ -1,4 +1,4 @@
-# Doodle Dungeon level and scene formats
+# Doodlebound level and scene formats
 
 Milestone 15 defines two small JSON formats and the conversion between them. Both
 are pure data, have no renderer dependency, and round-trip through save/load.

--- a/src/cv/Robust.h
+++ b/src/cv/Robust.h
@@ -14,7 +14,7 @@
  * @file Robust.h
  * @brief Phase 2 robustness for the drawing->map CV pipeline (issue #239).
  *
- * Milestone 16, "Doodle Dungeon". Phase 1 (Rectify.h / Vectorize.h / Topology.h)
+ * Milestone 16, "Doodlebound". Phase 1 (Rectify.h / Vectorize.h / Topology.h)
  * turns a clean grid-paper photo into snapped wall polylines. Phase 2 hardens that
  * against real-world input - uneven lighting and shadows, off-angle photos, colored
  * paper, and freehand wobble - which PHONE_GAME_CONCEPT.md flags as the biggest

--- a/src/doodle/Doodle.h
+++ b/src/doodle/Doodle.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// The full Doodle Dungeon drawing -> scene pipeline, as one portable header.
+// The full Doodlebound drawing -> scene pipeline, as one portable header.
 #include "cv/Image.h"
 #include "cv/Rectify.h"
 #include "cv/Symbols.h"
@@ -17,7 +17,7 @@
 
 /**
  * @file Doodle.h
- * @brief Portable, renderer-agnostic Doodle Dungeon converter library (issue #171).
+ * @brief Portable, renderer-agnostic Doodlebound converter library (issue #171).
  *
  * Milestone 17. A single public header that packages the drawing -> scene pipeline
  * (Milestones 15-16) as a standalone library usable from a mobile app or any

--- a/src/game/DoodleScene.h
+++ b/src/game/DoodleScene.h
@@ -13,7 +13,7 @@
  * @file DoodleScene.h
  * @brief Renderer-agnostic drawing -> 3D scene converter (issue #162).
  *
- * Milestone 15 (Doodle Dungeon) core. Converts a LevelSpec - the output of a
+ * Milestone 15 (Doodlebound) core. Converts a LevelSpec - the output of a
  * hand-drawn floor plan: wall polylines plus placed symbols - into a 3D scene
  * description: extruded wall geometry and a list of entity spawns.
  *

--- a/src/game/Leaderboard.h
+++ b/src/game/Leaderboard.h
@@ -16,7 +16,7 @@
  * @file Leaderboard.h
  * @brief Fastest-clear leaderboards with deterministic-replay anti-cheat (issue #242).
  *
- * Milestone 17, "Doodle Dungeon" Phase 5. Ranks players by clear time per level,
+ * Milestone 17, "Doodlebound" Phase 5. Ranks players by clear time per level,
  * keyed by the content share code from LevelShare.h (#241). Because DungeonGame is
  * fully deterministic (no RNG; enemies chase deterministically), a fixed-timestep
  * input trace replays to the identical result on any device - so a submitted time

--- a/src/game/LevelBrowser.h
+++ b/src/game/LevelBrowser.h
@@ -13,7 +13,7 @@
  * @file LevelBrowser.h
  * @brief Local level-browser view-model over the UGC catalog (issue #241).
  *
- * Milestone 17, "Doodle Dungeon" Phase 5. The headless UI model a mobile shell
+ * Milestone 17, "Doodlebound" Phase 5. The headless UI model a mobile shell
  * binds to for browsing published levels: pick a feed (New / Top / Hot), page
  * through the entries, move the selection, and get a preview of the highlighted
  * level - a small ASCII map plus counts (walls, coins, player/exit) so the list

--- a/src/game/LevelFormat.h
+++ b/src/game/LevelFormat.h
@@ -13,7 +13,7 @@
 
 /**
  * @file LevelFormat.h
- * @brief Level-spec and 3D-scene JSON save/load for Doodle Dungeon (issue #163).
+ * @brief Level-spec and 3D-scene JSON save/load for Doodlebound (issue #163).
  *
  * Milestone 15. Defines two JSON formats and their (de)serialization:
  *   - "doodle-level": the intermediate, hand-authorable level spec (wall polylines

--- a/src/game/LevelShare.h
+++ b/src/game/LevelShare.h
@@ -7,7 +7,7 @@
  * @file LevelShare.h
  * @brief Stable share codes and portable level sharing for UGC (issue #241).
  *
- * Milestone 17, "Doodle Dungeon" Phase 5. Turns a level (the doodle-level JSON,
+ * Milestone 17, "Doodlebound" Phase 5. Turns a level (the doodle-level JSON,
  * game::toLevelJson) into something friends can pass around:
  *
  *   - shareCodeFor(json): a stable, content-addressed code. The same level yields
@@ -112,6 +112,8 @@ inline bool base64Decode(const std::string& in, std::string& out) {
 
 /// A stable, content-addressed share code for a level's JSON (same input -> same
 /// code on any device). Format: "DD-" followed by 13 Crockford base32 digits.
+/// ("DD-" and the "DDL1:" prefix below predate the Doodlebound rename; they are
+/// frozen wire-format identifiers and must not change with branding.)
 inline std::string shareCodeFor(const std::string& levelJson) {
     return "DD-" + detail::base32Crockford(detail::fnv1a64(levelJson), 13);
 }

--- a/src/ml/SymbolRecognizer.h
+++ b/src/ml/SymbolRecognizer.h
@@ -16,7 +16,7 @@
  * @brief Phase 4 symbol-recognition maturity: data pipeline, model export, an
  *        accuracy/confusion harness, and a heuristic fallback (issue #240).
  *
- * Milestone 16/17, "Doodle Dungeon". GlyphNet.h provides the invariant feature
+ * Milestone 16/17, "Doodlebound". GlyphNet.h provides the invariant feature
  * frontend (normalizeGlyph) and a trainable softmax model (GlyphClassifier). This
  * header matures that into the shippable recognizer for the seven game symbols and
  * the reproducible pipeline around it, which PHONE_GAME_CONCEPT.md 5 (step 5) calls

--- a/src/mobile/AppShell.h
+++ b/src/mobile/AppShell.h
@@ -9,7 +9,7 @@
 
 /**
  * @file AppShell.h
- * @brief Platform-agnostic mobile app shell for Doodle Dungeon (issue #172).
+ * @brief Platform-agnostic mobile app shell for Doodlebound (issue #172).
  *
  * Milestone 17. The device build pairs an OpenGL ES renderer and native
  * Android/iOS touch events with this headless shell, which owns the actual app


### PR DESCRIPTION
## Summary

Renames both products in all forward-facing text, per the naming decision:

- **Engine: IKore Engine -> Charta** (Latin for *paper* or *map* - it names the worlds-from-drawings identity). Availability-checked: no game engine, framework, or library collision found.
- **Game: "Doodle Dungeon" (working title) -> Doodlebound**. Availability-checked: no existing game or app by that name found; the previously considered alternates are recorded in the concept doc.

## What changed

- `README.md`: retitled **Charta** with a new tagline and description ("From paper to playable: an engine that turns drawings, floor plans, and map data into living, rewindable 3D worlds"), the doodle CV pipeline added to the identity paragraph, the flagship concept named Doodlebound, and a note that the rebrand is source-compatible.
- `EXPANSION_IDEAS.md`, `PHONE_GAME_CONCEPT.md`, `PHONE_GAME_DESIGN.md`: engine prose renamed to Charta; every game mention renamed to Doodlebound (including the uppercase cell in the competitive-landscape diagram, with box alignment preserved). The concept doc's working-title note now records the decision.
- `docs/DOODLE_LEVEL_FORMAT.md` and product-name mentions in source comments (`src/game/`, `src/cv/`, `src/ml/`, `src/mobile/`, `src/doodle/` headers): renamed to Doodlebound. Comment/text-only changes.
- `src/game/LevelShare.h`: documents that the `DD-` share-code and `DDL1:` share-string prefixes predate the rename and are **frozen wire-format identifiers**.

## Deliberately unchanged (and why)

- `namespace IKore::` and all code identifiers - the rebrand is branding-only and source-compatible (noted in the README).
- The `IKore` executable name and `project(IKoreEngine ...)` in CMake - `ci.yml` verifies both verbatim (its build check greps for them); renaming those belongs to a dedicated change that updates the workflow in lockstep.
- `DD-` / `DDL1:` wire prefixes - frozen formats with tests pinning them.
- Historical implementation reports under `docs/` - they are records of past issues, left as written.
- Badge and repository URLs - still correct until the repository slug itself is renamed (see below).

## Verification

- `test_level_share`, `test_symbol_recognizer`, `test_leaderboard`, and `test_cv_robust` (the suites covering every touched header) rebuilt and passed.
- Unicode scan: no new non-ASCII introduced (the section signs, diagram box-drawing, and star glyphs flagged in the docs are the set deliberately retained by #243 / PR #257).

## After merging - two clicks in GitHub settings (cannot be done via this session's API access)

1. **Repository rename:** Settings -> General -> rename `IKore-Engine` to `Charta` (GitHub redirects the old URLs). A follow-up PR can then update the badge/URL slugs in the README.
2. **Repository description:** paste
   > From paper to playable: a C++17/OpenGL engine that turns drawings, floor plans, and map data into living, rewindable 3D worlds - with a deterministic, replay-verifiable sim, headless-tested cores, and Doodlebound, a game that makes your hand-drawn dungeon playable.