### PR TITLE
Wire cascaded shadow maps into the GPU shadow path (#265)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ set(ENGINE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Skybox.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ParticleSystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ShadowMap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/CascadedShadowMap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Frustum.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/InputComponent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ControllableEntities.cpp
@@ -772,6 +773,13 @@ add_executable(test_tone_mapping
 # (rendering P4 / #236) - header-only.
 add_executable(test_shadow_cascades
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_shadow_cascades.cpp
+)
+
+# Per-cascade light-matrix assembly: matrix algebra, slice fit, split monotonicity,
+# CPU/GPU cascade-selection agreement, count==1 degradation (rendering / #265) -
+# header-only, glm-free.
+add_executable(test_shadow_cascade_build
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_shadow_cascade_build.cpp
 )
 
 # PCF soft-shadow filtering math: tap sets / averaging / softness (rendering P4 /

--- a/src/CascadedShadowMap.cpp
+++ b/src/CascadedShadowMap.cpp
@@ -1,0 +1,152 @@
+#include "CascadedShadowMap.h"
+
+#include "core/Picking.h"          // pick::Mat4
+#include "render/ShadowCascadeBuild.h" // render::buildCascades, render::Cascade
+#include "core/Logger.h"
+
+#include <algorithm>
+
+namespace IKore {
+
+namespace {
+
+// glm::mat4 and pick::Mat4 are both column-major, 16 contiguous floats, so a light
+// matrix converts by copy in either direction with no transposition.
+pick::Mat4 toPick(const glm::mat4& g) {
+    pick::Mat4 r{};
+    const float* src = &g[0][0];
+    for (int i = 0; i < 16; ++i) r.m[i] = src[i];
+    return r;
+}
+
+glm::mat4 toGlm(const pick::Mat4& p) {
+    glm::mat4 g(1.0f);
+    float* dst = &g[0][0];
+    for (int i = 0; i < 16; ++i) dst[i] = p.m[i];
+    return g;
+}
+
+} // namespace
+
+CascadedShadowMap::CascadedShadowMap(int cascadeCount, int resolution)
+    : m_cascadeCount(std::clamp(cascadeCount, 1, kMaxCascades))
+    , m_resolution(resolution > 0 ? resolution : 2048) {}
+
+CascadedShadowMap::~CascadedShadowMap() {
+    cleanup();
+}
+
+bool CascadedShadowMap::initialize() {
+    if (m_initialized) {
+        return true;
+    }
+
+    glGenFramebuffers(1, &m_framebuffer);
+
+    glGenTextures(1, &m_depthArray);
+    glBindTexture(GL_TEXTURE_2D_ARRAY, m_depthArray);
+    glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_DEPTH_COMPONENT24,
+                 m_resolution, m_resolution, m_cascadeCount,
+                 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    // White border so samples outside a cascade's fitted box read as fully lit.
+    const float borderColor[] = {1.0f, 1.0f, 1.0f, 1.0f};
+    glTexParameterfv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_BORDER_COLOR, borderColor);
+
+    // Point the depth attachment at layer 0 just to validate completeness; the real
+    // per-cascade layer is selected in beginCascadePass().
+    glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
+    glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, m_depthArray, 0, 0);
+    glDrawBuffer(GL_NONE);
+    glReadBuffer(GL_NONE);
+
+    const bool complete = glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    if (!complete) {
+        LOG_ERROR("Cascaded shadow map framebuffer not complete!");
+        cleanup();
+        return false;
+    }
+
+    m_lightMatrices.assign(static_cast<std::size_t>(m_cascadeCount), glm::mat4(1.0f));
+    m_splitDepths.assign(static_cast<std::size_t>(m_cascadeCount), 0.0f);
+
+    m_initialized = true;
+    LOG_INFO("CascadedShadowMap initialized (" + std::to_string(m_cascadeCount) +
+             " cascades, " + std::to_string(m_resolution) + "px)");
+    return true;
+}
+
+void CascadedShadowMap::computeCascades(const glm::mat4& cameraView, float fovYRadians, float aspect,
+                                        float nearZ, float farZ, const glm::vec3& lightDir,
+                                        float splitLambda) {
+    const ecs::Vec3 dir{lightDir.x, lightDir.y, lightDir.z};
+    const std::vector<render::Cascade> cascades =
+        render::buildCascades(toPick(cameraView), fovYRadians, aspect, nearZ, farZ, dir,
+                              m_cascadeCount, splitLambda);
+
+    m_lightMatrices.assign(static_cast<std::size_t>(m_cascadeCount), glm::mat4(1.0f));
+    m_splitDepths.assign(static_cast<std::size_t>(m_cascadeCount), farZ);
+    for (std::size_t i = 0; i < cascades.size() && i < static_cast<std::size_t>(m_cascadeCount); ++i) {
+        m_lightMatrices[i] = toGlm(cascades[i].lightMatrix);
+        m_splitDepths[i] = cascades[i].splitViewDepth;
+    }
+}
+
+void CascadedShadowMap::beginCascadePass(int index) {
+    if (!m_initialized) {
+        LOG_WARNING("beginCascadePass on uninitialized CascadedShadowMap");
+        return;
+    }
+    index = std::clamp(index, 0, m_cascadeCount - 1);
+
+    if (index == 0) {
+        glGetIntegerv(GL_VIEWPORT, m_previousViewport);
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, m_framebuffer);
+    glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, m_depthArray, 0, index);
+    glViewport(0, 0, m_resolution, m_resolution);
+    glClear(GL_DEPTH_BUFFER_BIT);
+
+    glEnable(GL_DEPTH_TEST);
+    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+    glEnable(GL_POLYGON_OFFSET_FILL);
+    glPolygonOffset(2.0f, 4.0f);
+}
+
+void CascadedShadowMap::endShadowPass() {
+    if (!m_initialized) {
+        return;
+    }
+    glDisable(GL_POLYGON_OFFSET_FILL);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glViewport(m_previousViewport[0], m_previousViewport[1],
+               m_previousViewport[2], m_previousViewport[3]);
+}
+
+void CascadedShadowMap::bindArray(int textureUnit) const {
+    if (!m_initialized) {
+        return;
+    }
+    glActiveTexture(GL_TEXTURE0 + textureUnit);
+    glBindTexture(GL_TEXTURE_2D_ARRAY, m_depthArray);
+}
+
+void CascadedShadowMap::cleanup() {
+    if (m_framebuffer != 0) {
+        glDeleteFramebuffers(1, &m_framebuffer);
+        m_framebuffer = 0;
+    }
+    if (m_depthArray != 0) {
+        glDeleteTextures(1, &m_depthArray);
+        m_depthArray = 0;
+    }
+    m_initialized = false;
+}
+
+} // namespace IKore

--- a/src/CascadedShadowMap.h
+++ b/src/CascadedShadowMap.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <glad/glad.h>
+#include <glm/glm.hpp>
+#include <vector>
+
+/**
+ * @file CascadedShadowMap.h
+ * @brief GPU-side cascaded shadow map for the directional light (issue #265).
+ *
+ * Wraps a GL_TEXTURE_2D_ARRAY depth texture (one layer per cascade), a single
+ * framebuffer whose depth attachment is re-pointed at each layer, and the per-frame
+ * light matrices produced by render::buildCascades (the tested, glm-free split/fit
+ * core in src/render/). The renderer runs one depth pass per cascade and then binds
+ * the whole array plus the light matrices and split depths for the lighting shader,
+ * which selects a cascade per fragment mirroring render::selectCascade.
+ *
+ * With cascadeCount == 1 this is a single tightly fitted directional map - the same
+ * shape the pre-CSM ShadowMap produced - so the single-cascade path stays available.
+ * All CPU split/fit math lives in the tested core; this class only owns GL objects
+ * and forwards results.
+ */
+namespace IKore {
+
+class CascadedShadowMap {
+public:
+    static const int kMaxCascades = 4;
+
+    explicit CascadedShadowMap(int cascadeCount = 4, int resolution = 2048);
+    ~CascadedShadowMap();
+
+    CascadedShadowMap(const CascadedShadowMap&) = delete;
+    CascadedShadowMap& operator=(const CascadedShadowMap&) = delete;
+
+    /// Allocate the depth texture array and framebuffer. Idempotent.
+    bool initialize();
+    bool isInitialized() const { return m_initialized; }
+
+    /**
+     * @brief Recompute the per-cascade light matrices and split depths for this frame.
+     * @param cameraView  Camera view matrix (world -> view).
+     * @param fovYRadians Camera vertical field of view, radians.
+     * @param aspect      Camera aspect ratio (width / height).
+     * @param nearZ,farZ  Camera near/far plane distances (view space).
+     * @param lightDir    Direction the directional light travels.
+     * @param splitLambda Split blend (0 uniform .. 1 logarithmic).
+     *
+     * Delegates entirely to render::buildCascades; no fitting math lives here.
+     */
+    void computeCascades(const glm::mat4& cameraView, float fovYRadians, float aspect,
+                         float nearZ, float farZ, const glm::vec3& lightDir, float splitLambda);
+
+    /// Bind the framebuffer and target cascade layer @p index for its depth pass.
+    void beginCascadePass(int index);
+    /// Restore the previous framebuffer/viewport after the last cascade pass.
+    void endShadowPass();
+
+    /// Bind the depth texture array for sampling in the lighting shader.
+    void bindArray(int textureUnit) const;
+
+    int cascadeCount() const { return m_cascadeCount; }
+    int resolution() const { return m_resolution; }
+    GLuint textureArray() const { return m_depthArray; }
+
+    /// The light matrix for each cascade (size == cascadeCount), for shader upload.
+    const std::vector<glm::mat4>& lightMatrices() const { return m_lightMatrices; }
+    /// The far view-depth boundary of each cascade (size == cascadeCount).
+    const std::vector<float>& splitDepths() const { return m_splitDepths; }
+
+private:
+    void cleanup();
+
+    int m_cascadeCount;
+    int m_resolution;
+    bool m_initialized{false};
+
+    GLuint m_framebuffer{0};
+    GLuint m_depthArray{0};
+
+    std::vector<glm::mat4> m_lightMatrices;
+    std::vector<float> m_splitDepths;
+
+    GLint m_previousViewport[4]{0, 0, 0, 0};
+};
+
+} // namespace IKore

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
+#include <cmath>
+#include <string>
 #include <filesystem>
 #include <fstream>
 #include <thread>
@@ -22,6 +24,7 @@
 #include "Skybox.h"
 #include "ParticleSystem.h"
 #include "ShadowMap.h"
+#include "CascadedShadowMap.h"
 #include "Frustum.h"
 #include "render/FrameGraph.h"
 #include "core/Entity.h"
@@ -65,6 +68,14 @@ IKore::ParticleSystemManager* g_particleManager = nullptr;
 
 // Global shadow map manager for keyboard callbacks
 IKore::ShadowMapManager* g_shadowManager = nullptr;
+
+// Cascaded shadow maps for the directional light (issue #265). Opt-in: while
+// g_useCascadedShadows is false the directional light keeps the original single map
+// and the render is unchanged. Toggle with K; cycle the split lambda with J.
+IKore::CascadedShadowMap* g_cascadedShadowMap = nullptr;
+bool g_useCascadedShadows = false;
+float g_cascadeSplitLambda = 0.5f;   // 0 uniform .. 1 logarithmic split
+float g_cascadeBlendBand = 2.0f;     // view-depth width of the cross-cascade seam blend
 
 // Global frustum culler for rendering optimization
 IKore::FrustumCuller g_frustumCuller;
@@ -528,6 +539,17 @@ int main() {
     } else {
         LOG_INFO("Directional shadow map created successfully");
     }
+
+    // Cascaded shadow map for the directional light (issue #265). Additive and
+    // opt-in: it is only used while g_useCascadedShadows is true (toggle with K), so
+    // the default path stays the single directional map above.
+    IKore::CascadedShadowMap cascadedShadowMap(4 /* cascades */, 2048);
+    if (!cascadedShadowMap.initialize()) {
+        LOG_WARNING("Failed to create cascaded shadow map - CSM path will be unavailable");
+    } else {
+        g_cascadedShadowMap = &cascadedShadowMap;
+        LOG_INFO("Cascaded shadow map created successfully (press K to toggle)");
+    }
     
     // Create shadow map for point light
     auto* pointShadowMap = shadowManager.createPointShadowMap(1, 1024);
@@ -712,8 +734,32 @@ int main() {
             if (pointShadowMap) {
                 pointShadowMap->setPointLightMatrices(pointLight.position, 25.0f);
             }
-            // Render directional light shadow map
-            if (dirShadowMap && shadowShaderPtr) {
+            // Render directional light shadow map. When the CSM path is on, render
+            // one depth pass per cascade into the texture array; otherwise the
+            // original single directional pass (unchanged).
+            if (g_useCascadedShadows && g_cascadedShadowMap && shadowShaderPtr) {
+                // Recover the frustum parameters from this frame's projection so the
+                // cascade fit matches the camera exactly (works for either camera path).
+                const float p00 = projection[0][0];
+                const float p11 = projection[1][1];
+                const float p22 = projection[2][2];
+                const float p32 = projection[3][2];
+                const float fovY = 2.0f * std::atan(1.0f / p11);
+                const float aspect = p11 / p00;
+                const float nearZ = p32 / (p22 - 1.0f);
+                const float farZ = p32 / (p22 + 1.0f);
+
+                g_cascadedShadowMap->computeCascades(view, fovY, aspect, nearZ, farZ,
+                                                     dirLight.direction, g_cascadeSplitLambda);
+                shadowShaderPtr->use();
+                const auto& mats = g_cascadedShadowMap->lightMatrices();
+                for (int c = 0; c < g_cascadedShadowMap->cascadeCount(); ++c) {
+                    g_cascadedShadowMap->beginCascadePass(c);
+                    shadowShaderPtr->setMat4("lightSpaceMatrix", glm::value_ptr(mats[static_cast<std::size_t>(c)]));
+                    renderSceneObjects(shadowShaderPtr, VAO, modelLoaded, cubeModel, currentFrameTime);
+                }
+                g_cascadedShadowMap->endShadowPass();
+            } else if (dirShadowMap && shadowShaderPtr) {
                 dirShadowMap->beginShadowPass();
                 shadowShaderPtr->use();
                 glm::mat4 lightSpaceMatrix = dirShadowMap->getLightSpaceMatrix();
@@ -818,7 +864,31 @@ int main() {
             if (dirShadowMap) {
                 shaderPtr->setMat4("lightSpaceMatrix", glm::value_ptr(dirShadowMap->getLightSpaceMatrix()));
             }
-            
+
+            // Cascaded shadow map uniforms (issue #265). When off, the shader ignores
+            // all of these and takes the single-map path, so this is regression-safe.
+            if (g_useCascadedShadows && g_cascadedShadowMap) {
+                shaderPtr->setFloat("useCascades", 1.0f);
+                shaderPtr->setFloat("dirLight.castShadows", 1.0f);
+                const auto& mats = g_cascadedShadowMap->lightMatrices();
+                const auto& splits = g_cascadedShadowMap->splitDepths();
+                const int count = g_cascadedShadowMap->cascadeCount();
+                shaderPtr->setInt("dirCascadeCount", count);
+                for (int c = 0; c < count; ++c) {
+                    const std::string idx = std::to_string(c);
+                    shaderPtr->setMat4(("dirCascadeMatrices[" + idx + "]").c_str(),
+                                       glm::value_ptr(mats[static_cast<std::size_t>(c)]));
+                    shaderPtr->setFloat(("dirCascadeSplits[" + idx + "]").c_str(),
+                                        splits[static_cast<std::size_t>(c)]);
+                }
+                shaderPtr->setMat4("cascadeViewMatrix", glm::value_ptr(view));
+                shaderPtr->setFloat("cascadeBlendBand", g_cascadeBlendBand);
+                g_cascadedShadowMap->bindArray(14); // texture unit 14 for the cascade array
+                shaderPtr->setInt("dirCascadeMaps", 14);
+            } else {
+                shaderPtr->setFloat("useCascades", 0.0f);
+            }
+
             // Set point light
             shaderPtr->setFloat("numPointLights", 1.0f);
             shaderPtr->setVec3("pointLights[0].position", pointLight.position.x, pointLight.position.y, pointLight.position.z);
@@ -1208,6 +1278,20 @@ void key_callback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action,
             g_shadowManager->setShadowQuality(quality);
             std::string qualityName = qualityLevel == 0 ? "Low" : (qualityLevel == 1 ? "Medium" : "High");
             LOG_INFO("Shadow quality set to: " + qualityName);
+        }
+        else if (key == GLFW_KEY_K && g_cascadedShadowMap) {
+            // Toggle cascaded shadow maps for the directional light (issue #265).
+            g_useCascadedShadows = !g_useCascadedShadows;
+            LOG_INFO("Cascaded shadow maps " + std::string(g_useCascadedShadows ? "enabled" : "disabled") +
+                     " (" + std::to_string(g_cascadedShadowMap->cascadeCount()) + " cascades)");
+        }
+        else if (key == GLFW_KEY_J && g_cascadedShadowMap) {
+            // Cycle the cascade split lambda (uniform <-> logarithmic split blend).
+            static const float lambdas[] = {0.0f, 0.25f, 0.5f, 0.75f, 1.0f};
+            static int li = 2; // starts at 0.5
+            li = (li + 1) % 5;
+            g_cascadeSplitLambda = lambdas[li];
+            LOG_INFO("Cascade split lambda: " + std::to_string(g_cascadeSplitLambda));
         }
         else if (key == GLFW_KEY_C) {
             // Toggle frustum culling

--- a/src/render/ShadowCascadeBuild.h
+++ b/src/render/ShadowCascadeBuild.h
@@ -1,0 +1,205 @@
+#pragma once
+
+#include "core/Picking.h"          // pick::Mat4, pick::unproject, ecs::Vec3
+#include "render/ShadowCascades.h" // cascadeSplitDistances, frustumCornersWorld, lightSpaceBounds, orthoFromBounds
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+/**
+ * @file ShadowCascadeBuild.h
+ * @brief Per-cascade light-matrix assembly for the GPU shadow path (issue #265).
+ *
+ * ShadowCascades.h (#236) is the split/fit math: where to cut the view frustum and
+ * how to fit an orthographic box around one slice. What it does not do is assemble a
+ * ready-to-upload light matrix per cascade, because that needs the 4x4 matrix
+ * algebra (perspective, lookAt, multiply, inverse) that the engine normally gets
+ * from glm. This header supplies those operations on the glm-free, column-major
+ * pick::Mat4 so the whole build is unit-testable without glm or a GL context, then
+ * ties them together:
+ *
+ *   - mat::mul / perspective / lookAt / inverse: minimal column-major matrix algebra
+ *     matching glm's conventions (so glm::value_ptr output and these agree bit-for-
+ *     bit up to float rounding, and the results upload without transposition).
+ *   - buildCascades(): for each cascade, narrow the camera projection to that depth
+ *     slice, unproject its frustum corners to world space, fit a light-space box
+ *     (padded so occluders behind the slice still cast into it), and return the
+ *     per-cascade light matrix plus the view-space split depth the shader compares
+ *     against. Cascade selection uses render::selectCascade, so CPU and GPU agree.
+ *
+ * count == 1 degrades to a single fitted map covering [nearZ, farZ] - the same shape
+ * the pre-CSM directional map had - so the single-cascade path stays available.
+ * Header-only, std only.
+ */
+namespace IKore {
+namespace render {
+namespace mat {
+
+/// Column-major 4x4 multiply: result = a * b (glm convention, element (r,c) = m[c*4+r]).
+inline Mat4 mul(const Mat4& a, const Mat4& b) {
+    Mat4 r{};
+    for (int c = 0; c < 4; ++c) {
+        for (int row = 0; row < 4; ++row) {
+            float sum = 0.0f;
+            for (int k = 0; k < 4; ++k) {
+                sum += a.m[k * 4 + row] * b.m[c * 4 + k];
+            }
+            r.m[c * 4 + row] = sum;
+        }
+    }
+    return r;
+}
+
+/// Right-handed perspective projection, OpenGL NDC z in [-1, 1] (matches glm::perspective).
+inline Mat4 perspective(float fovyRad, float aspect, float nearZ, float farZ) {
+    const float f = 1.0f / std::tan(fovyRad * 0.5f);
+    const float safeAspect = std::fabs(aspect) > 1e-8f ? aspect : 1.0f;
+    Mat4 r{}; // zero-initialized
+    r.m[0] = f / safeAspect;
+    r.m[5] = f;
+    r.m[10] = (farZ + nearZ) / (nearZ - farZ);
+    r.m[11] = -1.0f;
+    r.m[14] = (2.0f * farZ * nearZ) / (nearZ - farZ);
+    return r;
+}
+
+/// Right-handed look-at view matrix (matches glm::lookAt).
+inline Mat4 lookAt(const Vec3& eye, const Vec3& center, const Vec3& up) {
+    const Vec3 f = (center - eye).normalized();
+    Vec3 s = Vec3{f.y * up.z - f.z * up.y, f.z * up.x - f.x * up.z, f.x * up.y - f.y * up.x};
+    s = s.normalized();
+    const Vec3 u = Vec3{s.y * f.z - s.z * f.y, s.z * f.x - s.x * f.z, s.x * f.y - s.y * f.x};
+
+    Mat4 r = Mat4::identity();
+    r.m[0] = s.x;  r.m[4] = s.y;  r.m[8] = s.z;
+    r.m[1] = u.x;  r.m[5] = u.y;  r.m[9] = u.z;
+    r.m[2] = -f.x; r.m[6] = -f.y; r.m[10] = -f.z;
+    r.m[12] = -(s.x * eye.x + s.y * eye.y + s.z * eye.z);
+    r.m[13] = -(u.x * eye.x + u.y * eye.y + u.z * eye.z);
+    r.m[14] = (f.x * eye.x + f.y * eye.y + f.z * eye.z);
+    return r;
+}
+
+/**
+ * @brief General 4x4 inverse (cofactor method). Returns identity if singular.
+ *
+ * Column-major in and out, so inverse(proj * view) here equals
+ * glm::inverse(proj * view) up to float rounding.
+ */
+inline Mat4 inverse(const Mat4& in) {
+    const float* m = in.m;
+    Mat4 out{};
+    float* inv = out.m;
+
+    inv[0] = m[5] * m[10] * m[15] - m[5] * m[11] * m[14] - m[9] * m[6] * m[15] +
+             m[9] * m[7] * m[14] + m[13] * m[6] * m[11] - m[13] * m[7] * m[10];
+    inv[4] = -m[4] * m[10] * m[15] + m[4] * m[11] * m[14] + m[8] * m[6] * m[15] -
+             m[8] * m[7] * m[14] - m[12] * m[6] * m[11] + m[12] * m[7] * m[10];
+    inv[8] = m[4] * m[9] * m[15] - m[4] * m[11] * m[13] - m[8] * m[5] * m[15] +
+             m[8] * m[7] * m[13] + m[12] * m[5] * m[11] - m[12] * m[7] * m[9];
+    inv[12] = -m[4] * m[9] * m[14] + m[4] * m[10] * m[13] + m[8] * m[5] * m[14] -
+              m[8] * m[6] * m[13] - m[12] * m[5] * m[10] + m[12] * m[6] * m[9];
+    inv[1] = -m[1] * m[10] * m[15] + m[1] * m[11] * m[14] + m[9] * m[2] * m[15] -
+             m[9] * m[3] * m[14] - m[13] * m[2] * m[11] + m[13] * m[3] * m[10];
+    inv[5] = m[0] * m[10] * m[15] - m[0] * m[11] * m[14] - m[8] * m[2] * m[15] +
+             m[8] * m[3] * m[14] + m[12] * m[2] * m[11] - m[12] * m[3] * m[10];
+    inv[9] = -m[0] * m[9] * m[15] + m[0] * m[11] * m[13] + m[8] * m[1] * m[15] -
+             m[8] * m[3] * m[13] - m[12] * m[1] * m[11] + m[12] * m[3] * m[9];
+    inv[13] = m[0] * m[9] * m[14] - m[0] * m[10] * m[13] - m[8] * m[1] * m[14] +
+              m[8] * m[2] * m[13] + m[12] * m[1] * m[10] - m[12] * m[2] * m[9];
+    inv[2] = m[1] * m[6] * m[15] - m[1] * m[7] * m[14] - m[5] * m[2] * m[15] +
+             m[5] * m[3] * m[14] + m[13] * m[2] * m[7] - m[13] * m[3] * m[6];
+    inv[6] = -m[0] * m[6] * m[15] + m[0] * m[7] * m[14] + m[4] * m[2] * m[15] -
+             m[4] * m[3] * m[14] - m[12] * m[2] * m[7] + m[12] * m[3] * m[6];
+    inv[10] = m[0] * m[5] * m[15] - m[0] * m[7] * m[13] - m[4] * m[1] * m[15] +
+              m[4] * m[3] * m[13] + m[12] * m[1] * m[7] - m[12] * m[3] * m[5];
+    inv[14] = -m[0] * m[5] * m[14] + m[0] * m[6] * m[13] + m[4] * m[1] * m[14] -
+              m[4] * m[2] * m[13] - m[12] * m[1] * m[6] + m[12] * m[2] * m[5];
+    inv[3] = -m[1] * m[6] * m[11] + m[1] * m[7] * m[10] + m[5] * m[2] * m[11] -
+             m[5] * m[3] * m[10] - m[9] * m[2] * m[7] + m[9] * m[3] * m[6];
+    inv[7] = m[0] * m[6] * m[11] - m[0] * m[7] * m[10] - m[4] * m[2] * m[11] +
+             m[4] * m[3] * m[10] + m[8] * m[2] * m[7] - m[8] * m[3] * m[6];
+    inv[11] = -m[0] * m[5] * m[11] + m[0] * m[7] * m[9] + m[4] * m[1] * m[11] -
+              m[4] * m[3] * m[9] - m[8] * m[1] * m[7] + m[8] * m[3] * m[5];
+    inv[15] = m[0] * m[5] * m[10] - m[0] * m[6] * m[9] - m[4] * m[1] * m[10] +
+              m[4] * m[2] * m[9] + m[8] * m[1] * m[6] - m[8] * m[2] * m[5];
+
+    float det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
+    if (std::fabs(det) < 1e-20f) return Mat4::identity();
+    det = 1.0f / det;
+    for (int i = 0; i < 16; ++i) inv[i] *= det;
+    return out;
+}
+
+} // namespace mat
+
+/// One cascade ready for the GPU: its light matrix and the view-depth split it owns.
+struct Cascade {
+    Mat4 lightMatrix{};       ///< ortho(light-space fit) * lightView; world -> cascade clip.
+    float splitViewDepth{0};  ///< far boundary of this cascade in positive view depth.
+};
+
+/**
+ * @brief Build the per-cascade light matrices and split depths for a directional light.
+ * @param camView   Camera view matrix (world -> view), column-major.
+ * @param fovyRad   Camera vertical field of view in radians.
+ * @param aspect    Camera aspect ratio (width / height).
+ * @param nearZ     Camera near-plane distance (> 0).
+ * @param farZ      Camera far-plane distance (> nearZ).
+ * @param lightDir  Direction the light travels (from light toward scene); need not be unit.
+ * @param count     Number of cascades (clamped to >= 1). count == 1 = single fitted map.
+ * @param lambda    Split blend passed to cascadeSplitDistances (0 uniform .. 1 log).
+ * @param zPadding  Extra light-space depth pulled back behind each slice so occluders
+ *                  outside the view frustum still cast shadows into it.
+ * @return count cascades, near-slice first. Empty only if inputs are degenerate.
+ *
+ * Cascade i covers view depth [splits[i], splits[i+1]] and its splitViewDepth is the
+ * far end splits[i+1] - the same value render::selectCascade compares a fragment's
+ * view depth against, so the shader picks the identical cascade the CPU fitted.
+ */
+inline std::vector<Cascade> buildCascades(const Mat4& camView, float fovyRad, float aspect,
+                                          float nearZ, float farZ, const Vec3& lightDir,
+                                          int count, float lambda, float zPadding = 10.0f) {
+    if (count < 1) count = 1;
+    std::vector<Cascade> cascades;
+    const Vec3 dir = lightDir.normalized();
+    if (dir.lengthSquared() < 1e-12f) return cascades; // no light direction to fit to
+
+    const std::vector<float> splits = cascadeSplitDistances(nearZ, farZ, count, lambda);
+
+    // A stable up vector: world up unless the light is (near) vertical, then use +Z.
+    const Vec3 worldUp = std::fabs(dir.y) > 0.999f ? Vec3{0.0f, 0.0f, 1.0f} : Vec3{0.0f, 1.0f, 0.0f};
+
+    cascades.reserve(static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        const float sliceNear = splits[static_cast<std::size_t>(i)];
+        const float sliceFar = splits[static_cast<std::size_t>(i) + 1u];
+
+        // World-space corners of just this depth slice of the camera frustum.
+        const Mat4 sliceProj = mat::perspective(fovyRad, aspect, sliceNear, sliceFar);
+        const Mat4 sliceViewProj = mat::mul(sliceProj, camView);
+        const std::array<Vec3, 8> corners = frustumCornersWorld(mat::inverse(sliceViewProj));
+
+        // Frustum centroid to anchor the light "camera".
+        Vec3 center{0.0f, 0.0f, 0.0f};
+        for (const Vec3& c : corners) center += c;
+        center *= (1.0f / 8.0f);
+
+        // Look at the slice from along the light direction; ortho fit handles distance.
+        const Mat4 lightView = mat::lookAt(center - dir, center, worldUp);
+
+        Aabb box = lightSpaceBounds(corners, lightView);
+        box.min.z -= zPadding; // pull the near plane back so off-frustum occluders cast in
+        box.max.z += zPadding;
+
+        Cascade cascade;
+        cascade.lightMatrix = mat::mul(orthoFromBounds(box), lightView);
+        cascade.splitViewDepth = sliceFar;
+        cascades.push_back(cascade);
+    }
+    return cascades;
+}
+
+} // namespace render
+} // namespace IKore

--- a/src/shaders/phong_shadows.frag
+++ b/src/shaders/phong_shadows.frag
@@ -85,6 +85,7 @@ struct SpotLight {
 
 #define MAX_POINT_LIGHTS 4
 #define MAX_SPOT_LIGHTS 4
+#define MAX_CASCADES 4
 
 uniform Material material;
 uniform DirectionalLight dirLight;
@@ -95,6 +96,21 @@ uniform int numSpotLights;
 uniform bool useDirLight;
 
 uniform vec3 viewPos;
+
+// Cascaded shadow maps for the directional light (issue #265). When useCascades is
+// false every one of these is ignored and the directional shadow takes the original
+// single-map path above, so the default render is byte-identical. When true, the
+// directional light samples dirCascadeMaps (one depth layer per cascade) using the
+// per-cascade matrices, selecting a cascade per fragment by view depth exactly as
+// render::selectCascade does on the CPU, with a cross-cascade blend band to hide the
+// resolution seam.
+uniform bool useCascades;
+uniform sampler2DArray dirCascadeMaps;         // one fitted depth layer per cascade
+uniform mat4 dirCascadeMatrices[MAX_CASCADES]; // world -> cascade clip, per cascade
+uniform float dirCascadeSplits[MAX_CASCADES];  // far view-depth boundary per cascade
+uniform int dirCascadeCount;
+uniform mat4 cascadeViewMatrix;                // camera view, for per-fragment view depth
+uniform float cascadeBlendBand;                // view-depth width of the seam blend (0 = off)
 
 // 16-tap Poisson disk mirroring poissonDiskOffsets() in src/render/ShadowFiltering.h
 // (issue #237). Sampling this instead of the box grid trades structured banding for
@@ -113,6 +129,10 @@ const vec2 poissonDisk[16] = vec2[](
 // Shadow mapping functions
 float ShadowCalculation(vec4 fragPosLightSpace, sampler2D shadowMap, float bias, bool softShadows, int kernelSize, bool usePoisson, float softness);
 float PointShadowCalculation(vec3 fragPos, vec3 lightPos, samplerCube shadowCubemap, float farPlane, float bias, bool softShadows);
+// Cascaded directional shadow (issue #265).
+int SelectCascadeIndex(float viewDepth);
+float ShadowCalculationArray(vec4 fragPosLightSpace, int layer, float bias, bool softShadows, int kernelSize, bool usePoisson, float softness);
+float CascadedShadowCalculation(DirectionalLight light);
 
 // Lighting calculation functions
 vec3 CalcDirLight(DirectionalLight light, vec3 normal, vec3 viewDir);
@@ -177,11 +197,17 @@ vec3 CalcDirLight(DirectionalLight light, vec3 normal, vec3 viewDir) {
     // Calculate shadow
     float shadow = 0.0;
     if (light.castShadows) {
-        shadow = ShadowCalculation(FragPosLightSpace, light.shadowMap, light.shadowBias,
-                                 light.softShadows, light.pcfKernelSize,
-                                 light.poissonShadows, light.shadowSoftness);
+        if (useCascades) {
+            // CSM path (issue #265): pick a cascade by view depth and sample its layer.
+            shadow = CascadedShadowCalculation(light);
+        } else {
+            // Original single-map path (unchanged).
+            shadow = ShadowCalculation(FragPosLightSpace, light.shadowMap, light.shadowBias,
+                                     light.softShadows, light.pcfKernelSize,
+                                     light.poissonShadows, light.shadowSoftness);
+        }
     }
-    
+
     // Apply shadow to diffuse and specular components (not ambient)
     return ambient + (1.0 - shadow) * (diffuse + specular);
 }
@@ -324,6 +350,86 @@ float ShadowCalculation(vec4 fragPosLightSpace, sampler2D shadowMap, float bias,
         shadow /= float(taps);
     }
 
+    return shadow;
+}
+
+// Pick the cascade for a positive view-space depth. Mirrors render::selectCascade in
+// src/render/ShadowCascades.h: the first cascade whose far split covers the depth,
+// clamping to the last cascade beyond the final split, so CPU and GPU always agree.
+int SelectCascadeIndex(float viewDepth) {
+    int count = dirCascadeCount < MAX_CASCADES ? dirCascadeCount : MAX_CASCADES;
+    if (count < 1) count = 1;
+    for (int i = 0; i < count; ++i) {
+        if (viewDepth <= dirCascadeSplits[i]) return i;
+    }
+    return count - 1;
+}
+
+// PCF depth compare against one layer of the cascade depth array. Identical filtering
+// to ShadowCalculation() (hard tap, box kernel, or Poisson disk), but sampling a
+// sampler2DArray layer instead of a sampler2D.
+float ShadowCalculationArray(vec4 fragPosLightSpace, int layer, float bias, bool softShadows, int kernelSize, bool usePoisson, float softness) {
+    vec3 projCoords = fragPosLightSpace.xyz / fragPosLightSpace.w;
+    projCoords = projCoords * 0.5 + 0.5;
+    float currentDepth = projCoords.z;
+    if (projCoords.z > 1.0) {
+        return 0.0; // beyond this cascade's far plane, treat as lit
+    }
+
+    if (!softShadows || kernelSize <= 1) {
+        float closestDepth = texture(dirCascadeMaps, vec3(projCoords.xy, float(layer))).r;
+        return currentDepth - bias > closestDepth ? 1.0 : 0.0;
+    }
+
+    vec2 texelSize = 1.0 / vec2(textureSize(dirCascadeMaps, 0).xy);
+    float shadow = 0.0;
+    if (usePoisson) {
+        for (int i = 0; i < 16; ++i) {
+            vec2 offset = poissonDisk[i] * texelSize * softness;
+            float pcfDepth = texture(dirCascadeMaps, vec3(projCoords.xy + offset, float(layer))).r;
+            shadow += currentDepth - bias > pcfDepth ? 1.0 : 0.0;
+        }
+        shadow /= 16.0;
+    } else {
+        int halfKernel = kernelSize / 2;
+        int taps = 0;
+        for (int x = -halfKernel; x <= halfKernel; ++x) {
+            for (int y = -halfKernel; y <= halfKernel; ++y) {
+                vec2 offset = vec2(x, y) * texelSize * softness;
+                float pcfDepth = texture(dirCascadeMaps, vec3(projCoords.xy + offset, float(layer))).r;
+                shadow += currentDepth - bias > pcfDepth ? 1.0 : 0.0;
+                taps++;
+            }
+        }
+        shadow /= float(taps);
+    }
+    return shadow;
+}
+
+// Directional shadow via cascades: select a cascade by the fragment's view depth,
+// sample it, and blend into the next cascade across a band before the split so the
+// resolution change does not visibly pop at the seam.
+float CascadedShadowCalculation(DirectionalLight light) {
+    float viewDepth = -(cascadeViewMatrix * vec4(FragPos, 1.0)).z;
+    int idx = SelectCascadeIndex(viewDepth);
+
+    vec4 lsp = dirCascadeMatrices[idx] * vec4(FragPos, 1.0);
+    float shadow = ShadowCalculationArray(lsp, idx, light.shadowBias, light.softShadows,
+                                          light.pcfKernelSize, light.poissonShadows, light.shadowSoftness);
+
+    int count = dirCascadeCount < MAX_CASCADES ? dirCascadeCount : MAX_CASCADES;
+    if (count < 1) count = 1;
+    // Blend toward the next cascade as the fragment nears this cascade's far split.
+    if (cascadeBlendBand > 0.0 && idx < count - 1) {
+        float dist = dirCascadeSplits[idx] - viewDepth; // > 0 before the boundary
+        if (dist < cascadeBlendBand) {
+            vec4 lspNext = dirCascadeMatrices[idx + 1] * vec4(FragPos, 1.0);
+            float shadowNext = ShadowCalculationArray(lspNext, idx + 1, light.shadowBias, light.softShadows,
+                                                      light.pcfKernelSize, light.poissonShadows, light.shadowSoftness);
+            float t = clamp(dist / cascadeBlendBand, 0.0, 1.0); // 1 deep in cascade, 0 at seam
+            shadow = mix(shadowNext, shadow, t);
+        }
+    }
     return shadow;
 }
 

--- a/tests/test_shadow_cascade_build.cpp
+++ b/tests/test_shadow_cascade_build.cpp
@@ -1,0 +1,175 @@
+// Test for the per-cascade light-matrix assembly - issue #265 (CSM GPU wiring).
+//
+// buildCascades() turns the camera view/projection plus a light direction into one
+// light matrix per cascade and the view-space split depth the shader compares
+// against. The GPU path (depth texture array, one pass per cascade, and the
+// shader's per-fragment cascade selection + seam blend) mirrors this, so verifying
+// it here checks the matrix algebra (multiply, perspective, lookAt, inverse), the
+// slice fit, split monotonicity, CPU/GPU cascade-selection agreement, and the
+// count == 1 degradation headlessly (GLSL is not compiled in CI and the GL engine
+// cannot run in this environment).
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_shadow_cascade_build.cpp -o test_shadow_cascade_build
+
+#include "render/ShadowCascadeBuild.h"
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::render;
+using IKore::pick::Mat4;
+using IKore::pick::unproject;
+// Vec3 comes from `using namespace IKore::render` (render::Vec3 == IKore::ecs::Vec3).
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-3f) { return std::fabs(a - b) < eps; }
+
+// A representative camera: looking down -Z from the origin, 60 deg fov, 16:9.
+static Mat4 makeCamView() {
+    return mat::lookAt(Vec3{0.0f, 0.0f, 0.0f}, Vec3{0.0f, 0.0f, -1.0f}, Vec3{0.0f, 1.0f, 0.0f});
+}
+
+// inverse(A) * A == identity, so the general 4x4 inverse is correct.
+static void testInverseRoundTrip() {
+    const Mat4 view = mat::lookAt(Vec3{3.0f, 4.0f, 5.0f}, Vec3{0.0f, 0.0f, 0.0f}, Vec3{0.0f, 1.0f, 0.0f});
+    const Mat4 proj = mat::perspective(1.0472f /* 60 deg */, 16.0f / 9.0f, 0.1f, 100.0f);
+    const Mat4 vp = mat::mul(proj, view);
+    const Mat4 back = mat::mul(mat::inverse(vp), vp);
+    for (int c = 0; c < 4; ++c) {
+        for (int r = 0; r < 4; ++r) {
+            const float expected = (c == r) ? 1.0f : 0.0f;
+            CHECK(approx(back.m[c * 4 + r], expected, 1e-3f));
+        }
+    }
+}
+
+// mul() must honor column-major order: identity is neutral, and a known product holds.
+static void testMulConventions() {
+    const Mat4 id = Mat4::identity();
+    const Mat4 proj = mat::perspective(1.0f, 1.5f, 0.5f, 50.0f);
+    const Mat4 lhs = mat::mul(id, proj);
+    const Mat4 rhs = mat::mul(proj, id);
+    for (int i = 0; i < 16; ++i) {
+        CHECK(approx(lhs.m[i], proj.m[i]));
+        CHECK(approx(rhs.m[i], proj.m[i]));
+    }
+}
+
+// Splits are strictly increasing and each cascade's stored split is its slice's far end.
+static void testSplitMonotonic() {
+    const float nearZ = 0.1f, farZ = 100.0f;
+    const int count = 4;
+    const std::vector<Cascade> cs = buildCascades(makeCamView(), 1.0472f, 16.0f / 9.0f, nearZ, farZ,
+                                                  Vec3{-0.3f, -1.0f, -0.2f}, count, 0.6f);
+    CHECK(cs.size() == static_cast<std::size_t>(count));
+    const std::vector<float> boundaries = cascadeSplitDistances(nearZ, farZ, count, 0.6f);
+    for (int i = 0; i < count; ++i) {
+        CHECK(approx(cs[static_cast<std::size_t>(i)].splitViewDepth, boundaries[static_cast<std::size_t>(i) + 1u]));
+        if (i > 0) CHECK(cs[static_cast<std::size_t>(i)].splitViewDepth > cs[static_cast<std::size_t>(i) - 1u].splitViewDepth);
+    }
+    CHECK(approx(cs.back().splitViewDepth, farZ));
+}
+
+// Every corner of a cascade's own frustum slice must land inside that cascade's clip
+// cube [-1, 1]^3 - i.e. the fitted ortho actually covers the slice it was built for.
+static void testSliceCornersInsideClip() {
+    const float nearZ = 0.1f, farZ = 80.0f;
+    const int count = 3;
+    const float fovy = 1.0472f, aspect = 16.0f / 9.0f, lambda = 0.5f;
+    const Mat4 camView = makeCamView();
+    const std::vector<Cascade> cs = buildCascades(camView, fovy, aspect, nearZ, farZ,
+                                                  Vec3{-0.4f, -1.0f, -0.3f}, count, lambda);
+    const std::vector<float> boundaries = cascadeSplitDistances(nearZ, farZ, count, lambda);
+    CHECK(cs.size() == static_cast<std::size_t>(count));
+
+    for (int i = 0; i < count; ++i) {
+        const Mat4 sliceProj = mat::perspective(fovy, aspect, boundaries[static_cast<std::size_t>(i)],
+                                                boundaries[static_cast<std::size_t>(i) + 1u]);
+        const std::array<Vec3, 8> corners = frustumCornersWorld(mat::inverse(mat::mul(sliceProj, camView)));
+        const Mat4& lm = cs[static_cast<std::size_t>(i)].lightMatrix;
+        for (const Vec3& w : corners) {
+            // Light matrix is affine (ortho * view), so w stays 1; unproject reuses it as a transform.
+            const Vec3 clip = unproject(lm, w.x, w.y, w.z);
+            CHECK(clip.x >= -1.0001f && clip.x <= 1.0001f);
+            CHECK(clip.y >= -1.0001f && clip.y <= 1.0001f);
+            // z stays within the padded [-1, 1] range (padding only enlarges the box).
+            CHECK(clip.z >= -1.0001f && clip.z <= 1.0001f);
+        }
+    }
+}
+
+// The shader selects a cascade by comparing view depth to the stored splits; that
+// selection must agree with render::selectCascade over the whole depth range.
+static void testSelectionAgreement() {
+    const float nearZ = 0.1f, farZ = 100.0f;
+    const int count = 4;
+    const std::vector<Cascade> cs = buildCascades(makeCamView(), 1.0472f, 16.0f / 9.0f, nearZ, farZ,
+                                                  Vec3{-0.3f, -1.0f, -0.2f}, count, 0.7f);
+    std::vector<float> boundaries;
+    boundaries.push_back(nearZ);
+    for (const Cascade& c : cs) boundaries.push_back(c.splitViewDepth);
+
+    for (float depth = 0.0f; depth <= 120.0f; depth += 0.37f) {
+        const int core = selectCascade(depth, boundaries);
+        // Mirror the shader: first cascade whose splitViewDepth covers this depth.
+        int gpu = count - 1;
+        for (int i = 0; i < count; ++i) {
+            if (depth <= cs[static_cast<std::size_t>(i)].splitViewDepth) { gpu = i; break; }
+        }
+        CHECK(core == gpu);
+        CHECK(core >= 0 && core < count);
+    }
+}
+
+// count == 1 degrades to a single fitted map spanning the whole [nearZ, farZ] frustum.
+static void testSingleCascadeDegrades() {
+    const float nearZ = 0.1f, farZ = 60.0f;
+    const std::vector<Cascade> cs = buildCascades(makeCamView(), 1.0472f, 16.0f / 9.0f, nearZ, farZ,
+                                                  Vec3{-0.2f, -1.0f, -0.1f}, 1, 0.5f);
+    CHECK(cs.size() == 1u);
+    CHECK(approx(cs[0].splitViewDepth, farZ));
+
+    // The single cascade must cover the full-frustum corners.
+    const Mat4 camView = makeCamView();
+    const std::array<Vec3, 8> corners =
+        frustumCornersWorld(mat::inverse(mat::mul(mat::perspective(1.0472f, 16.0f / 9.0f, nearZ, farZ), camView)));
+    for (const Vec3& w : corners) {
+        const Vec3 clip = unproject(cs[0].lightMatrix, w.x, w.y, w.z);
+        CHECK(clip.x >= -1.0001f && clip.x <= 1.0001f);
+        CHECK(clip.y >= -1.0001f && clip.y <= 1.0001f);
+        CHECK(clip.z >= -1.0001f && clip.z <= 1.0001f);
+    }
+
+    // Clamping / degenerate guards: count <= 0 still yields at least one cascade.
+    CHECK(buildCascades(camView, 1.0472f, 16.0f / 9.0f, nearZ, farZ, Vec3{0.0f, -1.0f, 0.0f}, 0, 0.5f).size() == 1u);
+    // A zero light direction cannot be fit and yields no cascades (caller falls back).
+    CHECK(buildCascades(camView, 1.0472f, 16.0f / 9.0f, nearZ, farZ, Vec3{0.0f, 0.0f, 0.0f}, 4, 0.5f).empty());
+}
+
+int main() {
+    testInverseRoundTrip();
+    testMulConventions();
+    testSplitMonotonic();
+    testSliceCornersInsideClip();
+    testSelectionAgreement();
+    testSingleCascadeDegrades();
+
+    if (g_failures == 0) {
+        std::printf("All shadow cascade build tests passed.\n");
+        return 0;
+    }
+    std::printf("%d shadow cascade build test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #265.

The tested CSM core (#236) computes where to split the view frustum and how to fit an orthographic box around one slice, but stops short of a ready-to-upload light matrix per cascade and the GPU plumbing to use it. This PR adds that integration, keeping all split/fit math in the tested core and mirroring the per-fragment cascade selection in the shader so CPU and GPU agree. The single-cascade path stays available and the default render is byte-identical.

## Changes

- **`src/render/ShadowCascadeBuild.h`** (new, tested core): glm-free, column-major matrix algebra (`mul` / `perspective` / `lookAt` / general 4x4 `inverse`) on `pick::Mat4`, plus `buildCascades()`. For each cascade it narrows the camera projection to that depth slice, unprojects the slice's frustum corners, fits a padded light-space box, and returns the cascade's light matrix and the view-space split depth the shader compares against. `count == 1` degrades to a single fitted map spanning the whole frustum.
- **`tests/test_shadow_cascade_build.cpp`** (new): inverse round-trip, multiply conventions, split monotonicity, every slice corner landing inside its cascade's `[-1,1]^3` clip cube, CPU/GPU cascade-selection agreement against `render::selectCascade`, and the `count == 1` degradation.
- **`src/CascadedShadowMap.{h,cpp}`** (new): a `GL_TEXTURE_2D_ARRAY` depth target (one layer per cascade) with one framebuffer re-pointed per layer; `computeCascades()` delegates entirely to the tested core.
- **`src/shaders/phong_shadows.frag`**: a `useCascades`-gated cascaded path that selects a cascade by view depth exactly as `selectCascade` does, samples its array layer with the same PCF/Poisson filtering, and blends across a band before each split to hide the seam. When `useCascades` is false the directional light takes the original single-map path unchanged.
- **`src/main.cpp`**: opt-in wiring (default off; toggle CSM with K, cycle split lambda with J). When on, one depth pass per cascade fills the array and the lit pass uploads the per-cascade matrices, splits, and camera view. Frustum params are recovered from the frame's projection so the fit matches whichever camera path is active.
- **`CMakeLists.txt`**: build `CascadedShadowMap.cpp` and register the new test.

## Acceptance

- CPU split/fit math stays in the tested core; the class and shader only consume it.
- The shader mirrors `selectCascade` (verified by a CPU/GPU agreement test).
- Single-cascade path remains available; the `useCascades = false` path is byte-identical to before.

## Verification

- New and existing cascade tests pass under ASan/UBSan (`g++ -std=c++17 -fsanitize=address,undefined`).
- `CascadedShadowMap.cpp` and the new `main.cpp` fragments syntax-check against the real GL/glm/`Shader` APIs.
- `phong_shadows.frag` validates clean under `glslangValidator`.
- The GPU-visual properties (near-field resolution improvement, seam-free blending) cannot be verified headlessly. Correctness rests on the tested core, the mirrored selection, and glslang validation, with the integration additive and default-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74