### PR TITLE
PBR: image-based lighting (irradiance, prefiltered specular, BRDF LUT) (#270)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ set(ENGINE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ParticleSystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ShadowMap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/CascadedShadowMap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/render/Ibl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Frustum.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/InputComponent.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ControllableEntities.cpp
@@ -779,6 +780,12 @@ add_executable(test_pbr_material
 # PBR texture/factor blending rule mirrored by pbr.frag (#269) - header-only.
 add_executable(test_pbr_textures
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pbr_textures.cpp
+)
+
+# IBL split-sum math: Hammersley, GGX importance sample, BRDF LUT integration, mip
+# <-> roughness mapping, mirrored by the generation shaders (#270) - header-only.
+add_executable(test_ibl_brdf
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ibl_brdf.cpp
 )
 
 # HDR exposure + ACES tone-mapping resolve math (rendering P3 / #235) - header-only.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "ParticleSystem.h"
 #include "ShadowMap.h"
 #include "CascadedShadowMap.h"
+#include "render/Ibl.h"
 #include "Frustum.h"
 #include "render/FrameGraph.h"
 #include "render/ShadowSkinning.h"
@@ -65,6 +66,12 @@ IKore::PostProcessor* g_postProcessor = nullptr;
 
 // Global skybox pointer for keyboard callbacks
 IKore::Skybox* g_skybox = nullptr;
+
+// Image-based lighting for the PBR ambient term (issue #270). Generated at load from
+// the skybox cubemap; g_iblEnabled (toggle B) gates the IBL ambient so the constant-
+// ambient fallback stays available and is used whenever no environment is present.
+IKore::IblEnvironment* g_ibl = nullptr;
+bool g_iblEnabled = true;
 
 // Global debug UI pointer for keyboard callbacks (F1 toggles the overlay)
 IKore::DebugUI* g_debugUI = nullptr;
@@ -217,7 +224,19 @@ int main() {
     }
     
     g_skybox = &skybox; // Set global pointer for keyboard callbacks
-    
+
+    // Generate image-based lighting from the skybox cubemap (issue #270): irradiance,
+    // prefiltered specular, and the BRDF LUT for the PBR ambient term. Opt-in and only
+    // used when valid; PBR materials fall back to constant ambient otherwise.
+    IKore::IblEnvironment iblEnv;
+    if (skyboxLoaded && skybox.isLoaded()) {
+        if (iblEnv.generate(skybox.getTextureID())) {
+            g_ibl = &iblEnv;
+        } else {
+            LOG_WARNING("IBL generation failed - PBR uses constant ambient");
+        }
+    }
+
     // === Particle System Initialization ===
     IKore::ParticleSystemManager particleManager;
     g_particleManager = &particleManager; // Set global pointer for keyboard callbacks
@@ -958,6 +977,28 @@ int main() {
                 pbrShaderPtr->setFloat("pointLights[0].constant", pointLight.constant);
                 pbrShaderPtr->setFloat("pointLights[0].linear", pointLight.linear);
                 pbrShaderPtr->setFloat("pointLights[0].quadratic", pointLight.quadratic);
+
+                // Image-based lighting for the ambient term (issue #270). The IBL
+                // samplers always point at dedicated units 5-7 (which Mesh::render never
+                // uses - it binds material maps to 0-3) so a cube sampler can never
+                // alias unit 0's 2D material texture. Textures are bound and useIBL set
+                // only when a valid environment exists; otherwise the shader keeps the
+                // constant-ambient fallback.
+                pbrShaderPtr->setInt("irradianceMap", 5);
+                pbrShaderPtr->setInt("prefilterMap", 6);
+                pbrShaderPtr->setInt("brdfLUT", 7);
+                const bool iblOn = g_ibl && g_ibl->isValid() && g_iblEnabled;
+                pbrShaderPtr->setInt("useIBL", iblOn ? 1 : 0);
+                if (iblOn) {
+                    glActiveTexture(GL_TEXTURE5);
+                    glBindTexture(GL_TEXTURE_CUBE_MAP, g_ibl->irradianceMap());
+                    glActiveTexture(GL_TEXTURE6);
+                    glBindTexture(GL_TEXTURE_CUBE_MAP, g_ibl->prefilterMap());
+                    glActiveTexture(GL_TEXTURE7);
+                    glBindTexture(GL_TEXTURE_2D, g_ibl->brdfLUT());
+                    pbrShaderPtr->setFloat("maxReflectionLod", g_ibl->maxReflectionLod());
+                    glActiveTexture(GL_TEXTURE0);
+                }
                 shaderPtr->use(); // restore the Phong program for the draw loop below
             }
 
@@ -1302,6 +1343,11 @@ void key_callback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action,
             li = (li + 1) % 5;
             g_cascadeSplitLambda = lambdas[li];
             LOG_INFO("Cascade split lambda: " + std::to_string(g_cascadeSplitLambda));
+        }
+        else if (key == GLFW_KEY_B && g_ibl && g_ibl->isValid()) {
+            // Toggle image-based lighting for the PBR ambient term (issue #270).
+            g_iblEnabled = !g_iblEnabled;
+            LOG_INFO("Image-based lighting " + std::string(g_iblEnabled ? "enabled" : "disabled"));
         }
         else if (key == GLFW_KEY_C) {
             // Toggle frustum culling

--- a/src/render/Ibl.cpp
+++ b/src/render/Ibl.cpp
@@ -1,0 +1,236 @@
+#include "render/Ibl.h"
+
+#include "core/Logger.h"
+#include "render/IblBrdf.h" // shared mip<->roughness mapping (mirrored by the shaders)
+
+#include <cmath>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
+namespace IKore {
+
+namespace {
+
+// The six capture views for rendering a cubemap (matches GL_TEXTURE_CUBE_MAP_* order:
+// +X, -X, +Y, -Y, +Z, -Z), with a 90-degree FOV projection covering one face.
+const glm::mat4 kCaptureProjection = glm::perspective(glm::radians(90.0f), 1.0f, 0.1f, 10.0f);
+
+glm::mat4 captureView(int face) {
+    const glm::vec3 eye(0.0f);
+    switch (face) {
+        case 0: return glm::lookAt(eye, glm::vec3( 1,  0,  0), glm::vec3(0, -1,  0));
+        case 1: return glm::lookAt(eye, glm::vec3(-1,  0,  0), glm::vec3(0, -1,  0));
+        case 2: return glm::lookAt(eye, glm::vec3( 0,  1,  0), glm::vec3(0,  0,  1));
+        case 3: return glm::lookAt(eye, glm::vec3( 0, -1,  0), glm::vec3(0,  0, -1));
+        case 4: return glm::lookAt(eye, glm::vec3( 0,  0,  1), glm::vec3(0, -1,  0));
+        default: return glm::lookAt(eye, glm::vec3(0, 0, -1), glm::vec3(0, -1, 0));
+    }
+}
+
+} // namespace
+
+IblEnvironment::~IblEnvironment() {
+    cleanup();
+}
+
+bool IblEnvironment::loadShaders() {
+    std::string err;
+    m_irradianceShader = Shader::loadFromFilesCached("src/shaders/cubemap.vert",
+                                                     "src/shaders/irradiance_convolution.frag", err);
+    m_prefilterShader = Shader::loadFromFilesCached("src/shaders/cubemap.vert",
+                                                    "src/shaders/prefilter.frag", err);
+    m_brdfShader = Shader::loadFromFilesCached("src/shaders/brdf_lut.vert",
+                                               "src/shaders/brdf_lut.frag", err);
+    if (!m_irradianceShader || !m_prefilterShader || !m_brdfShader) {
+        LOG_ERROR("IBL shader load failed: " + err);
+        return false;
+    }
+    return true;
+}
+
+bool IblEnvironment::setupGeometry() {
+    // Unit cube (positions only) for the cubemap convolution passes.
+    const float cube[] = {
+        -1, -1, -1,  1,  1, -1,  1, -1, -1,  1,  1, -1, -1, -1, -1, -1,  1, -1,
+        -1, -1,  1,  1, -1,  1,  1,  1,  1,  1,  1,  1, -1,  1,  1, -1, -1,  1,
+        -1,  1,  1, -1,  1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  1, -1,  1,  1,
+         1,  1,  1,  1, -1, -1,  1,  1, -1,  1, -1, -1,  1,  1,  1,  1, -1,  1,
+        -1, -1, -1,  1, -1, -1,  1, -1,  1,  1, -1,  1, -1, -1,  1, -1, -1, -1,
+        -1,  1, -1,  1,  1,  1,  1,  1, -1,  1,  1,  1, -1,  1, -1, -1,  1,  1
+    };
+    glGenVertexArrays(1, &m_cubeVAO);
+    glGenBuffers(1, &m_cubeVBO);
+    glBindVertexArray(m_cubeVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, m_cubeVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(cube), cube, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+    glBindVertexArray(0);
+
+    // Fullscreen quad (pos.xy, uv) for the BRDF LUT pass; matches brdf_lut.vert.
+    const float quad[] = {
+        -1.0f,  1.0f, 0.0f, 1.0f,
+        -1.0f, -1.0f, 0.0f, 0.0f,
+         1.0f, -1.0f, 1.0f, 0.0f,
+        -1.0f,  1.0f, 0.0f, 1.0f,
+         1.0f, -1.0f, 1.0f, 0.0f,
+         1.0f,  1.0f, 1.0f, 1.0f
+    };
+    glGenVertexArrays(1, &m_quadVAO);
+    glGenBuffers(1, &m_quadVBO);
+    glBindVertexArray(m_quadVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, m_quadVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(quad), quad, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
+    glBindVertexArray(0);
+    return true;
+}
+
+void IblEnvironment::renderCube() {
+    glBindVertexArray(m_cubeVAO);
+    glDrawArrays(GL_TRIANGLES, 0, 36);
+    glBindVertexArray(0);
+}
+
+void IblEnvironment::renderQuad() {
+    glBindVertexArray(m_quadVAO);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+    glBindVertexArray(0);
+}
+
+bool IblEnvironment::generate(GLuint environmentCubemap) {
+    if (environmentCubemap == 0) return false;
+    cleanup();
+    if (!loadShaders() || !setupGeometry()) {
+        cleanup();
+        return false;
+    }
+
+    // Seamless cubemap sampling avoids visible face seams in the convolution.
+    glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
+
+    GLint previousViewport[4];
+    glGetIntegerv(GL_VIEWPORT, previousViewport);
+
+    glGenFramebuffers(1, &m_captureFBO);
+    glGenRenderbuffers(1, &m_captureRBO);
+
+    // --- 1. Diffuse irradiance cubemap (small; low-frequency signal). ---
+    const int kIrradianceSize = 32;
+    glGenTextures(1, &m_irradianceMap);
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_irradianceMap);
+    for (int i = 0; i < 6; ++i) {
+        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB16F, kIrradianceSize,
+                     kIrradianceSize, 0, GL_RGB, GL_FLOAT, nullptr);
+    }
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, m_captureFBO);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_captureRBO);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, kIrradianceSize, kIrradianceSize);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_captureRBO);
+
+    m_irradianceShader->use();
+    m_irradianceShader->setMat4("projection", glm::value_ptr(kCaptureProjection));
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_CUBE_MAP, environmentCubemap);
+    m_irradianceShader->setInt("environmentMap", 0);
+    glViewport(0, 0, kIrradianceSize, kIrradianceSize);
+    for (int i = 0; i < 6; ++i) {
+        m_irradianceShader->setMat4("view", glm::value_ptr(captureView(i)));
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                               GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, m_irradianceMap, 0);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        renderCube();
+    }
+
+    // --- 2. Prefiltered specular cubemap (mips = roughness levels). ---
+    const int kPrefilterSize = 128;
+    glGenTextures(1, &m_prefilterMap);
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_prefilterMap);
+    for (int i = 0; i < 6; ++i) {
+        glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL_RGB16F, kPrefilterSize,
+                     kPrefilterSize, 0, GL_RGB, GL_FLOAT, nullptr);
+    }
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
+
+    m_prefilterShader->use();
+    m_prefilterShader->setMat4("projection", glm::value_ptr(kCaptureProjection));
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_CUBE_MAP, environmentCubemap);
+    m_prefilterShader->setInt("environmentMap", 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_captureFBO);
+    for (int mip = 0; mip < kMipLevels; ++mip) {
+        const int mipSize = static_cast<int>(kPrefilterSize * std::pow(0.5, mip));
+        glBindRenderbuffer(GL_RENDERBUFFER, m_captureRBO);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, mipSize, mipSize);
+        glViewport(0, 0, mipSize, mipSize);
+
+        const float roughness = render::mipToRoughness(mip, kMipLevels - 1);
+        m_prefilterShader->setFloat("roughness", roughness);
+        for (int i = 0; i < 6; ++i) {
+            m_prefilterShader->setMat4("view", glm::value_ptr(captureView(i)));
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                   GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, m_prefilterMap, mip);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            renderCube();
+        }
+    }
+
+    // --- 3. Split-sum BRDF integration LUT (2D RG). ---
+    const int kLutSize = 512;
+    glGenTextures(1, &m_brdfLUT);
+    glBindTexture(GL_TEXTURE_2D, m_brdfLUT);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RG16F, kLutSize, kLutSize, 0, GL_RG, GL_FLOAT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, m_captureFBO);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_captureRBO);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, kLutSize, kLutSize);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_brdfLUT, 0);
+    glViewport(0, 0, kLutSize, kLutSize);
+    m_brdfShader->use();
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    renderQuad();
+
+    // Restore default framebuffer + viewport.
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glViewport(previousViewport[0], previousViewport[1], previousViewport[2], previousViewport[3]);
+
+    m_valid = m_irradianceMap != 0 && m_prefilterMap != 0 && m_brdfLUT != 0;
+    if (m_valid) {
+        LOG_INFO("IBL environment generated (irradiance + prefilter + BRDF LUT)");
+    }
+    return m_valid;
+}
+
+void IblEnvironment::cleanup() {
+    if (m_irradianceMap) { glDeleteTextures(1, &m_irradianceMap); m_irradianceMap = 0; }
+    if (m_prefilterMap) { glDeleteTextures(1, &m_prefilterMap); m_prefilterMap = 0; }
+    if (m_brdfLUT) { glDeleteTextures(1, &m_brdfLUT); m_brdfLUT = 0; }
+    if (m_captureFBO) { glDeleteFramebuffers(1, &m_captureFBO); m_captureFBO = 0; }
+    if (m_captureRBO) { glDeleteRenderbuffers(1, &m_captureRBO); m_captureRBO = 0; }
+    if (m_cubeVAO) { glDeleteVertexArrays(1, &m_cubeVAO); m_cubeVAO = 0; }
+    if (m_cubeVBO) { glDeleteBuffers(1, &m_cubeVBO); m_cubeVBO = 0; }
+    if (m_quadVAO) { glDeleteVertexArrays(1, &m_quadVAO); m_quadVAO = 0; }
+    if (m_quadVBO) { glDeleteBuffers(1, &m_quadVBO); m_quadVBO = 0; }
+    m_valid = false;
+}
+
+} // namespace IKore

--- a/src/render/Ibl.h
+++ b/src/render/Ibl.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <glad/glad.h>
+#include <memory>
+#include "Shader.h"
+
+namespace IKore {
+
+/**
+ * @file Ibl.h
+ * @brief Image-based-lighting environment generator for PBR (issue #270).
+ *
+ * At load, convolves a source environment cubemap (the skybox) into the three textures
+ * the PBR ambient term needs:
+ *   - a small diffuse irradiance cubemap (cosine-weighted convolution),
+ *   - a prefiltered specular cubemap with one mip per roughness (GGX importance
+ *     sampling), and
+ *   - the split-sum BRDF integration LUT (a 2D RG texture).
+ *
+ * The convolution/integration weights live in the unit-tested render::IblBrdf core;
+ * the generation shaders (irradiance_convolution.frag / prefilter.frag /
+ * brdf_lut.frag) mirror it. This class owns only the GL objects and the render-to-
+ * cubemap passes. It is opt-in: pbr.frag falls back to constant ambient unless these
+ * maps are bound and useIBL is set, so a scene with no environment is unchanged.
+ */
+class IblEnvironment {
+public:
+    IblEnvironment() = default;
+    ~IblEnvironment();
+
+    IblEnvironment(const IblEnvironment&) = delete;
+    IblEnvironment& operator=(const IblEnvironment&) = delete;
+
+    /**
+     * @brief Generate the irradiance map, prefiltered environment, and BRDF LUT from
+     *        @p environmentCubemap. Safe to call again to regenerate. Returns false
+     *        (and leaves isValid() false) if shaders or GL resources fail.
+     */
+    bool generate(GLuint environmentCubemap);
+
+    bool isValid() const { return m_valid; }
+    GLuint irradianceMap() const { return m_irradianceMap; }
+    GLuint prefilterMap() const { return m_prefilterMap; }
+    GLuint brdfLUT() const { return m_brdfLUT; }
+
+    /// Highest prefilter mip index; the shader's maxReflectionLod (LOD = roughness * this).
+    float maxReflectionLod() const { return static_cast<float>(kMipLevels - 1); }
+
+    void cleanup();
+
+private:
+    static const int kMipLevels = 5; // prefilter roughness levels (LOD 0..4)
+
+    bool loadShaders();
+    bool setupGeometry();
+    void renderCube();
+    void renderQuad();
+
+    bool m_valid{false};
+    GLuint m_irradianceMap{0};
+    GLuint m_prefilterMap{0};
+    GLuint m_brdfLUT{0};
+    GLuint m_captureFBO{0};
+    GLuint m_captureRBO{0};
+    GLuint m_cubeVAO{0};
+    GLuint m_cubeVBO{0};
+    GLuint m_quadVAO{0};
+    GLuint m_quadVBO{0};
+
+    std::shared_ptr<Shader> m_irradianceShader;
+    std::shared_ptr<Shader> m_prefilterShader;
+    std::shared_ptr<Shader> m_brdfShader;
+};
+
+} // namespace IKore

--- a/src/render/IblBrdf.h
+++ b/src/render/IblBrdf.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include "render/PbrBrdf.h" // clamp01, kPi, roughnessToAlpha, roughnessToKIBL, geometrySchlickGGX
+
+#include <cmath>
+#include <cstdint>
+
+/**
+ * @file IblBrdf.h
+ * @brief Split-sum image-based-lighting math for PBR (issue #270), header-only.
+ *
+ * Direct PBR lighting shipped with PbrBrdf.h (#233); IBL completes the look with a
+ * diffuse irradiance map, prefiltered specular environment mips, and the split-sum
+ * BRDF integration LUT. The GPU generates those textures by convolving the skybox
+ * cubemap, but the sampling/weighting math is pure and unit-testable, so it lives
+ * here as the reference the generation shaders mirror (the way pbr.frag mirrors
+ * PbrBrdf.h):
+ *
+ *   - hammersley() / radicalInverseVdC(): the low-discrepancy sequence the importance
+ *     sampling draws from.
+ *   - importanceSampleGGX(): a GGX-distributed half-vector in tangent space (N = +Z),
+ *     used by both the prefilter pass and the BRDF LUT.
+ *   - integrateBrdfLut(): the split-sum environment BRDF (scale, bias) that brdf_lut
+ *     .frag mirrors, built on PbrBrdf.h's Smith geometry with the IBL roughness remap.
+ *   - mipToRoughness() / roughnessToMip(): the prefilter mip <-> roughness mapping the
+ *     specular sample uses (textureLod level = roughness * maxMip).
+ *
+ * All std-only float math; no GL, so it unit-tests without a context.
+ */
+namespace IKore {
+namespace render {
+
+/// A minimal 2D/3D vector for the sampling math (kept local so this stays GL-free).
+struct Vec2f {
+    float x{0.0f};
+    float y{0.0f};
+};
+struct Vec3f {
+    float x{0.0f};
+    float y{0.0f};
+    float z{0.0f};
+};
+
+/// Van der Corput radical inverse of @p bits in base 2, in [0, 1).
+inline float radicalInverseVdC(std::uint32_t bits) {
+    bits = (bits << 16) | (bits >> 16);
+    bits = ((bits & 0x55555555u) << 1) | ((bits & 0xAAAAAAAAu) >> 1);
+    bits = ((bits & 0x33333333u) << 2) | ((bits & 0xCCCCCCCCu) >> 2);
+    bits = ((bits & 0x0F0F0F0Fu) << 4) | ((bits & 0xF0F0F0F0u) >> 4);
+    bits = ((bits & 0x00FF00FFu) << 8) | ((bits & 0xFF00FF00u) >> 8);
+    return static_cast<float>(bits) * 2.3283064365386963e-10f; // / 2^32
+}
+
+/// The i-th of @p n points of the Hammersley sequence: (i/n, radicalInverse(i)).
+inline Vec2f hammersley(std::uint32_t i, std::uint32_t n) {
+    const float invN = n > 0u ? 1.0f / static_cast<float>(n) : 0.0f;
+    return Vec2f{static_cast<float>(i) * invN, radicalInverseVdC(i)};
+}
+
+/**
+ * @brief A GGX-importance-sampled half-vector in tangent space (surface normal = +Z).
+ * @param xi        A point from hammersley() in [0, 1)^2.
+ * @param roughness Perceptual roughness in [0, 1].
+ * @return Unit half-vector; roughness 0 concentrates it at +Z (mirror), higher
+ *         roughness spreads it toward the hemisphere.
+ *
+ * Because the tangent frame has N = +Z, the returned vector is also the world-space
+ * half-vector when the shader builds its basis around N. brdf_lut.frag and
+ * prefilter.frag mirror this exactly.
+ */
+inline Vec3f importanceSampleGGX(const Vec2f& xi, float roughness) {
+    const float a = roughnessToAlpha(roughness); // alpha = roughness^2
+    const float phi = 2.0f * kPi * xi.x;
+    const float cosTheta = std::sqrt((1.0f - xi.y) / (1.0f + (a * a - 1.0f) * xi.y));
+    const float sinTheta = std::sqrt(1.0f - cosTheta * cosTheta);
+    return Vec3f{std::cos(phi) * sinTheta, std::sin(phi) * sinTheta, cosTheta};
+}
+
+/// Smith geometry for IBL: G1(NdotV) * G1(NdotL) with the IBL remap k = roughness^2/2.
+inline float geometrySmithIBL(float NdotV, float NdotL, float roughness) {
+    const float k = roughnessToKIBL(roughness);
+    return geometrySchlickGGX(NdotV, k) * geometrySchlickGGX(NdotL, k);
+}
+
+/**
+ * @brief Split-sum environment BRDF integration: the (scale, bias) LUT entry.
+ * @param NdotV       cos angle between normal and view, clamped to (0, 1].
+ * @param roughness   Perceptual roughness in [0, 1].
+ * @param sampleCount Number of importance samples (>= 1).
+ * @return Vec2f{scale, bias}: specular reflectance = F0 * scale + bias.
+ *
+ * This is the environment half of the split-sum approximation (Karis 2013), the exact
+ * value brdf_lut.frag writes into the LUT texture. It depends only on NdotV and
+ * roughness (not on the environment), so precomputing it once is valid for any scene.
+ */
+inline Vec2f integrateBrdfLut(float NdotV, float roughness, std::uint32_t sampleCount = 1024u) {
+    NdotV = NdotV < 1.0e-4f ? 1.0e-4f : (NdotV > 1.0f ? 1.0f : NdotV);
+    // View in tangent space (N = +Z), in the plane y = 0.
+    const Vec3f V{std::sqrt(1.0f - NdotV * NdotV), 0.0f, NdotV};
+
+    float A = 0.0f;
+    float B = 0.0f;
+    const std::uint32_t n = sampleCount > 0u ? sampleCount : 1u;
+    for (std::uint32_t i = 0u; i < n; ++i) {
+        const Vec2f xi = hammersley(i, n);
+        const Vec3f H = importanceSampleGGX(xi, roughness);
+        const float VdotH = V.x * H.x + V.y * H.y + V.z * H.z;
+        // L = reflect(-V, H) = 2 (V.H) H - V; only its z (= NdotL) is needed.
+        const Vec3f L{2.0f * VdotH * H.x - V.x, 2.0f * VdotH * H.y - V.y, 2.0f * VdotH * H.z - V.z};
+        const float NdotL = L.z > 0.0f ? L.z : 0.0f;
+        const float NdotH = H.z > 0.0f ? H.z : 0.0f;
+        const float vh = VdotH > 0.0f ? VdotH : 0.0f;
+        if (NdotL > 0.0f) {
+            const float g = geometrySmithIBL(NdotV, NdotL, roughness);
+            const float gVis = (g * vh) / (NdotH * NdotV + 1.0e-8f);
+            const float fc = std::pow(1.0f - vh, 5.0f);
+            A += (1.0f - fc) * gVis;
+            B += fc * gVis;
+        }
+    }
+    return Vec2f{A / static_cast<float>(n), B / static_cast<float>(n)};
+}
+
+/// Prefilter mip level -> perceptual roughness: roughness = mip / maxMipLevel.
+inline float mipToRoughness(int mip, int maxMipLevel) {
+    if (maxMipLevel <= 0) return 0.0f;
+    return clamp01(static_cast<float>(mip) / static_cast<float>(maxMipLevel));
+}
+
+/// Perceptual roughness -> prefilter LOD: level = roughness * maxMipLevel (the value
+/// the shader passes to textureLod on the prefiltered environment map).
+inline float roughnessToMip(float roughness, int maxMipLevel) {
+    return clamp01(roughness) * static_cast<float>(maxMipLevel > 0 ? maxMipLevel : 0);
+}
+
+} // namespace render
+} // namespace IKore

--- a/src/shaders/brdf_lut.frag
+++ b/src/shaders/brdf_lut.frag
@@ -1,0 +1,70 @@
+#version 330 core
+out vec2 FragColor; // (scale, bias) written into an RG LUT
+
+in vec2 TexCoord;
+
+const float PI = 3.14159265359;
+
+// Split-sum environment BRDF integration (issue #270). Mirrors
+// render::integrateBrdfLut / hammersley / importanceSampleGGX / geometrySmithIBL in
+// src/render/IblBrdf.h, which is unit-tested; GLSL is not compiled in CI, so keeping
+// the math identical to the tested C++ is the safeguard against drift.
+float RadicalInverse_VdC(uint bits) {
+    bits = (bits << 16u) | (bits >> 16u);
+    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+    return float(bits) * 2.3283064365386963e-10;
+}
+
+vec2 Hammersley(uint i, uint N) {
+    return vec2(float(i) / float(N), RadicalInverse_VdC(i));
+}
+
+// Tangent-space (N = +Z) GGX-importance-sampled half-vector.
+vec3 ImportanceSampleGGX(vec2 Xi, float roughness) {
+    float a = roughness * roughness;
+    float phi = 2.0 * PI * Xi.x;
+    float cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
+    float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+    return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+}
+
+float GeometrySchlickGGX(float NdotX, float k) {
+    return NdotX / (NdotX * (1.0 - k) + k);
+}
+
+float GeometrySmithIBL(float NdotV, float NdotL, float roughness) {
+    float k = (roughness * roughness) / 2.0; // IBL remap (PbrBrdf.h roughnessToKIBL)
+    return GeometrySchlickGGX(NdotV, k) * GeometrySchlickGGX(NdotL, k);
+}
+
+vec2 IntegrateBRDF(float NdotV, float roughness) {
+    vec3 V = vec3(sqrt(1.0 - NdotV * NdotV), 0.0, NdotV);
+    float A = 0.0;
+    float B = 0.0;
+    const uint SAMPLE_COUNT = 1024u;
+    for (uint i = 0u; i < SAMPLE_COUNT; ++i) {
+        vec2 Xi = Hammersley(i, SAMPLE_COUNT);
+        vec3 H = ImportanceSampleGGX(Xi, roughness);
+        vec3 L = 2.0 * dot(V, H) * H - V;
+
+        float NdotL = max(L.z, 0.0);
+        float NdotH = max(H.z, 0.0);
+        float VdotH = max(dot(V, H), 0.0);
+
+        if (NdotL > 0.0) {
+            float G = GeometrySmithIBL(NdotV, NdotL, roughness);
+            float G_Vis = (G * VdotH) / (NdotH * NdotV + 1e-8);
+            float Fc = pow(1.0 - VdotH, 5.0);
+            A += (1.0 - Fc) * G_Vis;
+            B += Fc * G_Vis;
+        }
+    }
+    return vec2(A, B) / float(SAMPLE_COUNT);
+}
+
+void main() {
+    FragColor = IntegrateBRDF(TexCoord.x, TexCoord.y);
+}

--- a/src/shaders/brdf_lut.vert
+++ b/src/shaders/brdf_lut.vert
@@ -1,0 +1,12 @@
+#version 330 core
+layout (location = 0) in vec2 aPos;
+layout (location = 1) in vec2 aTexCoord;
+
+out vec2 TexCoord;
+
+// Fullscreen quad for the split-sum BRDF integration LUT (issue #270). Same quad
+// layout the post-processing effects use (vec2 position, vec2 uv).
+void main() {
+    TexCoord = aTexCoord;
+    gl_Position = vec4(aPos, 0.0, 1.0);
+}

--- a/src/shaders/cubemap.vert
+++ b/src/shaders/cubemap.vert
@@ -1,0 +1,14 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+
+out vec3 LocalPos;
+
+uniform mat4 projection;
+uniform mat4 view;
+
+// Renders a unit cube once per face for the IBL convolution passes (issue #270). The
+// local position is the sampling direction the fragment shader convolves around.
+void main() {
+    LocalPos = aPos;
+    gl_Position = projection * view * vec4(aPos, 1.0);
+}

--- a/src/shaders/irradiance_convolution.frag
+++ b/src/shaders/irradiance_convolution.frag
@@ -1,0 +1,37 @@
+#version 330 core
+out vec4 FragColor;
+
+in vec3 LocalPos;
+
+uniform samplerCube environmentMap;
+
+const float PI = 3.14159265359;
+
+// Diffuse irradiance convolution (issue #270): cosine-weighted hemisphere integral of
+// the environment around the surface normal, producing the diffuse IBL term. Rendered
+// once per face into a small irradiance cubemap at load. The cos(theta)*sin(theta)
+// weighting is the Lambertian * solid-angle factor.
+void main() {
+    vec3 N = normalize(LocalPos);
+
+    vec3 irradiance = vec3(0.0);
+
+    vec3 up = vec3(0.0, 1.0, 0.0);
+    vec3 right = normalize(cross(up, N));
+    up = normalize(cross(N, right));
+
+    const float sampleDelta = 0.025;
+    float nrSamples = 0.0;
+    for (float phi = 0.0; phi < 2.0 * PI; phi += sampleDelta) {
+        for (float theta = 0.0; theta < 0.5 * PI; theta += sampleDelta) {
+            // Spherical -> cartesian in tangent space, then to world.
+            vec3 tangentSample = vec3(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta));
+            vec3 sampleVec = tangentSample.x * right + tangentSample.y * up + tangentSample.z * N;
+            irradiance += texture(environmentMap, sampleVec).rgb * cos(theta) * sin(theta);
+            nrSamples++;
+        }
+    }
+    irradiance = PI * irradiance * (1.0 / max(nrSamples, 1.0));
+
+    FragColor = vec4(irradiance, 1.0);
+}

--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -50,7 +50,23 @@ uniform int numPointLights;
 uniform bool useDirLight;
 uniform vec3 viewPos;
 
+// Image-based lighting (issue #270). When useIBL is false these are ignored and the
+// ambient term is the constant fallback below, byte-identical to before. When true the
+// ambient term samples the irradiance map (diffuse), the prefiltered environment
+// (specular), and the split-sum BRDF LUT, mirroring render::IblBrdf.
+uniform samplerCube irradianceMap;
+uniform samplerCube prefilterMap;
+uniform sampler2D brdfLUT;
+uniform bool useIBL;
+uniform float maxReflectionLod;
+
 const float PI = 3.14159265359;
+
+// Roughness-aware Fresnel for the ambient term: rough surfaces keep more of their
+// specular at grazing angles clamped by F0 (Sebastien Lagarde).
+vec3 fresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness) {
+    return F0 + (max(vec3(1.0 - roughness), F0) - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
 
 // The functions below mirror src/render/PbrBrdf.h and the reference evaluation in
 // src/render/PbrMaterial.h (evaluateDirectionalPbr), which are unit-tested. GLSL is
@@ -143,8 +159,29 @@ void main() {
         Lo += shadePbr(N, V, L, radiance, albedo, metallic, roughness);
     }
 
-    // Simple ambient so unlit faces are not pure black (IBL replaces this later).
-    vec3 ambient = vec3(0.03) * albedo * ao;
+    // Ambient term. With IBL (issue #270): diffuse from the irradiance map and
+    // specular from the prefiltered environment weighted by the split-sum BRDF LUT.
+    // Without an environment (useIBL false), fall back to the constant ambient so the
+    // output matches the pre-IBL look exactly.
+    vec3 ambient;
+    if (useIBL) {
+        float NdotV = max(dot(N, V), 0.0);
+        vec3 F0 = mix(vec3(0.04), albedo, metallic);
+        vec3 F = fresnelSchlickRoughness(NdotV, F0, roughness);
+        vec3 kD = (vec3(1.0) - F) * (1.0 - metallic);
+
+        vec3 irradiance = texture(irradianceMap, N).rgb;
+        vec3 diffuseIBL = irradiance * albedo;
+
+        vec3 R = reflect(-V, N);
+        vec3 prefiltered = textureLod(prefilterMap, R, roughness * maxReflectionLod).rgb;
+        vec2 envBRDF = texture(brdfLUT, vec2(NdotV, roughness)).rg;
+        vec3 specularIBL = prefiltered * (F * envBRDF.x + envBRDF.y);
+
+        ambient = (kD * diffuseIBL + specularIBL) * ao;
+    } else {
+        ambient = vec3(0.03) * albedo * ao;
+    }
     vec3 color = ambient + Lo;
 
     // Reinhard tone map + gamma for display.

--- a/src/shaders/prefilter.frag
+++ b/src/shaders/prefilter.frag
@@ -1,0 +1,66 @@
+#version 330 core
+out vec4 FragColor;
+
+in vec3 LocalPos;
+
+uniform samplerCube environmentMap;
+uniform float roughness; // set per prefiltered mip level (mip / maxMip)
+
+const float PI = 3.14159265359;
+
+// Prefiltered specular environment (issue #270): GGX-importance-sample the environment
+// around the reflection direction for a given roughness, storing the result in one mip
+// of the prefilter cubemap. Mirrors render::importanceSampleGGX / hammersley in
+// src/render/IblBrdf.h (the tangent-basis build is the world-space version of the same
+// half-vector). Rougher mips blur the environment more.
+float RadicalInverse_VdC(uint bits) {
+    bits = (bits << 16u) | (bits >> 16u);
+    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+    return float(bits) * 2.3283064365386963e-10;
+}
+
+vec2 Hammersley(uint i, uint N) {
+    return vec2(float(i) / float(N), RadicalInverse_VdC(i));
+}
+
+vec3 ImportanceSampleGGX(vec2 Xi, vec3 N, float rough) {
+    float a = rough * rough;
+    float phi = 2.0 * PI * Xi.x;
+    float cosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
+    float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+
+    // Tangent-space half-vector (matches IblBrdf.h) rotated into world space around N.
+    vec3 H = vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+    vec3 up = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+    vec3 tangent = normalize(cross(up, N));
+    vec3 bitangent = cross(N, tangent);
+    return normalize(tangent * H.x + bitangent * H.y + N * H.z);
+}
+
+void main() {
+    vec3 N = normalize(LocalPos);
+    vec3 R = N;
+    vec3 V = R; // isotropic assumption: view = reflection = normal
+
+    const uint SAMPLE_COUNT = 1024u;
+    vec3 prefilteredColor = vec3(0.0);
+    float totalWeight = 0.0;
+
+    for (uint i = 0u; i < SAMPLE_COUNT; ++i) {
+        vec2 Xi = Hammersley(i, SAMPLE_COUNT);
+        vec3 H = ImportanceSampleGGX(Xi, N, roughness);
+        vec3 L = normalize(2.0 * dot(V, H) * H - V);
+
+        float NdotL = max(dot(N, L), 0.0);
+        if (NdotL > 0.0) {
+            prefilteredColor += texture(environmentMap, L).rgb * NdotL;
+            totalWeight += NdotL;
+        }
+    }
+
+    prefilteredColor = prefilteredColor / max(totalWeight, 0.001);
+    FragColor = vec4(prefilteredColor, 1.0);
+}

--- a/tests/test_ibl_brdf.cpp
+++ b/tests/test_ibl_brdf.cpp
@@ -1,0 +1,139 @@
+// Test for the image-based-lighting split-sum math - issue #270.
+//
+// The GPU generates the irradiance map, prefiltered specular mips, and the BRDF LUT
+// by convolving the skybox cubemap; the sampling/weighting math is pure and lives in
+// render::IblBrdf, mirrored by the generation shaders (brdf_lut.frag / prefilter.frag).
+// GLSL is not compiled in CI and the GL passes cannot run here, so this locks the
+// low-discrepancy sequence, the GGX importance sample, the split-sum BRDF integration
+// LUT, and the mip <-> roughness mapping headlessly.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_ibl_brdf.cpp -o test_ibl_brdf
+
+#include "render/IblBrdf.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore::render;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1e-4f) { return std::fabs(a - b) < eps; }
+
+// Radical inverse and Hammersley: known values and range.
+static void testHammersley() {
+    CHECK(approx(radicalInverseVdC(0u), 0.0f));
+    CHECK(approx(radicalInverseVdC(1u), 0.5f));      // bit 0 -> 0.5
+    CHECK(approx(radicalInverseVdC(2u), 0.25f));     // bit 1 -> 0.25
+    CHECK(approx(radicalInverseVdC(3u), 0.75f));     // 0.5 + 0.25
+
+    const Vec2f h0 = hammersley(0u, 16u);
+    CHECK(approx(h0.x, 0.0f) && approx(h0.y, 0.0f));
+    const Vec2f h8 = hammersley(8u, 16u);
+    CHECK(approx(h8.x, 0.5f));                        // 8/16
+    // Every point lies in the unit square.
+    for (std::uint32_t i = 0; i < 64; ++i) {
+        const Vec2f h = hammersley(i, 64u);
+        CHECK(h.x >= 0.0f && h.x < 1.0f);
+        CHECK(h.y >= 0.0f && h.y < 1.0f);
+    }
+}
+
+// Importance sampling: mirror surface concentrates H at the normal (+Z); rougher
+// surfaces tilt it away.
+static void testImportanceSampleGGX() {
+    // At xi.y = 0 the half-vector is exactly the normal regardless of roughness.
+    const Vec3f mirror = importanceSampleGGX(Vec2f{0.3f, 0.0f}, 0.5f);
+    CHECK(approx(mirror.z, 1.0f, 1e-4f));
+
+    // A returned half-vector is unit length and in the upper hemisphere.
+    for (std::uint32_t i = 1; i < 32; ++i) {
+        const Vec2f xi = hammersley(i, 32u);
+        const Vec3f h = importanceSampleGGX(xi, 0.7f);
+        CHECK(approx(h.x * h.x + h.y * h.y + h.z * h.z, 1.0f, 1e-3f));
+        CHECK(h.z >= 0.0f);
+    }
+
+    // Smoother surfaces keep the sample closer to the normal (larger average z).
+    float smoothZ = 0.0f, roughZ = 0.0f;
+    for (std::uint32_t i = 0; i < 64; ++i) {
+        const Vec2f xi = hammersley(i, 64u);
+        smoothZ += importanceSampleGGX(xi, 0.05f).z;
+        roughZ += importanceSampleGGX(xi, 0.95f).z;
+    }
+    CHECK(smoothZ > roughZ);
+}
+
+// The split-sum BRDF LUT (scale, bias): valid range, smooth-surface limit, energy.
+static void testIntegrateBrdfLut() {
+    // Head-on, very smooth: scale ~ 1, bias ~ 0 (specular reflectance ~ F0).
+    const Vec2f headOnSmooth = integrateBrdfLut(1.0f, 0.02f, 2048u);
+    CHECK(headOnSmooth.x > 0.9f);
+    CHECK(headOnSmooth.y < 0.05f);
+
+    // Everywhere: both terms in [0, 1] and finite, and scale + bias <= ~1 (no energy
+    // gain: reflectance for F0 in [0,1] never exceeds 1).
+    for (float ndv = 0.05f; ndv <= 1.0f; ndv += 0.15f) {
+        for (float r = 0.0f; r <= 1.0f; r += 0.2f) {
+            const Vec2f lut = integrateBrdfLut(ndv, r, 512u);
+            CHECK(std::isfinite(lut.x) && std::isfinite(lut.y));
+            CHECK(lut.x >= 0.0f && lut.x <= 1.0001f);
+            CHECK(lut.y >= 0.0f && lut.y <= 1.0001f);
+            CHECK(lut.x + lut.y <= 1.02f);
+        }
+    }
+
+    // Deterministic: same inputs -> same output (precompute is stable).
+    const Vec2f a = integrateBrdfLut(0.5f, 0.5f, 256u);
+    const Vec2f b = integrateBrdfLut(0.5f, 0.5f, 256u);
+    CHECK(approx(a.x, b.x) && approx(a.y, b.y));
+
+    // At grazing angles the Fresnel-edge bias is strongest for smooth surfaces and
+    // falls off as roughness scatters it, so bias decreases with roughness at low NdotV.
+    const Vec2f grazSmooth = integrateBrdfLut(0.1f, 0.1f, 2048u);
+    const Vec2f grazRough = integrateBrdfLut(0.1f, 0.9f, 2048u);
+    CHECK(grazSmooth.y > grazRough.y);
+
+    // Head-on, the bias term is ~0 across the roughness range (no Fresnel edge).
+    CHECK(integrateBrdfLut(1.0f, 0.1f, 2048u).y < 0.02f);
+    CHECK(integrateBrdfLut(1.0f, 0.9f, 2048u).y < 0.02f);
+}
+
+// Mip <-> roughness mapping is a linear round trip across the prefiltered chain.
+static void testMipRoughnessMapping() {
+    const int maxMip = 5;
+    CHECK(approx(mipToRoughness(0, maxMip), 0.0f));
+    CHECK(approx(mipToRoughness(maxMip, maxMip), 1.0f));
+    CHECK(approx(mipToRoughness(2, maxMip), 0.4f));
+
+    // roughnessToMip is the inverse scaling used by textureLod.
+    CHECK(approx(roughnessToMip(0.0f, maxMip), 0.0f));
+    CHECK(approx(roughnessToMip(1.0f, maxMip), 5.0f));
+    CHECK(approx(roughnessToMip(0.4f, maxMip), 2.0f));
+
+    // Degenerate chain does not divide by zero.
+    CHECK(approx(mipToRoughness(3, 0), 0.0f));
+}
+
+int main() {
+    testHammersley();
+    testImportanceSampleGGX();
+    testIntegrateBrdfLut();
+    testMipRoughnessMapping();
+
+    if (g_failures == 0) {
+        std::printf("All IBL BRDF tests passed.\n");
+        return 0;
+    }
+    std::printf("%d IBL BRDF test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #270.

PBR direct lighting shipped with #233/#234 but the ambient term was a constant. This PR adds image-based lighting: at load the skybox cubemap is convolved into a diffuse irradiance map and prefiltered specular mips, plus the split-sum BRDF integration LUT, and the PBR ambient term samples all three. It is opt-in and falls back to the constant ambient when no environment is set, so scenes without a skybox are unchanged.

## Changes

- **`src/render/IblBrdf.h`** + **`tests/test_ibl_brdf.cpp`**: the split-sum math as a headless tested core: Van der Corput / Hammersley, GGX importance sampling, the environment BRDF integration `(scale, bias)` built on `PbrBrdf.h`'s Smith geometry with the IBL roughness remap, and the mip to roughness mapping. The generation shaders mirror it.
- **`src/shaders/brdf_lut.{vert,frag}`**: render the BRDF LUT, mirroring `integrateBrdfLut`.
- **`src/shaders/cubemap.vert`** + **`irradiance_convolution.frag`** + **`prefilter.frag`**: the cosine-weighted irradiance convolution and GGX prefilter passes (mirroring `importanceSampleGGX`), rendered per cubemap face.
- **`src/shaders/pbr.frag`**: the ambient term samples irradiance (diffuse) + prefiltered environment (specular) weighted by the BRDF LUT, gated by `useIBL`; when off it is the exact constant-ambient fallback (byte-identical).
- **`src/render/Ibl.{h,cpp}`**: `IblEnvironment` generates the irradiance map, prefiltered mips (one roughness per mip), and BRDF LUT from a source cubemap via render-to-cubemap; owns only the GL objects, delegating the weights to the tested core.
- **`src/main.cpp`**: generate IBL from the skybox at load; bind the maps on dedicated units 5-7 (never aliasing the 0-3 material units) and set `useIBL` each frame; toggle with `B`.
- **`CMakeLists.txt`**: build `Ibl.cpp` and register `test_ibl_brdf`.

## Acceptance

- Metallic surfaces reflect the prefiltered environment and rough ones blur it plausibly across the roughness range (via the prefilter mip chain and roughness-weighted LOD).
- With no environment map, output matches today's constant-ambient look: `useIBL` is false, and `pbr.frag`'s fallback branch is the exact prior expression.
- The LUT/convolution weights are mirrored by the unit-tested `IblBrdf` core, following the `PbrBrdf.h` pattern.

## Verification

- `test_ibl_brdf` (new) passes under ASan/UBSan; the existing `test_pbr_material` / `test_pbr_brdf` still pass. The LUT test covers Hammersley/radical-inverse values, the GGX sample spread, LUT validity/energy/smooth-surface limits, the grazing-Fresnel behavior, and the mip to roughness mapping. (I let the test find the true monotonicity direction rather than assume it: the grazing bias is largest for smooth surfaces and falls with roughness.)
- All five IBL shaders and `pbr.frag` validate clean under `glslangValidator`.
- `Ibl.cpp` and the new `main.cpp` fragments syntax-check against the real GL/glm/`Shader`/`Skybox` headers.

## Note

The render-to-cubemap generation and the GLSL sampling cannot be verified headlessly, so correctness rests on the tested core, the shaders mirroring it, glslang validation, and the compile checks. The feature is additive and default-safe: when the skybox fails to load or IBL generation fails, `useIBL` stays false and PBR keeps the constant ambient. Environment maps are treated as already-linear (the skybox path), matching the engine's current texture handling.