### PR TITLE
PBR: textured metallic-roughness materials + per-mesh program selection (#269)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,6 +776,11 @@ add_executable(test_pbr_material
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pbr_material.cpp
 )
 
+# PBR texture/factor blending rule mirrored by pbr.frag (#269) - header-only.
+add_executable(test_pbr_textures
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pbr_textures.cpp
+)
+
 # HDR exposure + ACES tone-mapping resolve math (rendering P3 / #235) - header-only.
 add_executable(test_tone_mapping
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tone_mapping.cpp

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -1,6 +1,7 @@
 #include "Model.h"
 #include "Shader.h"
 #include "core/Logger.h"
+#include <glm/gtc/type_ptr.hpp> // glm::value_ptr for renderSelectable (issue #269)
 
 #include <iostream>
 #include <filesystem>
@@ -182,43 +183,83 @@ void Mesh::render(std::shared_ptr<Shader> shader) const {
     if (!m_isSetup || !shader) return;
     
     shader->use();
-    
+
     // Bind textures and set uniforms
     GLuint textureUnit = 0;
-    
-    // Diffuse texture
-    if (m_material.hasDiffuseTexture()) {
-        m_material.diffuse->bind(textureUnit);
-        shader->setFloat("material.useDiffuseTexture", 1.0f);
-        glUniform1i(glGetUniformLocation(shader->id(), "material.diffuse"), textureUnit++);
+
+    if (m_material.isPBR) {
+        // Metallic-roughness PBR binding (issue #269): scalar factors plus optional
+        // albedo / metallic-roughness / AO / normal maps. The shader multiplies each
+        // factor by its map (or 1 when absent), mirroring render::resolvePbrInputs.
+        shader->setVec3("material.albedo", m_material.albedo.x, m_material.albedo.y, m_material.albedo.z);
+        shader->setFloat("material.metallic", m_material.metallic);
+        shader->setFloat("material.roughness", m_material.roughness);
+        shader->setFloat("material.ao", m_material.ao);
+
+        if (m_material.hasAlbedoTexture()) {
+            m_material.albedoMap->bind(textureUnit);
+            shader->setInt("useAlbedoMap", 1);
+            glUniform1i(glGetUniformLocation(shader->id(), "albedoMap"), textureUnit++);
+        } else {
+            shader->setInt("useAlbedoMap", 0);
+        }
+        if (m_material.hasMetallicRoughnessTexture()) {
+            m_material.metallicRoughnessMap->bind(textureUnit);
+            shader->setInt("useMetallicRoughnessMap", 1);
+            glUniform1i(glGetUniformLocation(shader->id(), "metallicRoughnessMap"), textureUnit++);
+        } else {
+            shader->setInt("useMetallicRoughnessMap", 0);
+        }
+        if (m_material.hasAoTexture()) {
+            m_material.aoMap->bind(textureUnit);
+            shader->setInt("useAoMap", 1);
+            glUniform1i(glGetUniformLocation(shader->id(), "aoMap"), textureUnit++);
+        } else {
+            shader->setInt("useAoMap", 0);
+        }
+        if (m_material.hasNormalTexture()) {
+            m_material.normal->bind(textureUnit);
+            shader->setInt("useNormalMap", 1);
+            glUniform1i(glGetUniformLocation(shader->id(), "normalMap"), textureUnit++);
+        } else {
+            shader->setInt("useNormalMap", 0);
+        }
     } else {
-        shader->setFloat("material.useDiffuseTexture", 0.0f);
+        // Blinn-Phong binding (unchanged).
+        // Diffuse texture
+        if (m_material.hasDiffuseTexture()) {
+            m_material.diffuse->bind(textureUnit);
+            shader->setFloat("material.useDiffuseTexture", 1.0f);
+            glUniform1i(glGetUniformLocation(shader->id(), "material.diffuse"), textureUnit++);
+        } else {
+            shader->setFloat("material.useDiffuseTexture", 0.0f);
+        }
+
+        // Specular texture
+        if (m_material.hasSpecularTexture()) {
+            m_material.specular->bind(textureUnit);
+            shader->setFloat("material.useSpecularTexture", 1.0f);
+            glUniform1i(glGetUniformLocation(shader->id(), "material.specular"), textureUnit++);
+        } else {
+            shader->setFloat("material.useSpecularTexture", 0.0f);
+        }
+
+        // Normal texture
+        if (m_material.hasNormalTexture()) {
+            m_material.normal->bind(textureUnit);
+            shader->setFloat("material.useNormalTexture", 1.0f);
+            glUniform1i(glGetUniformLocation(shader->id(), "material.normal"), textureUnit++);
+        } else {
+            shader->setFloat("material.useNormalTexture", 0.0f);
+        }
+
+        // Set material color properties
+        shader->setVec3("material.ambientColor", m_material.ambientColor.x, m_material.ambientColor.y, m_material.ambientColor.z);
+        shader->setVec3("material.diffuseColor", m_material.diffuseColor.x, m_material.diffuseColor.y, m_material.diffuseColor.z);
+        shader->setVec3("material.specularColor", m_material.specularColor.x, m_material.specularColor.y, m_material.specularColor.z);
+        shader->setFloat("material.shininess", m_material.shininess);
     }
-    
-    // Specular texture
-    if (m_material.hasSpecularTexture()) {
-        m_material.specular->bind(textureUnit);
-        shader->setFloat("material.useSpecularTexture", 1.0f);
-        glUniform1i(glGetUniformLocation(shader->id(), "material.specular"), textureUnit++);
-    } else {
-        shader->setFloat("material.useSpecularTexture", 0.0f);
-    }
-    
-    // Normal texture
-    if (m_material.hasNormalTexture()) {
-        m_material.normal->bind(textureUnit);
-        shader->setFloat("material.useNormalTexture", 1.0f);
-        glUniform1i(glGetUniformLocation(shader->id(), "material.normal"), textureUnit++);
-    } else {
-        shader->setFloat("material.useNormalTexture", 0.0f);
-    }
-    
-    // Set material color properties
-    shader->setVec3("material.ambientColor", m_material.ambientColor.x, m_material.ambientColor.y, m_material.ambientColor.z);
-    shader->setVec3("material.diffuseColor", m_material.diffuseColor.x, m_material.diffuseColor.y, m_material.diffuseColor.z);
-    shader->setVec3("material.specularColor", m_material.specularColor.x, m_material.specularColor.y, m_material.specularColor.z);
-    shader->setFloat("material.shininess", m_material.shininess);
-    
+
     // Draw mesh
     glBindVertexArray(m_VAO);
     glDrawElements(GL_TRIANGLES, static_cast<unsigned int>(m_indices.size()), GL_UNSIGNED_INT, 0);
@@ -481,7 +522,48 @@ Material Model::loadMaterial(aiMaterial* mat) {
     if (mat->Get(AI_MATKEY_SHININESS, shininess) == AI_SUCCESS) {
         material.shininess = shininess;
     }
-    
+
+    // Metallic-roughness PBR import (issue #269). A glTF-style asset provides PBR
+    // factors and/or textures; when any are present, mark the material PBR so the
+    // renderer picks the PBR program. Materials without them stay Blinn-Phong.
+    material.albedoMap = loadMaterialTexture(mat, aiTextureType_BASE_COLOR, Texture::Type::ALBEDO);
+    // glTF packs metallic-roughness in one texture; assimp exposes it under both
+    // METALNESS and DIFFUSE_ROUGHNESS, so accept whichever the importer filled.
+    material.metallicRoughnessMap =
+        loadMaterialTexture(mat, aiTextureType_METALNESS, Texture::Type::METALLIC_ROUGHNESS);
+    if (!material.metallicRoughnessMap) {
+        material.metallicRoughnessMap =
+            loadMaterialTexture(mat, aiTextureType_DIFFUSE_ROUGHNESS, Texture::Type::METALLIC_ROUGHNESS);
+    }
+    material.aoMap = loadMaterialTexture(mat, aiTextureType_AMBIENT_OCCLUSION, Texture::Type::AMBIENT_OCCLUSION);
+    if (!material.aoMap) {
+        material.aoMap = loadMaterialTexture(mat, aiTextureType_LIGHTMAP, Texture::Type::AMBIENT_OCCLUSION);
+    }
+
+    aiColor4D baseColor;
+    const bool hasBaseColor = mat->Get(AI_MATKEY_BASE_COLOR, baseColor) == AI_SUCCESS;
+    if (hasBaseColor) {
+        material.albedo = glm::vec3(baseColor.r, baseColor.g, baseColor.b);
+    }
+    float metallicFactor = 0.0f, roughnessFactor = 0.5f;
+    const bool hasMetallic = mat->Get(AI_MATKEY_METALLIC_FACTOR, metallicFactor) == AI_SUCCESS;
+    const bool hasRoughness = mat->Get(AI_MATKEY_ROUGHNESS_FACTOR, roughnessFactor) == AI_SUCCESS;
+    if (hasMetallic) material.metallic = metallicFactor;
+    if (hasRoughness) material.roughness = roughnessFactor;
+
+    material.isPBR = hasBaseColor || hasMetallic || hasRoughness ||
+                     material.hasAlbedoTexture() || material.hasMetallicRoughnessTexture() ||
+                     material.hasAoTexture();
+    if (material.isPBR) {
+        // Only for PBR materials, fill the normal slot from the glTF NORMALS channel
+        // when the Phong-style HEIGHT normal was absent. Gating on isPBR keeps
+        // Blinn-Phong materials byte-identical (their normal slot is untouched).
+        if (!material.normal) {
+            material.normal = loadMaterialTexture(mat, aiTextureType_NORMALS, Texture::Type::NORMAL);
+        }
+        LOG_INFO("Material imported as metallic-roughness PBR");
+    }
+
     return material;
 }
 
@@ -542,6 +624,24 @@ Texture::Type Model::aiTextureTypeToTextureType(aiTextureType type) {
 
 void Model::render(std::shared_ptr<Shader> shader) const {
     for (const auto& mesh : m_meshes) {
+        mesh->render(shader);
+    }
+}
+
+void Model::renderSelectable(std::shared_ptr<Shader> phongShader, std::shared_ptr<Shader> pbrShader,
+                             const glm::mat4& model, const glm::mat3& normalMatrix) const {
+    for (const auto& mesh : m_meshes) {
+        // Pick the PBR program for PBR meshes (issue #269); everything else stays on
+        // the Blinn-Phong path. Falls back to Phong when no PBR program is provided.
+        const bool usePbr = pbrShader && mesh->getMaterial().isPBR;
+        std::shared_ptr<Shader> shader = usePbr ? pbrShader : phongShader;
+        if (!shader) continue;
+
+        // Per-mesh matrices go on the chosen program (frame/light uniforms are set on
+        // both by the caller). Mesh::render also calls use(), binding this program.
+        shader->use();
+        shader->setMat4("model", glm::value_ptr(model));
+        shader->setMat3("normalMatrix", glm::value_ptr(normalMatrix));
         mesh->render(shader);
     }
 }

--- a/src/Model.h
+++ b/src/Model.h
@@ -52,12 +52,21 @@ struct Material {
     float roughness = 0.5f;
     float ao = 1.0f;
 
+    // Metallic-roughness PBR textures (issue #269). Optional: when a map is absent the
+    // corresponding scalar factor above is used unchanged (glTF factor * texture rule).
+    std::shared_ptr<Texture> albedoMap;             // base color
+    std::shared_ptr<Texture> metallicRoughnessMap;  // glTF packed: G roughness, B metallic
+    std::shared_ptr<Texture> aoMap;                 // ambient occlusion (R)
+
     // Flags to indicate texture availability
     bool hasDiffuseTexture() const { return diffuse && diffuse->isLoaded(); }
     bool hasSpecularTexture() const { return specular && specular->isLoaded(); }
     bool hasNormalTexture() const { return normal && normal->isLoaded(); }
     bool hasHeightTexture() const { return height && height->isLoaded(); }
     bool hasEmissiveTexture() const { return emissive && emissive->isLoaded(); }
+    bool hasAlbedoTexture() const { return albedoMap && albedoMap->isLoaded(); }
+    bool hasMetallicRoughnessTexture() const { return metallicRoughnessMap && metallicRoughnessMap->isLoaded(); }
+    bool hasAoTexture() const { return aoMap && aoMap->isLoaded(); }
 };
 
 class Mesh {
@@ -156,6 +165,13 @@ public:
     
     // Render the entire model
     void render(std::shared_ptr<Shader> shader) const;
+
+    // Render each mesh with the program its material selects (issue #269): meshes with
+    // Material::isPBR draw with @p pbrShader, the rest with @p phongShader. Per-mesh
+    // model/normal matrices are set on the chosen program; frame/light uniforms must
+    // already be set on both. If @p pbrShader is null, everything uses @p phongShader.
+    void renderSelectable(std::shared_ptr<Shader> phongShader, std::shared_ptr<Shader> pbrShader,
+                          const glm::mat4& model, const glm::mat3& normalMatrix) const;
     
     // Getters
     const std::vector<std::unique_ptr<Mesh>>& getMeshes() const { return m_meshes; }

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -214,6 +214,9 @@ std::string Texture::typeToString(Type type) {
         case Type::NORMAL: return "normal";
         case Type::HEIGHT: return "height";
         case Type::EMISSIVE: return "emissive";
+        case Type::ALBEDO: return "albedo";
+        case Type::METALLIC_ROUGHNESS: return "metallicRoughness";
+        case Type::AMBIENT_OCCLUSION: return "ao";
         default: return "unknown";
     }
 }
@@ -224,6 +227,9 @@ Texture::Type Texture::stringToType(const std::string& typeStr) {
     if (typeStr == "normal") return Type::NORMAL;
     if (typeStr == "height") return Type::HEIGHT;
     if (typeStr == "emissive") return Type::EMISSIVE;
+    if (typeStr == "albedo") return Type::ALBEDO;
+    if (typeStr == "metallicRoughness") return Type::METALLIC_ROUGHNESS;
+    if (typeStr == "ao") return Type::AMBIENT_OCCLUSION;
     return Type::DIFFUSE; // Default
 }
 
@@ -364,6 +370,9 @@ std::string TextureManager::getDefaultUniformName(Texture::Type type) const {
         case Texture::Type::NORMAL: return "material.normal";
         case Texture::Type::HEIGHT: return "material.height";
         case Texture::Type::EMISSIVE: return "material.emissive";
+        case Texture::Type::ALBEDO: return "albedoMap";
+        case Texture::Type::METALLIC_ROUGHNESS: return "metallicRoughnessMap";
+        case Texture::Type::AMBIENT_OCCLUSION: return "aoMap";
         default: return "material.texture";
     }
 }

--- a/src/Texture.h
+++ b/src/Texture.h
@@ -15,7 +15,11 @@ public:
         SPECULAR,
         NORMAL,
         HEIGHT,
-        EMISSIVE
+        EMISSIVE,
+        // Metallic-roughness PBR maps (issue #269).
+        ALBEDO,             // base color
+        METALLIC_ROUGHNESS, // glTF packed: G = roughness, B = metallic
+        AMBIENT_OCCLUSION   // R channel
     };
 
     enum class Format {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -939,7 +939,28 @@ int main() {
             
             // No spot lights for now
             shaderPtr->setFloat("numSpotLights", 0.0f);
-            
+
+            // PBR frame uniforms (issue #269): set once so meshes selected onto the PBR
+            // program (by Material::isPBR, via Model::renderSelectable below) are lit
+            // consistently with the Phong scene. Reuses the same directional + point
+            // light. Cheap and only matters when a mesh opts into PBR.
+            if (pbrShaderPtr) {
+                pbrShaderPtr->use();
+                pbrShaderPtr->setMat4("view", glm::value_ptr(view));
+                pbrShaderPtr->setMat4("projection", glm::value_ptr(projection));
+                pbrShaderPtr->setVec3("viewPos", cameraPos.x, cameraPos.y, cameraPos.z);
+                pbrShaderPtr->setInt("useDirLight", 1);
+                pbrShaderPtr->setVec3("dirLight.direction", dirLight.direction.x, dirLight.direction.y, dirLight.direction.z);
+                pbrShaderPtr->setVec3("dirLight.diffuse", dirLight.diffuse.x, dirLight.diffuse.y, dirLight.diffuse.z);
+                pbrShaderPtr->setInt("numPointLights", 1);
+                pbrShaderPtr->setVec3("pointLights[0].position", pointLight.position.x, pointLight.position.y, pointLight.position.z);
+                pbrShaderPtr->setVec3("pointLights[0].diffuse", pointLight.diffuse.x, pointLight.diffuse.y, pointLight.diffuse.z);
+                pbrShaderPtr->setFloat("pointLights[0].constant", pointLight.constant);
+                pbrShaderPtr->setFloat("pointLights[0].linear", pointLight.linear);
+                pbrShaderPtr->setFloat("pointLights[0].quadratic", pointLight.quadratic);
+                shaderPtr->use(); // restore the Phong program for the draw loop below
+            }
+
             // Render models if available, otherwise fallback to primitive cubes
             if (modelLoaded && !cubeModel.getMeshes().empty()) {
                 // Create a larger grid of objects for better frustum culling demonstration
@@ -977,13 +998,12 @@ int main() {
                     
                     renderedObjects++;
                     glm::mat3 cubeNormalMatrix = glm::mat3(glm::transpose(glm::inverse(instanceModel)));
-                    
-                    // Update matrices for this cube
-                    shaderPtr->setMat4("model", glm::value_ptr(instanceModel));
-                    shaderPtr->setMat3("normalMatrix", glm::value_ptr(cubeNormalMatrix));
-                    
-                    // Render the model instance
-                    cubeModel.render(shaderPtr);
+
+                    // Render the model instance, selecting the PBR or Blinn-Phong program
+                    // per mesh from Material::isPBR (issue #269). renderSelectable sets the
+                    // per-mesh matrices on the chosen program; boneless Phong meshes take
+                    // the existing path unchanged.
+                    cubeModel.renderSelectable(shaderPtr, pbrShaderPtr, instanceModel, cubeNormalMatrix);
                 }
                 
                 // Log culling statistics periodically
@@ -1066,44 +1086,10 @@ int main() {
             textureManager.unbindAll();
         }
 
-        // Opt-in PBR showcase (issue #234): a row of metallic-roughness cubes drawn
-        // with the PBR program, next to (above) the Blinn-Phong scene rendered above.
-        // This block is purely additive - it does not touch the Phong draws, so
-        // existing content renders byte-for-byte unchanged.
-        if (pbrShaderPtr && modelLoaded && !cubeModel.getMeshes().empty()) {
-            pbrShaderPtr->use();
-            pbrShaderPtr->setMat4("view", glm::value_ptr(view));
-            pbrShaderPtr->setMat4("projection", glm::value_ptr(projection));
-            glm::vec3 pbrCamPos = camera.getPosition();
-            pbrShaderPtr->setVec3("viewPos", pbrCamPos.x, pbrCamPos.y, pbrCamPos.z);
-
-            // Reuse the scene's directional + point light for the PBR objects.
-            pbrShaderPtr->setInt("useDirLight", 1);
-            pbrShaderPtr->setVec3("dirLight.direction", dirLight.direction.x, dirLight.direction.y, dirLight.direction.z);
-            pbrShaderPtr->setVec3("dirLight.diffuse", dirLight.diffuse.x, dirLight.diffuse.y, dirLight.diffuse.z);
-            pbrShaderPtr->setInt("numPointLights", 1);
-            pbrShaderPtr->setVec3("pointLights[0].position", pointLight.position.x, pointLight.position.y, pointLight.position.z);
-            pbrShaderPtr->setVec3("pointLights[0].diffuse", pointLight.diffuse.x, pointLight.diffuse.y, pointLight.diffuse.z);
-            pbrShaderPtr->setFloat("pointLights[0].constant", pointLight.constant);
-            pbrShaderPtr->setFloat("pointLights[0].linear", pointLight.linear);
-            pbrShaderPtr->setFloat("pointLights[0].quadratic", pointLight.quadratic);
-
-            const int kPbrShowcaseCount = 5;
-            for (int i = 0; i < kPbrShowcaseCount; ++i) {
-                const float t = static_cast<float>(i) / static_cast<float>(kPbrShowcaseCount - 1);
-                glm::mat4 pbrModel = glm::mat4(1.0f);
-                pbrModel = glm::translate(pbrModel, glm::vec3(-8.0f + i * 4.0f, 12.0f, 0.0f));
-                const glm::mat3 pbrNormal = glm::mat3(glm::transpose(glm::inverse(pbrModel)));
-                pbrShaderPtr->setMat4("model", glm::value_ptr(pbrModel));
-                pbrShaderPtr->setMat3("normalMatrix", glm::value_ptr(pbrNormal));
-                // Metallic increases left -> right; fixed mid-low roughness.
-                pbrShaderPtr->setVec3("material.albedo", 0.9f, 0.2f, 0.2f);
-                pbrShaderPtr->setFloat("material.metallic", t);
-                pbrShaderPtr->setFloat("material.roughness", 0.35f);
-                pbrShaderPtr->setFloat("material.ao", 1.0f);
-                cubeModel.render(pbrShaderPtr);
-            }
-        }
+        // The PBR path is now driven per mesh by Material::isPBR via
+        // Model::renderSelectable above (issue #269), replacing the hardcoded #234
+        // showcase row: a glTF-style asset renders through the PBR program with its
+        // imported textures, while Blinn-Phong meshes stay on the existing path.
         });  // end forward pass handler
 
         frameGraph.setHandler(IKore::render::passes::Particles, [&]() {

--- a/src/render/PbrMaterial.h
+++ b/src/render/PbrMaterial.h
@@ -32,6 +32,34 @@ struct PbrMaterial {
     float ao{1.0f};
 };
 
+/**
+ * @brief Combine scalar PBR factors with sampled texture values (issue #269).
+ * @param factors           The material's scalar factors (albedo/metallic/roughness/ao).
+ * @param albedoTexel       Base-color texture sample, or {1,1,1} when no albedo map.
+ * @param mrGreenRoughness  Green channel of the metallic-roughness texture (roughness),
+ *                          or 1 when no map. glTF packs roughness in G.
+ * @param mrBlueMetallic    Blue channel of the metallic-roughness texture (metallic),
+ *                          or 1 when no map. glTF packs metallic in B.
+ * @param aoTexel           Red channel of the occlusion texture, or 1 when no AO map.
+ * @return The resolved inputs to feed evaluateDirectionalPbr / the PBR shader.
+ *
+ * The blend is multiplicative (factor * texture channel), the glTF metallic-roughness
+ * convention: a missing texture passes 1 so the factor is used unchanged, and a factor
+ * of 1 uses the texture unchanged. src/shaders/pbr.frag mirrors this exactly, so the
+ * texture/uniform blending rule is unit-tested even though GLSL is not compiled in CI.
+ */
+inline PbrMaterial resolvePbrInputs(const PbrMaterial& factors, const ecs::Vec3& albedoTexel,
+                                    float mrGreenRoughness, float mrBlueMetallic, float aoTexel) {
+    PbrMaterial r;
+    r.enabled = factors.enabled;
+    r.albedo = ecs::Vec3{factors.albedo.x * albedoTexel.x, factors.albedo.y * albedoTexel.y,
+                         factors.albedo.z * albedoTexel.z};
+    r.metallic = factors.metallic * mrBlueMetallic;
+    r.roughness = factors.roughness * mrGreenRoughness;
+    r.ao = factors.ao * aoTexel;
+    return r;
+}
+
 namespace detail {
 
 inline float dot3(const ecs::Vec3& a, const ecs::Vec3& b) {

--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -4,6 +4,7 @@ out vec4 FragColor;
 in vec3 FragPos;
 in vec3 Normal;
 in vec2 TexCoord;
+in mat3 TBN;
 
 // Metallic-roughness material (issue #234). This fragment path is only used by
 // materials that opt in; Blinn-Phong materials use phong_shadows.frag unchanged.
@@ -13,6 +14,19 @@ struct Material {
     float roughness;
     float ao;
 };
+
+// Textured metallic-roughness (issue #269). Each map is optional; when absent the
+// corresponding use* flag is false and the scalar factor above is used unchanged.
+// glTF packs roughness in the G channel and metallic in the B channel of the
+// metallic-roughness texture, and occlusion in the R channel of the AO texture.
+uniform sampler2D albedoMap;
+uniform sampler2D metallicRoughnessMap;
+uniform sampler2D aoMap;
+uniform sampler2D normalMap;
+uniform bool useAlbedoMap;
+uniform bool useMetallicRoughnessMap;
+uniform bool useAoMap;
+uniform bool useNormalMap;
 
 struct DirectionalLight {
     vec3 direction; // direction the light travels
@@ -92,12 +106,27 @@ vec3 shadePbr(vec3 N, vec3 V, vec3 L, vec3 radiance, vec3 albedo, float metallic
 }
 
 void main() {
-    vec3 N = normalize(Normal);
+    // Surface normal: perturb by the normal map when bound (tangent space via TBN),
+    // else the interpolated vertex normal. Mirrors phong_shadows.frag's normal path.
+    vec3 N;
+    if (useNormalMap) {
+        vec3 tangentNormal = texture(normalMap, TexCoord).rgb * 2.0 - 1.0;
+        N = normalize(TBN * tangentNormal);
+    } else {
+        N = normalize(Normal);
+    }
     vec3 V = normalize(viewPos - FragPos);
 
-    vec3 albedo = material.albedo;
-    float metallic = material.metallic;
-    float roughness = material.roughness;
+    // Combine scalar factors with the textures the glTF way (factor * channel, a
+    // missing map passing 1). Mirrors render::resolvePbrInputs in PbrMaterial.h.
+    vec3 albedoTexel = useAlbedoMap ? texture(albedoMap, TexCoord).rgb : vec3(1.0);
+    vec2 mrTexel = useMetallicRoughnessMap ? texture(metallicRoughnessMap, TexCoord).gb : vec2(1.0);
+    float aoTexel = useAoMap ? texture(aoMap, TexCoord).r : 1.0;
+
+    vec3 albedo = material.albedo * albedoTexel;
+    float roughness = material.roughness * mrTexel.x; // G channel
+    float metallic = material.metallic * mrTexel.y;   // B channel
+    float ao = material.ao * aoTexel;
 
     vec3 Lo = vec3(0.0);
     if (useDirLight) {
@@ -115,7 +144,7 @@ void main() {
     }
 
     // Simple ambient so unlit faces are not pure black (IBL replaces this later).
-    vec3 ambient = vec3(0.03) * albedo * material.ao;
+    vec3 ambient = vec3(0.03) * albedo * ao;
     vec3 color = ambient + Lo;
 
     // Reinhard tone map + gamma for display.

--- a/src/shaders/pbr.vert
+++ b/src/shaders/pbr.vert
@@ -2,10 +2,12 @@
 layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec3 aNormal;
 layout (location = 2) in vec2 aTexCoord;
+layout (location = 3) in vec3 aTangent; // supplied by the mesh VAO (issue #238)
 
 out vec3 FragPos;
 out vec3 Normal;
 out vec2 TexCoord;
+out mat3 TBN; // tangent-space -> world basis for normal mapping (issue #269)
 
 uniform mat4 model;
 uniform mat4 view;
@@ -18,5 +20,15 @@ void main() {
     FragPos = vec3(model * vec4(aPos, 1.0));
     Normal = normalMatrix * aNormal;
     TexCoord = aTexCoord;
+
+    // TBN basis for tangent-space normal maps (issue #269). Same Gram-Schmidt as
+    // phong_shadows.vert (mirrors src/render/NormalMapping.h); only used by the
+    // fragment shader when a normal map is bound, so meshes without one are unaffected.
+    vec3 N = normalize(Normal);
+    vec3 T = normalize(normalMatrix * aTangent);
+    T = normalize(T - dot(T, N) * N);
+    vec3 B = cross(N, T);
+    TBN = mat3(T, B, N);
+
     gl_Position = projection * view * vec4(FragPos, 1.0);
 }

--- a/tests/test_pbr_textures.cpp
+++ b/tests/test_pbr_textures.cpp
@@ -1,0 +1,114 @@
+// Test for the PBR texture/factor blending rule - issue #269.
+//
+// resolvePbrInputs() combines the scalar material factors with sampled albedo,
+// metallic-roughness, and AO texture channels the glTF way (factor * texture, with a
+// missing texture passing 1). src/shaders/pbr.frag mirrors it, so testing it here
+// locks the texture/uniform blending headlessly (GLSL is not compiled in CI) and
+// keeps the CPU reference and the shader in agreement.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_pbr_textures.cpp -o test_pbr_textures
+
+#include "render/PbrMaterial.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore::render;
+using Vec3 = IKore::ecs::Vec3;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-5f) { return std::fabs(a - b) < eps; }
+
+// With no textures (all channels 1), the resolved inputs equal the scalar factors.
+static void testNoTexturesUsesFactors() {
+    PbrMaterial m;
+    m.enabled = true;
+    m.albedo = Vec3{0.8f, 0.4f, 0.2f};
+    m.metallic = 0.6f;
+    m.roughness = 0.3f;
+    m.ao = 0.9f;
+
+    const PbrMaterial r = resolvePbrInputs(m, Vec3{1.0f, 1.0f, 1.0f}, 1.0f, 1.0f, 1.0f);
+    CHECK(r.enabled);
+    CHECK(approx(r.albedo.x, 0.8f) && approx(r.albedo.y, 0.4f) && approx(r.albedo.z, 0.2f));
+    CHECK(approx(r.metallic, 0.6f));
+    CHECK(approx(r.roughness, 0.3f));
+    CHECK(approx(r.ao, 0.9f));
+}
+
+// With unit factors, the resolved inputs equal the texture samples (glTF channels:
+// roughness in G, metallic in B, AO in R).
+static void testUnitFactorsUsesTextures() {
+    PbrMaterial m;
+    m.albedo = Vec3{1.0f, 1.0f, 1.0f};
+    m.metallic = 1.0f;
+    m.roughness = 1.0f;
+    m.ao = 1.0f;
+
+    const Vec3 albedoTexel{0.5f, 0.25f, 0.125f};
+    const float roughnessG = 0.7f;
+    const float metallicB = 0.2f;
+    const float aoR = 0.6f;
+    const PbrMaterial r = resolvePbrInputs(m, albedoTexel, roughnessG, metallicB, aoR);
+
+    CHECK(approx(r.albedo.x, 0.5f) && approx(r.albedo.y, 0.25f) && approx(r.albedo.z, 0.125f));
+    CHECK(approx(r.roughness, 0.7f)); // G channel
+    CHECK(approx(r.metallic, 0.2f));  // B channel
+    CHECK(approx(r.ao, 0.6f));        // R channel
+}
+
+// Factor and texture combine multiplicatively (the glTF rule).
+static void testMultiplicativeBlend() {
+    PbrMaterial m;
+    m.albedo = Vec3{0.8f, 0.8f, 0.8f};
+    m.metallic = 0.5f;
+    m.roughness = 0.4f;
+    m.ao = 0.5f;
+
+    const PbrMaterial r = resolvePbrInputs(m, Vec3{0.5f, 0.5f, 0.5f}, 0.5f, 0.4f, 0.2f);
+    CHECK(approx(r.albedo.x, 0.4f)); // 0.8 * 0.5
+    CHECK(approx(r.roughness, 0.2f)); // 0.4 * 0.5 (G)
+    CHECK(approx(r.metallic, 0.2f));  // 0.5 * 0.4 (B)
+    CHECK(approx(r.ao, 0.1f));        // 0.5 * 0.2 (R)
+}
+
+// The resolved inputs feed the tested shading equation unchanged: an all-white AO
+// texture leaves ambient response identical to the scalar-only path.
+static void testResolvedFeedsShading() {
+    PbrMaterial factors;
+    factors.enabled = true;
+    factors.albedo = Vec3{0.9f, 0.1f, 0.1f};
+    factors.metallic = 0.2f;
+    factors.roughness = 0.5f;
+    factors.ao = 1.0f;
+
+    const PbrMaterial noTex = resolvePbrInputs(factors, Vec3{1, 1, 1}, 1.0f, 1.0f, 1.0f);
+    const Vec3 N{0, 0, 1}, V{0, 0, 1}, L{0, 0, 1}, radiance{1, 1, 1};
+    const Vec3 a = evaluateDirectionalPbr(N, V, L, radiance, factors);
+    const Vec3 b = evaluateDirectionalPbr(N, V, L, radiance, noTex);
+    CHECK(approx(a.x, b.x) && approx(a.y, b.y) && approx(a.z, b.z));
+}
+
+int main() {
+    testNoTexturesUsesFactors();
+    testUnitFactorsUsesTextures();
+    testMultiplicativeBlend();
+    testResolvedFeedsShading();
+
+    if (g_failures == 0) {
+        std::printf("All PBR texture blending tests passed.\n");
+        return 0;
+    }
+    std::printf("%d PBR texture blending test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #269.

#234 added the opt-in PBR path (`pbr.vert`/`pbr.frag` mirroring the tested `PbrBrdf.h`/`PbrMaterial.h`), but it was uniform-driven: model loading imported no PBR textures and the only PBR rendering was a hardcoded showcase row in `main.cpp`. This PR imports albedo / metallic-roughness / AO (and glTF normal) textures into `Material`, makes `pbr.frag` sample them with scalar-factor fallback plus tangent-space normal mapping, and selects the PBR program per mesh from `Material::isPBR`. Blinn-Phong materials are untouched.

## Changes

- **`src/render/PbrMaterial.h`** + **`tests/test_pbr_textures.cpp`**: `resolvePbrInputs()`, the factor * texture blend in the glTF convention (roughness in G, metallic in B, AO in R, a missing map passing 1). `pbr.frag` mirrors it, so the blending rule is unit-tested.
- **`src/shaders/pbr.vert`**: emit a TBN basis (same Gram-Schmidt as `phong_shadows.vert`) for tangent-space normal maps.
- **`src/shaders/pbr.frag`**: sample albedo / metallic-roughness / AO / normal maps, each gated by a `use*` flag and combined with the scalar factors exactly as `resolvePbrInputs` does; perturb the normal via TBN when a normal map is bound.
- **`src/Texture.{h,cpp}`**: `ALBEDO` / `METALLIC_ROUGHNESS` / `AMBIENT_OCCLUSION` texture types.
- **`src/Model.{h,cpp}`**: import PBR factors and textures via assimp (`BASE_COLOR`, `METALNESS`/`DIFFUSE_ROUGHNESS`, `AMBIENT_OCCLUSION`/`LIGHTMAP`, and `NORMALS` for PBR materials only), setting `isPBR` when any are present; `Mesh::render` binds the PBR uniforms/textures for PBR materials and the unchanged Blinn-Phong set otherwise; `Model::renderSelectable` picks the program per mesh from `isPBR`.
- **`src/main.cpp`**: upload the PBR frame/light uniforms once, draw the model through `renderSelectable`, and drop the hardcoded #234 showcase.
- **`CMakeLists.txt`**: register `test_pbr_textures`.

## Acceptance

- A glTF-style PBR asset renders through the PBR path with its textures applied (base color, metallic-roughness, AO, normal), selected per mesh by `Material::isPBR`.
- Materials without `isPBR` render byte-identically via Blinn-Phong: `Mesh::render`'s Phong branch is unchanged, and the only shared-slot change (the glTF `NORMALS` fallback) is gated on `isPBR`, so Phong materials' normal slot is untouched.
- The texture/uniform blend is mirrored in the tested reference (`resolvePbrInputs`), which composes with the already-tested `evaluateDirectionalPbr`.

## Verification

- `test_pbr_textures` (new) and the existing `test_pbr_material` pass; the new test runs under ASan/UBSan.
- `pbr.vert` and `pbr.frag` validate clean under `glslangValidator`.
- `Model.cpp`, `Texture.cpp`, and the new `main.cpp` fragments syntax-check against the real GL/glm/assimp/`Shader`/`Model` headers.

## Note

The hardcoded #234 showcase row is replaced by real per-mesh selection, per the issue. In a scene with only Blinn-Phong assets the PBR program simply goes unused (byte-identical Phong output); load a glTF metallic-roughness asset to exercise the PBR path. The GL path cannot be verified headlessly, so correctness rests on the tested core, the shader mirroring it, glslang validation, and the compile checks. Base-color textures are sampled as-is (no sRGB decode), matching the rest of the engine's texture handling; sRGB-correct sampling is a separate follow-up.