### PR TITLE
Render particles from the SSBO and move emission onto the GPU (#267)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,12 @@ add_executable(test_particle_sim
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_particle_sim.cpp
 )
 
+# Particle emitter cadence (rate/bursts/looping) + readback-free live-count estimate
+# shared by the CPU and GPU emission paths (#267) - header-only.
+add_executable(test_particle_emit
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_particle_emit.cpp
+)
+
 # Debug-text font atlas + quad geometry for the overlay renderer (#259) -
 # header-only.
 add_executable(test_debug_text

--- a/src/ParticleSystem.cpp
+++ b/src/ParticleSystem.cpp
@@ -1,7 +1,9 @@
 #include "ParticleSystem.h"
 #include "core/Logger.h"
+#include "render/ParticleEmit.h" // particlesToEmit, emissionFinished, estimateActiveParticles (#267)
 #include <stb_image.h>
 #include <algorithm>
+#include <cmath>
 #include <fstream>
 #include <iterator>
 #include <random>
@@ -16,6 +18,54 @@ namespace {
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_real_distribution<float> dis(0.0f, 1.0f);
+
+    // std140 mirror of the EmitterConfig block in particle_emit.compute /
+    // particle_ssbo.vert (issue #267). ParticleEmitterConfig is tightly packed glm
+    // types, which do not match std140 (vec3 aligns to 16, GLSL bool is 4 bytes), so
+    // the emitter UBO is uploaded through this padded layout instead. Keep field
+    // order and padding in lockstep with the shader block.
+    struct EmitterConfigGPU {
+        glm::vec3 position;            float _p1;
+        glm::vec3 positionVariance;    float _p2;
+        glm::vec3 velocity;            float _p3;
+        glm::vec3 velocityVariance;    float _p4;
+        glm::vec3 acceleration;        float _p5;
+        glm::vec3 accelerationVariance; float _p6;
+        glm::vec4 startColor;
+        glm::vec4 endColor;
+        glm::vec4 colorVariance;
+        float startSize; float endSize; float sizeVariance; float _p7;
+        float startLife; float lifeVariance; float emissionRate; float maxParticles;
+        float mass; float massVariance; float _p8; float _p9;
+        int looping; int worldSpace; float _p10; float _p11; // GLSL bool -> 4 bytes
+    };
+    static_assert(sizeof(EmitterConfigGPU) == 208,
+                  "EmitterConfigGPU must match the std140 EmitterConfig block in the shaders");
+
+    EmitterConfigGPU toGPU(const ParticleEmitterConfig& c) {
+        EmitterConfigGPU g{};
+        g.position = c.position;
+        g.positionVariance = c.positionVariance;
+        g.velocity = c.velocity;
+        g.velocityVariance = c.velocityVariance;
+        g.acceleration = c.acceleration;
+        g.accelerationVariance = c.accelerationVariance;
+        g.startColor = c.startColor;
+        g.endColor = c.endColor;
+        g.colorVariance = c.colorVariance;
+        g.startSize = c.startSize;
+        g.endSize = c.endSize;
+        g.sizeVariance = c.sizeVariance;
+        g.startLife = c.startLife;
+        g.lifeVariance = c.lifeVariance;
+        g.emissionRate = c.emissionRate;
+        g.maxParticles = c.maxParticles;
+        g.mass = c.mass;
+        g.massVariance = c.massVariance;
+        g.looping = c.looping ? 1 : 0;
+        g.worldSpace = c.worldSpace ? 1 : 0;
+        return g;
+    }
 }
 
 // ===== ParticleSystem Implementation =====
@@ -130,12 +180,14 @@ bool ParticleSystem::initializeBuffers() {
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, m_particleSSBO);
     }
     
-    // Create UBO for emitter configuration
+    // Create UBO for emitter configuration. Uploaded through the std140 mirror so the
+    // emit compute / SSBO render shaders read it correctly (issue #267).
+    const EmitterConfigGPU gpuConfig = toGPU(m_config);
     glGenBuffers(1, &m_emitterUBO);
     glBindBuffer(GL_UNIFORM_BUFFER, m_emitterUBO);
-    glBufferData(GL_UNIFORM_BUFFER, sizeof(ParticleEmitterConfig), &m_config, GL_DYNAMIC_DRAW);
+    glBufferData(GL_UNIFORM_BUFFER, sizeof(EmitterConfigGPU), &gpuConfig, GL_DYNAMIC_DRAW);
     glBindBufferBase(GL_UNIFORM_BUFFER, 0, m_emitterUBO);
-    
+
     return true;
 }
 
@@ -153,7 +205,22 @@ bool ParticleSystem::loadShaders() {
         LOG_ERROR("Failed to load particle rendering shaders: " + shaderError);
         return false;
     }
-    
+
+    // GPU path: a vertex-pull program that reads particles straight from the SSBO, so
+    // rendering needs no per-frame readback (issue #267). Only meaningful where compute
+    // (GL 4.3, and thus SSBOs in the vertex stage) is available; the CPU path keeps
+    // using m_renderShader above.
+    if (m_computeShadersSupported) {
+        m_renderShaderSSBO = Shader::loadFromFilesCached(
+            "src/shaders/particle_ssbo.vert",
+            "src/shaders/particle.frag",
+            shaderError
+        );
+        if (!m_renderShaderSSBO) {
+            LOG_WARNING("Failed to load SSBO particle render shader, using CPU render path: " + shaderError);
+        }
+    }
+
     return true;
 }
 
@@ -161,45 +228,58 @@ bool ParticleSystem::createComputeShaders() {
 #ifdef GL_COMPUTE_SHADER
     if (!m_computeShadersSupported) return false;
 
-    // Compile + link the update compute program (issue #259). Emission stays on
-    // the CPU (initializeParticle uses engine-side randomness), so only the
-    // update stage moves to the GPU; m_emitComputeShader remains unused.
-    std::ifstream file("src/shaders/particle_update.compute");
-    if (!file.is_open()) {
-        LOG_ERROR("Failed to open particle_update.compute");
-        return false;
-    }
-    std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-    file.close();
+    // Compile + link a compute program from a source file. Returns 0 on failure.
+    auto buildComputeProgram = [](const char* path) -> GLuint {
+        std::ifstream file(path);
+        if (!file.is_open()) {
+            LOG_ERROR(std::string("Failed to open ") + path);
+            return 0;
+        }
+        std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+        file.close();
 
-    const GLuint shader = glCreateShader(GL_COMPUTE_SHADER);
-    const char* src = source.c_str();
-    glShaderSource(shader, 1, &src, nullptr);
-    glCompileShader(shader);
-    GLint ok = GL_FALSE;
-    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
-    if (!ok) {
-        char log[1024] = {0};
-        glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
-        LOG_ERROR(std::string("Particle update compute shader compile failed: ") + log);
+        const GLuint shader = glCreateShader(GL_COMPUTE_SHADER);
+        const char* src = source.c_str();
+        glShaderSource(shader, 1, &src, nullptr);
+        glCompileShader(shader);
+        GLint ok = GL_FALSE;
+        glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+        if (!ok) {
+            char log[1024] = {0};
+            glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+            LOG_ERROR(std::string("Compute shader compile failed (") + path + "): " + log);
+            glDeleteShader(shader);
+            return 0;
+        }
+
+        const GLuint program = glCreateProgram();
+        glAttachShader(program, shader);
+        glLinkProgram(program);
+        glGetProgramiv(program, GL_LINK_STATUS, &ok);
         glDeleteShader(shader);
-        return false;
+        if (!ok) {
+            char log[1024] = {0};
+            glGetProgramInfoLog(program, sizeof(log), nullptr, log);
+            LOG_ERROR(std::string("Compute shader link failed (") + path + "): " + log);
+            glDeleteProgram(program);
+            return 0;
+        }
+        return program;
+    };
+
+    // The update stage is required for the GPU path (issue #259).
+    m_updateComputeShader = buildComputeProgram("src/shaders/particle_update.compute");
+    if (m_updateComputeShader == 0) return false;
+
+    // The emit stage moves emission onto the GPU (issue #267). If it fails to build,
+    // keep the update path and fall back to CPU emission (emit() checks the program).
+    m_emitComputeShader = buildComputeProgram("src/shaders/particle_emit.compute");
+    if (m_emitComputeShader == 0) {
+        LOG_WARNING("Particle emit compute shader unavailable, emission stays on the CPU");
+    } else {
+        LOG_INFO("Particle emit compute shader ready");
     }
 
-    const GLuint program = glCreateProgram();
-    glAttachShader(program, shader);
-    glLinkProgram(program);
-    glGetProgramiv(program, GL_LINK_STATUS, &ok);
-    glDeleteShader(shader);
-    if (!ok) {
-        char log[1024] = {0};
-        glGetProgramInfoLog(program, sizeof(log), nullptr, log);
-        LOG_ERROR(std::string("Particle update compute shader link failed: ") + log);
-        glDeleteProgram(program);
-        return false;
-    }
-
-    m_updateComputeShader = program;
     LOG_INFO("Particle update compute shader ready");
     return true;
 #else
@@ -262,8 +342,9 @@ void ParticleSystem::setEmitterConfig(const ParticleEmitterConfig& config) {
 
 void ParticleSystem::updateEmitterBuffer() {
     if (m_emitterUBO) {
+        const EmitterConfigGPU gpuConfig = toGPU(m_config);
         glBindBuffer(GL_UNIFORM_BUFFER, m_emitterUBO);
-        glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(ParticleEmitterConfig), &m_config);
+        glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(EmitterConfigGPU), &gpuConfig);
     }
 }
 
@@ -342,10 +423,19 @@ void ParticleSystem::stop() {
 void ParticleSystem::reset() {
     m_activeParticles = 0;
     m_emissionTimer = 0.0f;
-    
+    m_emissionRemainder = 0.0f;
+    m_activeEstimate = 0.0f;
+    m_pendingBirths = 0;
+
     // Kill all particles
     for (auto& particle : m_particles) {
         particle.life = 0.0f;
+    }
+
+    // Clear the GPU buffer too so the SSBO render/emit paths see an empty pool. This
+    // is a state-change upload, not the per-frame readback the GPU path avoids (#267).
+    if (m_computeShadersSupported && m_particleSSBO != 0) {
+        uploadParticlesToSSBO();
     }
 }
 
@@ -358,9 +448,14 @@ void ParticleSystem::update(float deltaTime) {
         // Emit new particles
         emitParticles(deltaTime);
     }
-    
+
     // Update particles
     if (m_computeShadersSupported) {
+        // Advance the readback-free live-count estimate from this frame's births and
+        // the per-particle death rate before the GPU update rounds it (issue #267).
+        m_activeEstimate = render::estimateActiveParticles(m_activeEstimate, m_pendingBirths,
+                                                           deltaTime, m_config.startLife, m_maxParticles);
+        m_pendingBirths = 0;
         updateGPU(deltaTime);
     } else {
         updateCPU(deltaTime);
@@ -401,62 +496,60 @@ void ParticleSystem::updateGPU(float deltaTime) {
         updateCPU(deltaTime);
         return;
     }
-    // The C++ Particle must match the std430 struct in particle_update.compute
-    // byte for byte, since the buffer is uploaded/read back verbatim.
+    // The C++ Particle must match the std430 struct in particle_update.compute byte
+    // for byte, since emission (emit compute) and rendering (SSBO vertex-pull) both
+    // read the buffer in place.
     static_assert(sizeof(Particle) == 80, "Particle layout must match particle_update.compute");
 
-    // Upload the current particle state (CPU-side emission writes new particles
-    // into m_particles between updates).
-    const GLsizeiptr bytes = static_cast<GLsizeiptr>(m_particles.size() * sizeof(Particle));
-    glBindBuffer(GL_SHADER_STORAGE_BUFFER, m_particleSSBO);
-    glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, bytes, m_particles.data());
+    // The SSBO is the single source of truth now: emission writes into it on the GPU
+    // and rendering pulls from it, so there is no per-frame upload or readback (#267).
+    // Dispatch one thread per particle (local_size_x = 64). The update math mirrors the
+    // unit-tested render::simulateParticleStep.
     glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, m_particleSSBO);
-
-    // Dispatch one thread per particle (local_size_x = 64 in the shader). The
-    // update math mirrors the unit-tested render::simulateParticleStep.
     glUseProgram(m_updateComputeShader);
     glUniform1f(glGetUniformLocation(m_updateComputeShader, "deltaTime"), deltaTime);
     glUniform1f(glGetUniformLocation(m_updateComputeShader, "time"), m_emissionTimer);
     const GLuint groups = static_cast<GLuint>((m_particles.size() + 63) / 64);
     glDispatchCompute(groups, 1, 1);
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
-
-    // Read the advanced state back so the CPU-side render/emission paths keep
-    // working unchanged. Rendering directly from the SSBO (zero readback) is a
-    // follow-up optimization.
-    glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, bytes, m_particles.data());
-    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
     glUseProgram(0);
 
-    m_activeParticles = 0;
-    for (const auto& particle : m_particles) {
-        if (particle.life > 0.0f) ++m_activeParticles;
-    }
+    // The live count is no longer read back from the GPU; track it on the CPU with the
+    // same birth/death rates (render::estimateActiveParticles).
+    m_activeParticles = static_cast<int>(std::lround(m_activeEstimate));
 #else
     updateCPU(deltaTime);
 #endif
 }
 
 void ParticleSystem::emitParticles(float deltaTime) {
-    if (!m_config.looping && m_emissionTimer > m_config.startLife) {
+    // Looping/rate/burst cadence is shared with the GPU path via the tested
+    // render::* helpers, so emitter behavior is identical however emission runs (#267).
+    if (render::emissionFinished(m_config.looping, m_emissionTimer, m_config.startLife)) {
         return; // Stop emitting for non-looping effects
     }
-    
+
     m_emissionTimer += deltaTime;
-    float particlesToEmit = m_config.emissionRate * deltaTime;
-    
-    // Handle fractional particles
-    static float particleRemainder = 0.0f;
-    particlesToEmit += particleRemainder;
-    int wholeParticles = static_cast<int>(particlesToEmit);
-    particleRemainder = particlesToEmit - wholeParticles;
-    
+    // The fractional carry is per-system state (a function-local static would have
+    // been shared across every particle system).
+    const int wholeParticles = render::particlesToEmit(m_config.emissionRate, deltaTime, m_emissionRemainder);
     emit(wholeParticles);
 }
 
 void ParticleSystem::emit(int count) {
     if (!m_initialized || count <= 0) return;
-    
+
+    // GPU path: dispatch the emit compute so emission runs on the GPU with no CPU
+    // particle writes (issue #267). Falls back to the CPU loop if the emit program is
+    // unavailable (sub-4.3).
+#ifdef GL_COMPUTE_SHADER
+    if (m_computeShadersSupported && m_emitComputeShader != 0 && m_particleSSBO != 0) {
+        emitGPU(count);
+        m_pendingBirths += count; // feed the readback-free live-count estimate
+        return;
+    }
+#endif
+
     int emitted = 0;
     for (int i = 0; i < m_maxParticles && emitted < count; ++i) {
         if (m_particles[i].life <= 0.0f) {
@@ -464,6 +557,35 @@ void ParticleSystem::emit(int count) {
             emitted++;
         }
     }
+}
+
+void ParticleSystem::emitGPU(int count) {
+#ifdef GL_COMPUTE_SHADER
+    if (count <= 0 || m_emitComputeShader == 0 || m_particleSSBO == 0) return;
+
+    // GPU-side RNG is seeded from a per-dispatch counter so successive emissions vary.
+    m_emitSeed += 1.0f;
+
+    glUseProgram(m_emitComputeShader);
+    glUniform1f(glGetUniformLocation(m_emitComputeShader, "time"), m_emitSeed);
+    glUniform1i(glGetUniformLocation(m_emitComputeShader, "particlesToEmit"), count);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, m_particleSSBO);
+    glBindBufferBase(GL_UNIFORM_BUFFER, 0, m_emitterUBO);
+    // The emit shader scans the whole buffer in one invocation (local_size 1).
+    glDispatchCompute(1, 1, 1);
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+    glUseProgram(0);
+#else
+    (void)count;
+#endif
+}
+
+void ParticleSystem::uploadParticlesToSSBO() {
+    if (m_particleSSBO == 0) return;
+    const GLsizeiptr bytes = static_cast<GLsizeiptr>(m_particles.size() * sizeof(Particle));
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, m_particleSSBO);
+    glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, bytes, m_particles.data());
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
 void ParticleSystem::burst(int count) {
@@ -516,13 +638,45 @@ glm::vec4 ParticleSystem::randomVec4(const glm::vec4& base, const glm::vec4& var
 }
 
 void ParticleSystem::render(const glm::mat4& view, const glm::mat4& projection) {
-    if (!m_initialized || !m_enabled || !m_renderShader || m_activeParticles == 0) return;
-    
+    if (!m_initialized || !m_enabled) return;
+
+    // GPU path: render straight from the SSBO with no readback (issue #267). Draw one
+    // point per slot; the vertex shader pulls each particle by gl_VertexID and culls
+    // dead ones, so the CPU never touches the particle data at render time.
+#ifdef GL_COMPUTE_SHADER
+    if (m_computeShadersSupported && m_renderShaderSSBO && m_particleSSBO != 0) {
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glDepthMask(GL_FALSE);
+
+        m_renderShaderSSBO->use();
+        m_renderShaderSSBO->setMat4("view", glm::value_ptr(view));
+        m_renderShaderSSBO->setMat4("projection", glm::value_ptr(projection));
+
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, m_particleTexture);
+        m_renderShaderSSBO->setInt("particleTexture", 0);
+
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, m_particleSSBO);
+        glBindBufferBase(GL_UNIFORM_BUFFER, 0, m_emitterUBO);
+
+        glBindVertexArray(m_particleVAO); // a bound VAO is required; attributes go unused
+        glDrawArrays(GL_POINTS, 0, m_maxParticles);
+        glBindVertexArray(0);
+
+        glDepthMask(GL_TRUE);
+        glDisable(GL_BLEND);
+        return;
+    }
+#endif
+
+    if (!m_renderShader || m_activeParticles == 0) return;
+
     // Enable blending for particles
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glDepthMask(GL_FALSE); // Don't write to depth buffer
-    
+
     // Use particle shader
     m_renderShader->use();
     m_renderShader->setMat4("view", glm::value_ptr(view));

--- a/src/ParticleSystem.h
+++ b/src/ParticleSystem.h
@@ -87,7 +87,8 @@ private:
     GLuint m_particleTexture;           // Particle sprite texture
     
     // Shaders
-    std::shared_ptr<Shader> m_renderShader;
+    std::shared_ptr<Shader> m_renderShader;      // CPU-fed VBO render path
+    std::shared_ptr<Shader> m_renderShaderSSBO;  // GPU path: vertex-pull from the SSBO (#267)
     GLuint m_updateComputeShader;       // Compute shader for particle updates
     GLuint m_emitComputeShader;         // Compute shader for particle emission
     
@@ -102,6 +103,12 @@ private:
     bool m_initialized;
     bool m_enabled;
     bool m_playing;
+
+    // Emission / GPU-path bookkeeping (issue #267)
+    float m_emissionRemainder = 0.0f; // sub-particle emission carry (per system)
+    float m_emitSeed = 0.0f;          // varies the GPU emit shader's RNG each dispatch
+    float m_activeEstimate = 0.0f;    // readback-free live-count estimate for the GPU path
+    int m_pendingBirths = 0;          // particles emitted since the last estimate update
     
     // Performance tracking
     float m_lastUpdateTime;
@@ -171,7 +178,9 @@ private:
     
     void updateCPU(float deltaTime);      // Fallback CPU update
     void updateGPU(float deltaTime);      // GPU compute shader update
-    
+
+    void emitGPU(int count);              // Dispatch particle_emit.compute (#267)
+    void uploadParticlesToSSBO();         // Push m_particles into the SSBO (init/reset only)
     void emitParticles(float deltaTime);
     void initializeParticle(Particle& particle);
     float randomFloat(float min, float max);

--- a/src/render/ParticleEmit.h
+++ b/src/render/ParticleEmit.h
@@ -1,0 +1,79 @@
+#pragma once
+
+/**
+ * @file ParticleEmit.h
+ * @brief Emitter cadence + live-count estimate shared by the CPU and GPU particle
+ *        paths (issue #267).
+ *
+ * Moving emission onto the GPU must not change emitter behavior (rate, bursts,
+ * looping) from the user's perspective. The decisions that must stay identical across
+ * the two paths are pure scalar bookkeeping, so they live here as unit-testable math
+ * that both ParticleSystem::emitParticles (CPU) and the GPU dispatch call:
+ *
+ *   - particlesToEmit(): how many whole particles to spawn this step, carrying the
+ *     sub-particle fraction in a caller-owned accumulator so a fractional rate still
+ *     emits at the right average cadence.
+ *   - emissionFinished(): whether a non-looping emitter has stopped emitting.
+ *   - estimateActiveParticles(): a readback-free running estimate of the live count.
+ *     Rendering now reads the particle buffer directly (no glGetBufferSubData), so the
+ *     exact count is no longer pulled back from the GPU; this tracks it on the CPU via
+ *     the same birth/death rates, converging to emissionRate * startLife at steady
+ *     state (emissionRate*dt in == active*dt/startLife out).
+ *
+ * Header-only, std only.
+ */
+namespace IKore {
+namespace render {
+
+/**
+ * @brief Whole particles to emit this step for a (possibly fractional) rate.
+ * @param emissionRate Particles per second (negative treated as 0).
+ * @param dt           Seconds elapsed this step.
+ * @param[in,out] remainder Sub-particle carry; updated with the leftover fraction.
+ * @return Count in [0, ...] to emit now.
+ *
+ * Accumulates rate*dt plus the prior remainder, emits the whole part, and carries the
+ * fraction forward so, e.g., 0.4 particles/step emits every ~2-3 steps on average.
+ */
+inline int particlesToEmit(float emissionRate, float dt, float& remainder) {
+    float toEmit = emissionRate * dt + remainder;
+    if (toEmit < 0.0f) toEmit = 0.0f;
+    int whole = static_cast<int>(toEmit);
+    remainder = toEmit - static_cast<float>(whole);
+    return whole;
+}
+
+/// Whether a non-looping emitter has finished emitting (its run exceeded startLife).
+/// A looping emitter never finishes. Mirrors the guard in ParticleSystem::emitParticles.
+inline bool emissionFinished(bool looping, float emissionTimer, float startLife) {
+    return !looping && emissionTimer > startLife;
+}
+
+/**
+ * @brief Advance a readback-free estimate of the live particle count.
+ * @param currentActive Previous estimate (carried as a float to avoid per-step
+ *                      rounding drift; round only when reporting the count).
+ * @param emitted       Particles emitted this step.
+ * @param dt            Seconds elapsed this step.
+ * @param startLife     Mean particle lifetime in seconds (<= 0 applies no decay).
+ * @param maxParticles  Capacity clamp.
+ * @return New estimate in [0, maxParticles].
+ *
+ * Births add @p emitted; deaths remove the fraction of the pool whose life ran out
+ * this step (active * dt / startLife), the same decay the update step applies per
+ * particle. At steady state this settles at emissionRate * startLife.
+ */
+inline float estimateActiveParticles(float currentActive, int emitted, float dt,
+                                     float startLife, int maxParticles) {
+    float active = currentActive + static_cast<float>(emitted);
+    if (startLife > 0.0f) {
+        active -= currentActive * (dt / startLife);
+    }
+    if (active < 0.0f) active = 0.0f;
+    const float cap = static_cast<float>(maxParticles);
+    if (active > cap) active = cap;
+    return active;
+}
+
+} // namespace render
+} // namespace IKore

--- a/src/shaders/particle_ssbo.vert
+++ b/src/shaders/particle_ssbo.vert
@@ -1,0 +1,78 @@
+#version 430
+
+// SSBO-pull particle vertex shader (issue #267). Renders particles straight from
+// the compute buffer with no per-frame readback: the draw is glDrawArrays(GL_POINTS,
+// 0, maxParticles) with no vertex attributes, and each invocation pulls its particle
+// by gl_VertexID from the same std430 ParticleBuffer the update/emit compute shaders
+// write. Dead particles are culled by clipping them out with a zero point size.
+//
+// Color/size come from the emitter config faded by life, matching the CPU render
+// path (mix(endColor, startColor, life) / mix(endSize, startSize, life)) so the two
+// paths look identical. Pairs with particle.frag unchanged.
+
+struct Particle {
+    vec3 position;
+    float life;
+    vec3 velocity;
+    float size;
+    vec4 color;
+    vec3 acceleration;
+    float startLife;
+    vec2 rotation;
+    float mass;
+    float padding;
+};
+
+struct EmitterConfig {
+    vec3 position;            float padding1;
+    vec3 positionVariance;   float padding2;
+    vec3 velocity;           float padding3;
+    vec3 velocityVariance;   float padding4;
+    vec3 acceleration;       float padding5;
+    vec3 accelerationVariance; float padding6;
+    vec4 startColor;
+    vec4 endColor;
+    vec4 colorVariance;
+    float startSize;  float endSize;  float sizeVariance;  float padding7;
+    float startLife;  float lifeVariance;  float emissionRate;  float maxParticles;
+    float mass;  float massVariance;  float padding8;  float padding9;
+    bool looping;  bool worldSpace;  float padding10;  float padding11;
+};
+
+layout(std430, binding = 0) restrict readonly buffer ParticleBuffer {
+    Particle particles[];
+};
+
+layout(std140, binding = 0) uniform EmitterBuffer {
+    EmitterConfig emitter;
+};
+
+uniform mat4 view;
+uniform mat4 projection;
+
+out vec4 ParticleColor;
+out float ParticleRotation;
+
+void main() {
+    Particle p = particles[gl_VertexID];
+
+    // Cull dead particles: clip them out and give them no footprint.
+    if (p.life <= 0.0) {
+        gl_Position = vec4(2.0, 2.0, 2.0, 1.0); // outside the clip volume
+        gl_PointSize = 0.0;
+        ParticleColor = vec4(0.0);
+        ParticleRotation = 0.0;
+        return;
+    }
+
+    float lifeRatio = p.life;
+    ParticleColor = mix(emitter.endColor, emitter.startColor, lifeRatio);
+    ParticleRotation = p.rotation.x;
+    float currentSize = mix(emitter.endSize, emitter.startSize, lifeRatio);
+
+    vec4 viewPos = view * vec4(p.position, 1.0);
+    gl_Position = projection * viewPos;
+
+    float dist = length(viewPos.xyz);
+    gl_PointSize = max(1.0, (currentSize * 100.0) / dist);
+}

--- a/tests/test_particle_emit.cpp
+++ b/tests/test_particle_emit.cpp
@@ -1,0 +1,114 @@
+// Test for the particle emitter cadence + live-count estimate - issue #267.
+//
+// Moving emission onto the GPU must not change emitter behavior (rate, bursts,
+// looping) from the user's perspective, and rendering straight from the SSBO removes
+// the per-frame readback that used to give an exact live count. These helpers are the
+// scalar bookkeeping both paths share; testing them here locks the cadence and the
+// readback-free count estimate (the GPU path itself cannot run in this environment).
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_particle_emit.cpp -o test_particle_emit
+
+#include "render/ParticleEmit.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore::render;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// A fractional rate emits at the correct average cadence via the carried remainder.
+static void testFractionalCadence() {
+    float remainder = 0.0f;
+    // 0.4 particles/step: expect 0,0,1,0,1 pattern (cumulative floor).
+    int total = 0;
+    int emittedPerStep[5];
+    for (int i = 0; i < 5; ++i) {
+        emittedPerStep[i] = particlesToEmit(4.0f, 0.1f, remainder); // 4/s * 0.1s = 0.4
+        total += emittedPerStep[i];
+    }
+    CHECK(emittedPerStep[0] == 0);
+    CHECK(emittedPerStep[1] == 0);
+    CHECK(emittedPerStep[2] == 1);
+    CHECK(emittedPerStep[3] == 0);
+    CHECK(emittedPerStep[4] == 1);
+    CHECK(total == 2); // 5 * 0.4 = 2.0
+
+    // Over many steps the count tracks rate*time closely (no drift from the carry).
+    remainder = 0.0f;
+    total = 0;
+    for (int i = 0; i < 600; ++i) total += particlesToEmit(50.0f, 1.0f / 60.0f, remainder);
+    CHECK(total == 500); // 50/s over 10s
+}
+
+// A whole rate emits exactly that many each step; zero/negative rate emits nothing.
+static void testWholeAndZeroRate() {
+    float remainder = 0.0f;
+    CHECK(particlesToEmit(100.0f, 0.01f, remainder) == 1); // 1.0 exactly
+    remainder = 0.0f;
+    CHECK(particlesToEmit(0.0f, 0.5f, remainder) == 0);
+    remainder = 0.0f;
+    CHECK(particlesToEmit(-10.0f, 0.5f, remainder) == 0); // negative clamps to 0
+}
+
+static void testLoopingGuard() {
+    // Looping emitters never finish.
+    CHECK(!emissionFinished(true, 100.0f, 2.0f));
+    // Non-looping: finished once the run exceeds startLife.
+    CHECK(!emissionFinished(false, 1.9f, 2.0f));
+    CHECK(!emissionFinished(false, 2.0f, 2.0f)); // strictly greater
+    CHECK(emissionFinished(false, 2.1f, 2.0f));
+}
+
+// The readback-free estimate converges to emissionRate * startLife at steady state.
+static void testActiveEstimateConverges() {
+    const float rate = 50.0f;      // particles/sec
+    const float startLife = 3.0f;  // sec
+    const float dt = 1.0f / 60.0f;
+    const int maxParticles = 1000;
+    float remainder = 0.0f;
+    float active = 0.0f;
+    for (int i = 0; i < 6000; ++i) { // 100 seconds, plenty to settle
+        const int emitted = particlesToEmit(rate, dt, remainder);
+        active = estimateActiveParticles(active, emitted, dt, startLife, maxParticles);
+    }
+    const float expected = rate * startLife; // 150
+    CHECK(std::fabs(active - expected) < expected * 0.1f);
+    CHECK(active <= static_cast<float>(maxParticles));
+}
+
+// The estimate never exceeds capacity and decays to (effectively) zero.
+static void testActiveEstimateClamped() {
+    // Huge emission clamps to capacity.
+    CHECK(estimateActiveParticles(0.0f, 100000, 0.016f, 3.0f, 500) == 500.0f);
+    // No emission, everything decays toward 0.
+    float active = 500.0f;
+    for (int i = 0; i < 100000; ++i) active = estimateActiveParticles(active, 0, 0.5f, 3.0f, 500);
+    CHECK(active < 0.5f); // rounds to 0 particles
+    // startLife <= 0 does not divide by zero (no death term applied).
+    CHECK(estimateActiveParticles(10.0f, 5, 0.016f, 0.0f, 500) == 15.0f);
+}
+
+int main() {
+    testFractionalCadence();
+    testWholeAndZeroRate();
+    testLoopingGuard();
+    testActiveEstimateConverges();
+    testActiveEstimateClamped();
+
+    if (g_failures == 0) {
+        std::printf("All particle emit tests passed.\n");
+        return 0;
+    }
+    std::printf("%d particle emit test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #267.

#259 made the particle update a real compute dispatch, but it read the buffer back every frame (`glGetBufferSubData`) and kept emission on the CPU, with `particle_emit.compute` unwired. This PR makes the SSBO the single source of truth: emission and update run on the GPU and rendering pulls from the buffer directly, so the steady-state GPU path has no readback. The CPU path stays as the sub-4.3 fallback, and update semantics remain locked to the tested render core.

## Changes

- **`src/shaders/particle_ssbo.vert`** (new): vertex-pull render shader that reads each particle by `gl_VertexID` from the std430 `ParticleBuffer`. The draw becomes `glDrawArrays(GL_POINTS, 0, maxParticles)` with no vertex attributes; dead particles are culled in-shader, and color/size fade by life exactly as the CPU render path did. Pairs with `particle.frag`.
- **`particle_emit.compute` is now wired**: emission runs on the GPU with GPU-side RNG seeded per dispatch. The whole-particle count per step still comes from the shared cadence helper, so rate/bursts/looping are unchanged.
- **`src/render/ParticleEmit.h`** + **`tests/test_particle_emit.cpp`** (new): the emission cadence (fractional-rate carry, looping guard) and a readback-free live-count estimate (converges to `emissionRate * startLife`), shared by both paths and unit-tested.
- **`src/ParticleSystem.{h,cpp}`**:
  - `updateGPU` no longer uploads or reads back; it just dispatches the update compute against the SSBO. The live count is tracked via the estimate.
  - `emit()`/`burst()` route to `particle_emit.compute` on the GPU path, CPU loop otherwise. The fractional carry moved from a function-local `static` (which was shared across all particle systems, a latent bug) to a per-system member.
  - `render()` draws from the SSBO on the GPU path.
  - The emitter UBO is uploaded through a std140 mirror (`EmitterConfigGPU`). The tightly-packed `ParticleEmitterConfig` does not match std140 (vec3 aligns to 16, GLSL bool is 4 bytes), so the emit/render shaders could not have read it correctly before; a `static_assert` pins the layout at 208 bytes.
  - `reset()` clears the SSBO (a state-change upload, not the per-frame readback the issue removes).
- **`CMakeLists.txt`**: register `test_particle_emit`.

## Acceptance

- No `glGetBufferSubData` in the steady-state GPU path (verified by grep; only state-change uploads remain).
- The CPU fallback is intact behind the compute-support gate.
- Update math stays mirrored from `render::simulateParticleStep` (still guarded by `test_particle_sim`), so the CPU and GPU paths advance particles identically.
- Emitter rate/bursts/looping are unchanged: the whole-particle-per-step count and looping guard are the same tested helper on both paths.

## Verification

- `test_particle_emit` and the existing `test_particle_sim` pass (emit test under ASan/UBSan). ASan/logic caught a rounding bug in an earlier int-based count estimate (stuck at 1 on decay); the estimate now carries a float and rounds only at the getter.
- `particle_ssbo.vert` and `particle_emit.compute` validate clean under `glslangValidator`.
- `ParticleSystem.cpp` syntax-checks against the real GL/glm headers; `static_assert`s pin the `Particle` (80 bytes) and `EmitterConfigGPU` (208 bytes, std140) layouts the shaders depend on.

## Note

The GPU/GL path cannot be run headlessly here, so correctness rests on the tested cores, the shaders mirroring them, glslang validation, and the layout `static_assert`s. Visual parity between CPU and GPU is anchored on the shared, tested update step. The exact live count is now an estimate rather than a per-frame readback (that readback was the point of removal); no critical consumer depends on its exactness.