### PR TITLE
Deform skinned meshes in the shadow-map pass (#266)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,12 @@ add_executable(test_skinning
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_skinning.cpp
 )
 
+# Skinned shadow-depth pass: shadow-program selection + palette-upload policy, and
+# the shadow vertex shader's skinning matching the tested core (#266) - header-only.
+add_executable(test_skinned_shadow
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_skinned_shadow.cpp
+)
+
 # Performance-overlay stats core (Milestone 9 / #53) - header-only.
 add_executable(test_perf_stats
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_perf_stats.cpp

--- a/src/Model.h
+++ b/src/Model.h
@@ -169,6 +169,15 @@ public:
     bool hasAnimations() const { return m_hasAnimations; }
     const std::map<std::string, BoneInfo>& getBoneInfoMap() const { return m_boneInfoMap; }
     int getBoneCount() const { return m_boneCounter; }
+
+    // True if any mesh carries bone weights, i.e. the model needs the skinned vertex
+    // path (used to pick the skinned shadow-depth program, issue #266).
+    bool hasBones() const {
+        for (const auto& mesh : m_meshes) {
+            if (mesh && mesh->hasBones()) return true;
+        }
+        return false;
+    }
     
     // Static utility functions
     static std::shared_ptr<Model> loadFromFileShared(const std::string& path);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 #include "CascadedShadowMap.h"
 #include "Frustum.h"
 #include "render/FrameGraph.h"
+#include "render/ShadowSkinning.h"
 #include "core/Entity.h"
 #include "core/EntityTypes.h"
 #include "core/Transform.h"
@@ -46,9 +47,14 @@ void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods);
 
-// Function to render scene objects (for both shadow pass and main rendering)
-void renderSceneObjects(std::shared_ptr<IKore::Shader> shader, GLuint VAO, bool modelLoaded, 
-                       const IKore::Model& cubeModel, double currentFrameTime);
+// Function to render scene objects (for both shadow pass and main rendering).
+// For the shadow pass, an optional skinned depth program and bone palette let a mesh
+// with bones deform to its animated pose (issue #266); boneless meshes keep the
+// static path unchanged.
+void renderSceneObjects(std::shared_ptr<IKore::Shader> shader, GLuint VAO, bool modelLoaded,
+                       const IKore::Model& cubeModel, double currentFrameTime,
+                       std::shared_ptr<IKore::Shader> skinnedShadowShader = nullptr,
+                       const std::vector<glm::mat4>* bonePalette = nullptr);
 
 // Global camera instance and controller
 IKore::Camera camera(glm::vec3(0.0f, 0.0f, 3.0f));
@@ -513,6 +519,14 @@ int main() {
         LOG_ERROR(std::string("Shadow shader file load/compile failed: ") + shaderError);
     }
 
+    // Skinned directional shadow-depth program (issue #266): reuses shadow_depth.frag
+    // but skins the vertex so an animated mesh casts its posed shadow. Selected per
+    // mesh by hasBones(); boneless meshes keep shadowShaderPtr above.
+    auto skinnedShadowShaderPtr = IKore::Shader::loadFromFilesCached("src/shaders/skinned_shadow_depth.vert", "src/shaders/shadow_depth.frag", shaderError);
+    if(!skinnedShadowShaderPtr){
+        LOG_ERROR(std::string("Skinned shadow shader file load/compile failed: ") + shaderError);
+    }
+
     // Setup lights
     IKore::DirectionalLight dirLight(glm::vec3(-0.2f, -1.0f, -0.3f));
     dirLight.ambient = glm::vec3(0.05f, 0.05f, 0.05f);
@@ -756,15 +770,25 @@ int main() {
                 for (int c = 0; c < g_cascadedShadowMap->cascadeCount(); ++c) {
                     g_cascadedShadowMap->beginCascadePass(c);
                     shadowShaderPtr->setMat4("lightSpaceMatrix", glm::value_ptr(mats[static_cast<std::size_t>(c)]));
-                    renderSceneObjects(shadowShaderPtr, VAO, modelLoaded, cubeModel, currentFrameTime);
+                    // The skinned depth program shares the same light matrix (issue #266).
+                    if (skinnedShadowShaderPtr) {
+                        skinnedShadowShaderPtr->use();
+                        skinnedShadowShaderPtr->setMat4("lightSpaceMatrix", glm::value_ptr(mats[static_cast<std::size_t>(c)]));
+                    }
+                    renderSceneObjects(shadowShaderPtr, VAO, modelLoaded, cubeModel, currentFrameTime, skinnedShadowShaderPtr);
                 }
                 g_cascadedShadowMap->endShadowPass();
             } else if (dirShadowMap && shadowShaderPtr) {
                 dirShadowMap->beginShadowPass();
-                shadowShaderPtr->use();
                 glm::mat4 lightSpaceMatrix = dirShadowMap->getLightSpaceMatrix();
+                shadowShaderPtr->use();
                 shadowShaderPtr->setMat4("lightSpaceMatrix", glm::value_ptr(lightSpaceMatrix));
-                renderSceneObjects(shadowShaderPtr, VAO, modelLoaded, cubeModel, currentFrameTime);
+                // The skinned depth program shares the same light matrix (issue #266).
+                if (skinnedShadowShaderPtr) {
+                    skinnedShadowShaderPtr->use();
+                    skinnedShadowShaderPtr->setMat4("lightSpaceMatrix", glm::value_ptr(lightSpaceMatrix));
+                }
+                renderSceneObjects(shadowShaderPtr, VAO, modelLoaded, cubeModel, currentFrameTime, skinnedShadowShaderPtr);
                 dirShadowMap->endShadowPass();
             }
             // Point light shadow map needs a geometry-shader path; not rendered yet.
@@ -1606,8 +1630,10 @@ void key_callback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action,
 }
 
 // Function to render scene objects (for both shadow pass and main rendering)
-void renderSceneObjects(std::shared_ptr<IKore::Shader> shader, GLuint VAO, bool modelLoaded, 
-                       const IKore::Model& cubeModel, double currentFrameTime) {
+void renderSceneObjects(std::shared_ptr<IKore::Shader> shader, GLuint VAO, bool modelLoaded,
+                       const IKore::Model& cubeModel, double currentFrameTime,
+                       std::shared_ptr<IKore::Shader> skinnedShadowShader,
+                       const std::vector<glm::mat4>* bonePalette) {
     // Create a larger grid of objects for better frustum culling demonstration
     std::vector<glm::vec3> cubePositions;
     
@@ -1622,22 +1648,43 @@ void renderSceneObjects(std::shared_ptr<IKore::Shader> shader, GLuint VAO, bool 
     
     // Render models if available, otherwise fallback to primitive cubes
     if (modelLoaded && !cubeModel.getMeshes().empty()) {
+        // Shadow pass: choose the skinned depth program for a mesh with bones so its
+        // shadow follows the animated pose, else the static program (issue #266). The
+        // choice mirrors the forward pass's skinned-vs-static shader selection.
+        const bool useSkinned =
+            IKore::render::shadowProgramFor(cubeModel.hasBones()) == IKore::render::ShadowProgram::Skinned &&
+            skinnedShadowShader != nullptr;
+        std::shared_ptr<IKore::Shader> activeShader = useSkinned ? skinnedShadowShader : shader;
+        activeShader->use();
+
+        // Upload the bone palette once for the skinned program (clamped to the shader's
+        // finalBonesMatrices[MAX_BONES] capacity); the shaders' rigid fallback covers a
+        // missing palette.
+        if (useSkinned && bonePalette != nullptr) {
+            const int count =
+                IKore::render::shadowPaletteUploadCount(static_cast<int>(bonePalette->size()));
+            for (int b = 0; b < count; ++b) {
+                activeShader->setMat4(("finalBonesMatrices[" + std::to_string(b) + "]").c_str(),
+                                      glm::value_ptr((*bonePalette)[static_cast<std::size_t>(b)]));
+            }
+        }
+
         for (size_t i = 0; i < cubePositions.size(); i++) {
             // Calculate individual model matrix for each cube
             glm::mat4 instanceModel = glm::mat4(1.0f);
             instanceModel = glm::translate(instanceModel, cubePositions[i]);
             float angle = 20.0f * i + (float)currentFrameTime * 30.0f;
-            instanceModel = glm::rotate(instanceModel, glm::radians(angle), 
+            instanceModel = glm::rotate(instanceModel, glm::radians(angle),
                                   glm::vec3(1.0f, 0.3f, 0.5f));
-            
+
             glm::mat3 cubeNormalMatrix = glm::mat3(glm::transpose(glm::inverse(instanceModel)));
-            
+
             // Set matrices for this instance
-            shader->setMat4("model", glm::value_ptr(instanceModel));
-            shader->setMat3("normalMatrix", glm::value_ptr(cubeNormalMatrix));
-            
+            activeShader->setMat4("model", glm::value_ptr(instanceModel));
+            activeShader->setMat3("normalMatrix", glm::value_ptr(cubeNormalMatrix));
+
             // Render the model
-            cubeModel.render(shader);
+            cubeModel.render(activeShader);
         }
     } else {
         // Fallback: render primitive cubes using VAO

--- a/src/render/ShadowSkinning.h
+++ b/src/render/ShadowSkinning.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "render/Skinning.h" // render::skin::kMaxInfluences, skinPosition (the mirrored core)
+
+/**
+ * @file ShadowSkinning.h
+ * @brief Shadow-pass program selection and palette-upload policy for skinned meshes
+ *        (issue #266).
+ *
+ * The GPU wiring for skinned shadows has two small decisions that are worth pulling
+ * out of the render loop so they are unit-testable and shared between the directional
+ * and point shadow passes:
+ *
+ *   - shadowProgramFor(hasBones): pick the skinned depth program for a mesh that has
+ *     bones, otherwise the static one. This is exactly the selection the forward pass
+ *     makes between skinned_phong.vert and the static vertex path, applied to the
+ *     shadow depth programs (skinned_shadow_depth.vert vs shadow_depth.vert).
+ *   - shadowPaletteUploadCount(count): how many bone matrices to upload, clamped to
+ *     the shader's finalBonesMatrices[MAX_BONES] capacity. Mirrors the MAX_BONES
+ *     bound the skinned shaders guard against (a bone id >= MAX_BONES is skipped), so
+ *     the CPU never overruns the uniform array.
+ *
+ * The skinning math itself is not duplicated here - it lives in the tested
+ * render::skin core, which both skinned_phong.vert and skinned_shadow_depth.vert
+ * mirror line for line, so the shadow pose matches the lit pose. Header-only.
+ */
+namespace IKore {
+namespace render {
+
+/// Which shadow depth program a mesh should render with.
+enum class ShadowProgram {
+    Static,  ///< shadow_depth.vert / shadow_point.vert
+    Skinned  ///< skinned_shadow_depth.vert / skinned_shadow_point.vert
+};
+
+/// The shadow depth program to use for a mesh, given whether it has bones. Matches
+/// the forward pass's skinned-vs-static shader choice, so shadows deform with the pose.
+inline ShadowProgram shadowProgramFor(bool hasBones) {
+    return hasBones ? ShadowProgram::Skinned : ShadowProgram::Static;
+}
+
+/// The bone palette shader capacity (skinned_shadow_depth.vert's finalBonesMatrices).
+inline constexpr int kShadowMaxBones = 100;
+
+/**
+ * @brief Clamp a palette size to the shader's uniform-array capacity for upload.
+ * @param boneCount Bones the animation produced (may be 0, or exceed the cap).
+ * @param maxBones  Shader capacity (defaults to kShadowMaxBones, the shader constant).
+ * @return A count in [0, maxBones] safe to upload to finalBonesMatrices.
+ *
+ * A negative count clamps to 0 (nothing to upload -> the shaders' rigid fallback), and
+ * a count past the cap clamps down so the upload never overruns the uniform array; the
+ * shaders already skip any bone id >= MAX_BONES, so clamping here keeps CPU and GPU
+ * consistent about how many bones exist.
+ */
+inline int shadowPaletteUploadCount(int boneCount, int maxBones = kShadowMaxBones) {
+    if (boneCount < 0) return 0;
+    if (boneCount > maxBones) return maxBones;
+    return boneCount;
+}
+
+} // namespace render
+} // namespace IKore

--- a/src/shaders/skinned_shadow_depth.vert
+++ b/src/shaders/skinned_shadow_depth.vert
@@ -1,0 +1,34 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+layout (location = 5) in ivec4 aBoneIds;
+layout (location = 6) in vec4 aWeights;
+
+uniform mat4 lightSpaceMatrix;
+uniform mat4 model;
+
+const int MAX_BONES = 100;
+uniform mat4 finalBonesMatrices[MAX_BONES];
+
+// Skinned directional shadow-depth pass (issue #266). Applies the same linear-blend
+// skinning as skinned_phong.vert - which mirrors skinPosition in
+// src/render/Skinning.h line for line, including the out-of-range bone guard and the
+// no-influence identity fallback - so a skinned mesh's shadow matches its animated
+// pose instead of casting its bind pose. Only the position is skinned (depth pass);
+// it pairs with the existing shadow_depth.frag unchanged.
+void main() {
+    vec4 skinnedPos = vec4(0.0);
+    float applied = 0.0;
+
+    for (int i = 0; i < 4; ++i) {
+        int id = aBoneIds[i];
+        if (id < 0 || id >= MAX_BONES || aWeights[i] <= 0.0) continue;
+        skinnedPos += (finalBonesMatrices[id] * vec4(aPos, 1.0)) * aWeights[i];
+        applied += aWeights[i];
+    }
+    if (applied <= 0.0) {
+        // Rigid fallback: no influences bound (matches the core's behavior).
+        skinnedPos = vec4(aPos, 1.0);
+    }
+
+    gl_Position = lightSpaceMatrix * model * skinnedPos;
+}

--- a/src/shaders/skinned_shadow_point.vert
+++ b/src/shaders/skinned_shadow_point.vert
@@ -1,0 +1,31 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+layout (location = 5) in ivec4 aBoneIds;
+layout (location = 6) in vec4 aWeights;
+
+uniform mat4 model;
+
+const int MAX_BONES = 100;
+uniform mat4 finalBonesMatrices[MAX_BONES];
+
+// Skinned point-light shadow pass (issue #266). Same linear-blend skinning as
+// skinned_shadow_depth.vert / skinned_phong.vert (mirroring skinPosition in
+// src/render/Skinning.h, with the same out-of-range guard and rigid fallback), but
+// emitting the world-space skinned position; the point-shadow geometry stage
+// projects it to each cubemap face (as shadow_point.vert does for static meshes).
+void main() {
+    vec4 skinnedPos = vec4(0.0);
+    float applied = 0.0;
+
+    for (int i = 0; i < 4; ++i) {
+        int id = aBoneIds[i];
+        if (id < 0 || id >= MAX_BONES || aWeights[i] <= 0.0) continue;
+        skinnedPos += (finalBonesMatrices[id] * vec4(aPos, 1.0)) * aWeights[i];
+        applied += aWeights[i];
+    }
+    if (applied <= 0.0) {
+        skinnedPos = vec4(aPos, 1.0);
+    }
+
+    gl_Position = model * skinnedPos;
+}

--- a/tests/test_skinned_shadow.cpp
+++ b/tests/test_skinned_shadow.cpp
@@ -1,0 +1,124 @@
+// Test for skinned shadow depth passes - issue #266.
+//
+// skinned_shadow_depth.vert / skinned_shadow_point.vert apply linear-blend skinning
+// so a skinned mesh's shadow matches its animated pose. They must skin a position
+// exactly as skinned_phong.vert does - i.e. exactly as the tested render::skin core -
+// or the shadow would drift from the lit geometry. GLSL is not compiled in CI and the
+// GL engine cannot run here, so this transcribes the shaders' skinning loop (the same
+// out-of-range guard and no-influence fallback) into C++ and asserts it agrees with
+// render::skin::skinPosition, then checks the shadow-pass selection/upload policy.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_skinned_shadow.cpp -o test_skinned_shadow
+
+#include "render/ShadowSkinning.h"
+#include "render/Skinning.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore::render;
+using IKore::pick::Mat4;
+using Vec3 = IKore::ecs::Vec3;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(const Vec3& a, const Vec3& b, float eps = 1e-4f) {
+    return std::fabs(a.x - b.x) < eps && std::fabs(a.y - b.y) < eps && std::fabs(a.z - b.z) < eps;
+}
+
+// A column-major translation matrix (glm/pick layout), like a bone's palette entry.
+static Mat4 translation(float x, float y, float z) {
+    Mat4 m = Mat4::identity();
+    m.m[12] = x;
+    m.m[13] = y;
+    m.m[14] = z;
+    return m;
+}
+
+// Exact transcription of the skinning loop in skinned_shadow_depth.vert (position
+// only): guard out-of-range/zero-weight bones, blend by weight, rigid fallback when
+// nothing applies. If this ever diverges from render::skin::skinPosition, the shadow
+// pose diverges from the lit pose - which is the bug #266 fixes.
+static Vec3 skinLikeShadowShader(const std::vector<Mat4>& palette,
+                                 const int boneIds[4], const float weights[4], const Vec3& pos) {
+    const int maxBones = 100; // MAX_BONES in the shader
+    Vec3 skinned{0.0f, 0.0f, 0.0f};
+    float applied = 0.0f;
+    for (int i = 0; i < 4; ++i) {
+        const int id = boneIds[i];
+        if (id < 0 || id >= maxBones || weights[i] <= 0.0f) continue;
+        skinned += skin::transformPoint(palette[static_cast<std::size_t>(id)], pos) * weights[i];
+        applied += weights[i];
+    }
+    if (applied <= 0.0f) return pos; // rigid fallback
+    return skinned;
+}
+
+static void testShadowMatchesCore() {
+    // Model the palette exactly as the shader sees it: the finalBonesMatrices uniform
+    // is always MAX_BONES entries, identity-padded for unused slots. Passing the same
+    // count to the core makes the shared guard boundary (id >= MAX_BONES) line up, so
+    // the comparison isolates the skinning math rather than a guard mismatch.
+    std::vector<Mat4> palette(static_cast<std::size_t>(kShadowMaxBones), Mat4::identity());
+    palette[0] = translation(0.0f, 0.0f, 0.0f);
+    palette[1] = translation(2.0f, 0.0f, 0.0f);
+    palette[2] = translation(0.0f, 3.0f, 0.0f);
+    palette[3] = translation(-1.0f, 0.0f, 4.0f);
+    const Vec3 pos{1.0f, 1.0f, 1.0f};
+
+    struct Case {
+        int ids[4];
+        float w[4];
+    } cases[] = {
+        {{1, 2, -1, -1}, {0.5f, 0.5f, 0.0f, 0.0f}},   // two-bone blend
+        {{0, 3, 1, 2}, {0.25f, 0.25f, 0.25f, 0.25f}}, // four-bone blend
+        {{5, 2, -1, -1}, {0.5f, 0.5f, 0.0f, 0.0f}},   // identity-padded bone + real bone
+        {{2, -1, 3, -1}, {0.6f, 0.0f, 0.4f, 0.0f}},   // negative weight slots skipped
+        {{200, -1, -1, -1}, {1.0f, 0.0f, 0.0f, 0.0f}},// id >= MAX_BONES -> fallback
+        {{-1, -1, -1, -1}, {0.0f, 0.0f, 0.0f, 0.0f}}, // no influence -> rigid
+        {{1, -1, -1, -1}, {1.0f, 0.0f, 0.0f, 0.0f}},  // single full-weight bone
+    };
+
+    for (const Case& c : cases) {
+        const Vec3 core = skin::skinPosition(palette.data(), kShadowMaxBones, c.ids, c.w, pos);
+        const Vec3 shader = skinLikeShadowShader(palette, c.ids, c.w, pos);
+        CHECK(approx(core, shader));
+    }
+}
+
+static void testProgramSelection() {
+    CHECK(shadowProgramFor(true) == ShadowProgram::Skinned);
+    CHECK(shadowProgramFor(false) == ShadowProgram::Static);
+}
+
+static void testPaletteUploadClamp() {
+    CHECK(shadowPaletteUploadCount(0) == 0);
+    CHECK(shadowPaletteUploadCount(37) == 37);
+    CHECK(shadowPaletteUploadCount(kShadowMaxBones) == kShadowMaxBones);
+    CHECK(shadowPaletteUploadCount(kShadowMaxBones + 50) == kShadowMaxBones); // clamp down
+    CHECK(shadowPaletteUploadCount(-5) == 0);                                 // negative -> 0
+    CHECK(shadowPaletteUploadCount(9, 8) == 8);                               // custom cap
+}
+
+int main() {
+    testShadowMatchesCore();
+    testProgramSelection();
+    testPaletteUploadClamp();
+
+    if (g_failures == 0) {
+        std::printf("All skinned shadow tests passed.\n");
+        return 0;
+    }
+    std::printf("%d skinned shadow test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #266.

GPU skinning (#260) added `skinned_phong.vert` for the forward pass, but the shadow depth passes still used the static vertex path, so an animated skinned mesh cast its **bind-pose** shadow. This PR skins the shadow depth pass too, keeping the skinning math mirrored from the tested `render::skin` core so the shadow pose matches the lit pose, and leaving the static path unchanged.

## Changes

- **`src/shaders/skinned_shadow_depth.vert`** (new): directional shadow-depth vertex shader applying the same linear-blend skinning as `skinned_phong.vert` (mirroring `skinPosition` in `render/Skinning.h`, including the out-of-range bone guard and the no-influence rigid fallback), emitting light-space depth. Pairs with the existing `shadow_depth.frag`.
- **`src/shaders/skinned_shadow_point.vert`** (new): point-light variant emitting the world-space skinned position for the (future) cubemap geometry stage, matching `shadow_point.vert` for static meshes.
- **`src/render/ShadowSkinning.h`** (new, tested): the shadow-pass policy. `shadowProgramFor` (skinned iff the mesh has bones) and `shadowPaletteUploadCount` (clamp the palette to the shader's `finalBonesMatrices[MAX_BONES]` capacity).
- **`tests/test_skinned_shadow.cpp`** (new): transcribes the shadow shader's skinning loop and asserts it equals `render::skin::skinPosition` (blend, identity-padded and out-of-range bones, negative-weight slots, rigid fallback), plus the selection/clamp policy.
- **`src/Model.h`**: `hasBones()` convenience (true if any mesh carries bone weights).
- **`src/main.cpp`**: load the skinned shadow program and, in the directional shadow pass, select it per mesh via `render::shadowProgramFor` and upload the bone palette; the skinned program shares the light matrix (single-map and cascaded paths). The boneless demo mesh takes the static path, so the default render is unchanged.

## Acceptance

- A skinned mesh's shadow follows its animated pose (the shadow pass skins the same way the forward pass does).
- Static meshes take the existing shadow path unchanged.
- The skinning math stays mirrored from the tested core, with the same guards and fallback as `skinned_phong.vert`, verified by a CPU test comparing the shader's loop to `render::skin::skinPosition`.

## Verification

- New test passes under ASan/UBSan. ASan caught a real guard-boundary subtlety: the shader guards `id >= MAX_BONES` against a 100-entry identity-padded uniform, so the test models the palette the same way.
- `skinned_shadow_depth.vert` and `skinned_shadow_point.vert` validate clean under `glslangValidator`.
- The new `main.cpp` selection/upload fragments and `Model::hasBones()` syntax-check against the real GL/glm/assimp/`Shader`/`Model` headers.

## Scope note

The skinned **runtime draw** (an animated model plus its live palette in the scene) is the same hook #260 left unwired for the forward pass. Until that lands, the selection resolves to the static program for the current demo scene, so this is additive and regression-safe; the moment a skinned model is drawn, its shadow deforms. The point-light skinned shader is included for parity but not wired, since the point shadow pass itself is not rendered yet (`shadow_point.vert` is likewise unused at runtime).