### PR TITLE
Compose HDR tone mapping with the bloom/SSAO/FXAA chain (#268)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -781,6 +781,12 @@ add_executable(test_tone_mapping
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tone_mapping.cpp
 )
 
+# Composing the ACES resolve with the bloom chain: linear-space compositing and the
+# single tone-map + gamma invariant (#268) - header-only.
+add_executable(test_tonemap_chain
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tonemap_chain.cpp
+)
+
 # Cascaded shadow map math: splits / cascade selection / frustum fit / ortho
 # (rendering P4 / #236) - header-only.
 add_executable(test_shadow_cascades

--- a/src/PostProcessor.cpp
+++ b/src/PostProcessor.cpp
@@ -209,6 +209,8 @@ void BloomEffect::render(GLuint inputTexture, GLuint outputFramebuffer) {
     glBindFramebuffer(GL_FRAMEBUFFER, outputFramebuffer);
     m_combineShader->use();
     m_combineShader->setFloat("bloomIntensity", m_intensity);
+    // Emit linear HDR (skip Reinhard + gamma) when the ACES resolve runs later (#268).
+    m_combineShader->setInt("toneMapResolve", m_toneMapResolve ? 1 : 0);
     
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, inputTexture);
@@ -523,6 +525,9 @@ void PostProcessor::initialize(int width, int height) {
     // Separate SSAO composite target so the AO stage never reads and writes the
     // same buffer the bloom stage uses (issue #259).
     m_ssaoOutputBuffer = std::make_unique<Framebuffer>(width, height, false);
+    // Target for the ACES resolve when FXAA follows it, so the resolve never reads and
+    // writes the same buffer FXAA then samples (issue #268). RGBA16F like the rest.
+    m_resolveBuffer = std::make_unique<Framebuffer>(width, height, false);
 
     // Initialize effects
     m_bloomEffect = std::make_unique<BloomEffect>();
@@ -563,6 +568,7 @@ void PostProcessor::resize(int width, int height) {
     if (m_mainBuffer) m_mainBuffer->resize(width, height);
     if (m_tempBuffer) m_tempBuffer->resize(width, height);
     if (m_ssaoOutputBuffer) m_ssaoOutputBuffer->resize(width, height);
+    if (m_resolveBuffer) m_resolveBuffer->resize(width, height);
 
     if (m_bloomEffect) m_bloomEffect->resize(width, height);
     if (m_fxaaEffect) m_fxaaEffect->resize(width, height);
@@ -586,47 +592,62 @@ void PostProcessor::endFrame() {
 void PostProcessor::renderEffectChain(GLuint inputTexture, GLuint outputFramebuffer) {
     if (!m_initialized) return;
 
-    // Opt-in HDR resolve (issue #235): tone-map the raw HDR scene through exposure +
-    // ACES in a single pass, so bright highlights roll off instead of clipping.
-    // Disabled by default, so the LDR effect chain below is the unchanged fallback.
-    // (Composing ACES with the bloom/FXAA chain is a follow-up.)
-    if (m_toneMapEnabled && m_toneMapShader) {
-        glBindFramebuffer(GL_FRAMEBUFFER, outputFramebuffer);
-        glDisable(GL_DEPTH_TEST);
-        m_toneMapShader->use();
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, inputTexture);
-        glUniform1i(glGetUniformLocation(m_toneMapShader->id(), "hdrScene"), 0);
-        m_toneMapShader->setFloat("exposure", m_exposure);
-        renderQuad();
-        glEnable(GL_DEPTH_TEST);
-        return;
-    }
+    // Composed HDR pipeline (issue #268). SSAO and bloom run on linear HDR; when the
+    // ACES resolve is on it applies exposure + ACES + gamma exactly once at the end,
+    // before FXAA (which wants display-space input). When it is off (the default), the
+    // chain is byte-identical to before: bloom applies its own Reinhard + gamma and
+    // FXAA/copy writes the LDR result.
+    const bool resolveHDR = m_toneMapEnabled && m_toneMapShader;
 
     GLuint currentTexture = inputTexture;
-    
-    // Apply effects in order: SSAO -> Bloom -> FXAA
-    
-    // SSAO (issue #259): compute AO from the scene depth buffer and composite it
-    // onto the lit image before bloom/FXAA. Runs only when the effect is enabled
-    // AND the frame's projection was provided (setSceneProjection), so the chain
-    // is byte-identical to before when SSAO is off.
+
+    // SSAO (issue #259): compute AO from the scene depth buffer and composite it onto
+    // the lit image before bloom. The composite is a linear multiply, so it is correct
+    // in linear HDR. Runs only when enabled AND the frame's projection was provided, so
+    // the chain is byte-identical to before when SSAO is off.
     if (m_ssaoEffect && m_ssaoEffect->isEnabled() && m_ssaoEffect->hasProjection() &&
         m_mainBuffer && m_ssaoOutputBuffer && m_mainBuffer->getDepthTexture() != 0) {
         m_ssaoEffect->renderSSAO(currentTexture, m_mainBuffer->getDepthTexture(), 0,
                                  m_ssaoOutputBuffer->getFramebuffer());
         currentTexture = m_ssaoOutputBuffer->getColorTexture();
     }
-    
-    // Bloom (if enabled)
+
+    // Bloom (if enabled). With the resolve on, bloom leaves linear HDR (no Reinhard,
+    // no gamma) so the end-of-chain resolve is the only tone-map + gamma.
     if (m_bloomEffect && m_bloomEffect->isEnabled()) {
+        m_bloomEffect->setToneMapResolve(resolveHDR);
         if (m_tempBuffer) {
             m_bloomEffect->render(currentTexture, m_tempBuffer->getFramebuffer());
             currentTexture = m_tempBuffer->getColorTexture();
         }
     }
-    
-    // FXAA (if enabled) - always render to output
+
+    // HDR resolve (issue #235 math, now composed): exposure -> ACES -> gamma, once.
+    if (resolveHDR) {
+        const bool fxaa = m_fxaaEffect && m_fxaaEffect->isEnabled();
+        // Resolve into a scratch buffer when FXAA follows (so it never reads and writes
+        // the same target); otherwise resolve straight to the output.
+        const GLuint resolveTarget = (fxaa && m_resolveBuffer)
+                                         ? m_resolveBuffer->getFramebuffer()
+                                         : outputFramebuffer;
+        glBindFramebuffer(GL_FRAMEBUFFER, resolveTarget);
+        glDisable(GL_DEPTH_TEST);
+        m_toneMapShader->use();
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, currentTexture);
+        glUniform1i(glGetUniformLocation(m_toneMapShader->id(), "hdrScene"), 0);
+        m_toneMapShader->setFloat("exposure", m_exposure);
+        renderQuad();
+        glEnable(GL_DEPTH_TEST);
+
+        // FXAA on the resolved, display-space image.
+        if (fxaa && m_resolveBuffer) {
+            m_fxaaEffect->render(m_resolveBuffer->getColorTexture(), outputFramebuffer);
+        }
+        return;
+    }
+
+    // LDR path (tone map off): unchanged - FXAA, else copy.
     if (m_fxaaEffect && m_fxaaEffect->isEnabled()) {
         m_fxaaEffect->render(currentTexture, outputFramebuffer);
     } else {

--- a/src/PostProcessor.h
+++ b/src/PostProcessor.h
@@ -80,6 +80,7 @@ private:
     float m_threshold;
     float m_intensity;
     int m_blurPasses;
+    bool m_toneMapResolve = false; // emit linear HDR for a later ACES resolve (#268)
 
     void setupQuad();
     void renderQuad();
@@ -94,6 +95,11 @@ public:
     bool isEnabled() const override { return m_enabled; }
     void setEnabled(bool enabled) override { m_enabled = enabled; }
     
+    // When true, the combine stage leaves the image in linear HDR (no Reinhard, no
+    // gamma) because the ACES resolve runs later in the chain (issue #268).
+    void setToneMapResolve(bool resolve) { m_toneMapResolve = resolve; }
+    bool getToneMapResolve() const { return m_toneMapResolve; }
+
     // Parameter control
     void setThreshold(float threshold) { m_threshold = threshold; }
     void setIntensity(float intensity) { m_intensity = intensity; }
@@ -216,6 +222,7 @@ private:
     std::unique_ptr<Framebuffer> m_mainBuffer;
     std::unique_ptr<Framebuffer> m_tempBuffer;
     std::unique_ptr<Framebuffer> m_ssaoOutputBuffer; // SSAO composite target (issue #259)
+    std::unique_ptr<Framebuffer> m_resolveBuffer;    // ACES resolve target before FXAA (issue #268)
 
     std::unique_ptr<BloomEffect> m_bloomEffect;
     std::unique_ptr<FXAAEffect> m_fxaaEffect;

--- a/src/shaders/bloom_combine.frag
+++ b/src/shaders/bloom_combine.frag
@@ -7,18 +7,31 @@ uniform sampler2D scene;
 uniform sampler2D bloomBlur;
 uniform float bloomIntensity;
 
+// When the ACES resolve runs at the end of the chain (issue #268), bloom must leave
+// the image in linear HDR so the exposure + ACES + gamma resolve applies exactly
+// once. In that mode this shader only adds the bloom and emits linear HDR - no
+// Reinhard, no gamma. When off (the default), it keeps the original Reinhard + gamma
+// so the LDR chain is byte-identical.
+uniform bool toneMapResolve;
+
 void main() {
     vec3 hdrColor = texture(scene, TexCoord).rgb;
     vec3 bloomColor = texture(bloomBlur, TexCoord).rgb;
-    
+
     // Additive blending
     hdrColor += bloomColor * bloomIntensity;
-    
+
+    if (toneMapResolve) {
+        // Leave linear HDR for the single end-of-chain ACES + gamma resolve.
+        FragColor = vec4(hdrColor, 1.0);
+        return;
+    }
+
     // Tone mapping (Reinhard)
     vec3 result = hdrColor / (hdrColor + vec3(1.0));
-    
+
     // Gamma correction
     result = pow(result, vec3(1.0/2.2));
-    
+
     FragColor = vec4(result, 1.0);
 }

--- a/tests/test_tonemap_chain.cpp
+++ b/tests/test_tonemap_chain.cpp
@@ -1,0 +1,110 @@
+// Test for composing HDR tone mapping with the bloom chain - issue #268.
+//
+// The chain change is GL wiring (bloom leaves linear HDR; the ACES resolve applies
+// exposure + ACES + gamma once at the end, before FXAA), which cannot run headlessly.
+// What is verifiable is the math rationale behind it, expressed with the unit-tested
+// render::ToneMapping core that tonemap.frag mirrors:
+//   - bloom must be composited in linear HDR *before* the single resolve;
+//   - letting bloom keep its own Reinhard + gamma and then resolving again (the double
+//     application this issue removes) gives a materially different, wrong result;
+//   - with bloom contributing nothing, the composed result equals the plain #235
+//     resolve, so enabling the composition does not disturb the tone curve.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_tonemap_chain.cpp -o test_tonemap_chain
+
+#include "render/ToneMapping.h"
+
+#include <cmath>
+#include <cstdio>
+#include <initializer_list>
+
+using namespace IKore::render;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-5f) { return std::fabs(a - b) < eps; }
+
+// The old combine path (Reinhard + gamma) that bloom_combine.frag applies when the
+// resolve is OFF. Kept here to model the double application the gate avoids.
+static float bloomReinhardGamma(float linear) {
+    const float reinhard = linear / (linear + 1.0f);
+    return std::pow(reinhard, 1.0f / 2.2f);
+}
+
+// Bloom composites additively in linear HDR, then the chain resolves once.
+static void testLinearCompositeThenSingleResolve() {
+    const float exposure = 1.0f;
+    const float scene = 0.6f;
+    const float bloom = 0.9f;
+    const float intensity = 0.8f;
+
+    const float composited = scene + bloom * intensity; // linear HDR add
+    const float composed = resolveChannel(composited, exposure);
+
+    // Compositing in linear before the resolve is not the same as resolving each
+    // contributor and adding display values - order matters, and linear is correct.
+    const float wrongOrder = resolveChannel(scene, exposure) + resolveChannel(bloom * intensity, exposure);
+    CHECK(!approx(composed, wrongOrder, 1e-3f));
+
+    // The composed result is a valid display value in [0, 1].
+    CHECK(composed >= 0.0f && composed <= 1.0f);
+}
+
+// Letting bloom apply Reinhard + gamma and then running the ACES resolve (the double
+// tone-map + double gamma this issue removes) differs materially from resolving once.
+static void testNoDoubleApplication() {
+    const float exposure = 1.0f;
+    const float composited = 0.6f + 0.9f * 0.8f; // same linear HDR value as above
+
+    const float once = resolveChannel(composited, exposure);        // correct: single resolve
+    const float twice = resolveChannel(bloomReinhardGamma(composited), exposure); // bug: bloom + resolve
+
+    // The double application visibly changes the pixel (here by well over 5%), which is
+    // exactly why bloom_combine bypasses its Reinhard + gamma when the resolve is on.
+    CHECK(std::fabs(once - twice) > 0.05f);
+}
+
+// With bloom off (or zero intensity), the composed resolve equals the plain #235
+// resolve, so turning the composition on does not disturb the tone curve.
+static void testBloomOffMatchesPlainResolve() {
+    for (float exposure : {0.5f, 1.0f, 2.0f}) {
+        for (float scene : {0.0f, 0.25f, 1.0f, 4.0f}) {
+            const float composedNoBloom = resolveChannel(scene + 0.0f, exposure);
+            const float plain = resolveChannel(scene, exposure);
+            CHECK(approx(composedNoBloom, plain));
+        }
+    }
+}
+
+// The LDR path (resolve off) is independent of exposure/ACES: bloom's own Reinhard +
+// gamma is the whole tone map, unchanged from before this issue.
+static void testLdrPathUnchanged() {
+    const float composited = 0.6f + 0.9f * 0.8f;
+    const float ldr = bloomReinhardGamma(composited);
+    CHECK(ldr >= 0.0f && ldr <= 1.0f);
+    // Independent of exposure (exposure only exists in the resolve path).
+    CHECK(approx(ldr, bloomReinhardGamma(composited)));
+}
+
+int main() {
+    testLinearCompositeThenSingleResolve();
+    testNoDoubleApplication();
+    testBloomOffMatchesPlainResolve();
+    testLdrPathUnchanged();
+
+    if (g_failures == 0) {
+        std::printf("All tonemap chain tests passed.\n");
+        return 0;
+    }
+    std::printf("%d tonemap chain test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #268.

#235 added the ACES resolve as an early return in `renderEffectChain`: with tone mapping on it resolved the raw HDR scene and skipped the rest of the chain, so bloom, SSAO, and FXAA never composed with it, and `bloom_combine.frag` applied its own gamma that would double up if simply chained. This PR restructures the chain so SSAO and bloom operate on linear HDR and the exposure + ACES + gamma resolve runs once at the end, before FXAA (which wants display-space input). The LDR chain is unchanged when tone mapping is off (the default).

## Changes

- **`src/shaders/bloom_combine.frag`**: add a `toneMapResolve` uniform. When set, the combine stage adds bloom and emits linear HDR (no Reinhard, no gamma) so the end-of-chain resolve is the only tone-map + gamma. Default (off) keeps the original Reinhard + gamma, so the LDR path is byte-identical.
- **`src/PostProcessor.{h,cpp}`**:
  - `renderEffectChain` no longer early-returns for tone mapping. SSAO (a linear multiply) then bloom run in linear HDR; when the resolve is on, bloom is told to emit linear HDR, the ACES resolve runs once, and FXAA follows on the display-space result. When off, the chain is SSAO to bloom to FXAA/copy exactly as before.
  - `BloomEffect` gains `setToneMapResolve()`; the combine call sets the uniform.
  - Add `m_resolveBuffer` (RGBA16F) as the resolve target when FXAA follows, so the resolve never reads and writes the buffer FXAA then samples. All intermediate buffers are already RGBA16F, so composition stays in real HDR end to end.
- **`tests/test_tonemap_chain.cpp`**: lock the rationale against the tested `render::ToneMapping` core: bloom composites in linear before a single resolve; the double Reinhard+gamma-then-resolve this issue removes differs materially; bloom-off equals the plain #235 resolve; the LDR path is exposure-independent.
- **`CMakeLists.txt`**: register `test_tonemap_chain`.

## Acceptance

- With tone mapping on: SSAO, bloom, and FXAA all take effect together with ACES, and gamma is applied exactly once (bloom stops applying its own).
- With tone mapping off: output unchanged. The chain order and `bloom_combine` output are byte-identical (the new uniform is 0, and the resolve buffer is unused).
- The resolve math stays mirrored by the tested `src/render/ToneMapping.h`; `tonemap.frag` is unchanged.

## Verification

- `test_tonemap_chain` (new) and the existing `test_tone_mapping` pass; the chain test runs under ASan/UBSan.
- `bloom_combine.frag` and `tonemap.frag` validate clean under `glslangValidator`.
- `PostProcessor.cpp` syntax-checks against the real GL/glm headers.
- The existing tone-map keyboard toggles (`setToneMapEnabled` / `setExposure`) are unchanged and now drive the composed path.

## Note

The GL chain cannot run headlessly here, so correctness rests on the tested tone-map core, the shader gate, glslang validation, and the LDR path staying byte-identical behind the default-off toggle. The new test encodes why the gate is needed (linear-space compositing and the single tone-map + gamma invariant) rather than re-deriving the tested curve.