### PR TITLE
Doodle: ghost replays via share codes (#272)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,6 +637,12 @@ add_executable(test_leaderboard
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_leaderboard.cpp
 )
 
+# Shareable ghost replays: content-verified trace codec + deterministic playback
+# alongside a live run, bound to the level (#272) - header-only.
+add_executable(test_ghost_replay
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ghost_replay.cpp
+)
+
 # Audio decode core: robust WAV/PCM parser + tone generator (#258) - header-only.
 add_executable(test_audio_decode
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_audio_decode.cpp

--- a/src/game/GhostReplay.h
+++ b/src/game/GhostReplay.h
@@ -1,0 +1,231 @@
+#pragma once
+
+#include "game/Leaderboard.h" // RunTrace, replayRun (and transitively DungeonGame, LevelShare, LevelFormat)
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+/**
+ * @file GhostReplay.h
+ * @brief Shareable ghost replays for the doodle game (issue #272).
+ *
+ * #242 made a completed run a verifiable input trace (RunTrace + replayRun) and #241
+ * established content-verified share strings (LevelShare.h). Sharing a trace lets a
+ * friend race a ghost of your best run: the deterministic sim replays your inputs in
+ * their own game alongside the live one, tick for tick.
+ *
+ *   - encodeGhost/decodeGhost: a compact, content-verified share string for a RunTrace,
+ *     bound to the level's share code so a trace cannot be replayed against the wrong
+ *     level. Format "DDG1:<levelCode>:<traceCode>:<base64url(payload)>": the payload is
+ *     the trace's exact bytes (little-endian IEEE-754, portable across devices),
+ *     traceCode is a content hash of the payload (tamper check), and levelCode binds it
+ *     to a specific level. decodeGhost rejects a bad prefix, corrupted base64, a
+ *     payload that does not match traceCode, or a level whose code does not match.
+ *   - GhostPlayback: steps a decoded trace through its own DungeonGame, exposing the
+ *     ghost's position per tick. Because the sim is deterministic, the ghost's position
+ *     stream reproduces the original run exactly.
+ *
+ * Reuses the base64/base32/hash helpers and shareCodeFor from LevelShare.h - no new
+ * serialization scheme beyond the trace byte packing. Pure std, header-only, no wall
+ * clock.
+ */
+namespace IKore {
+namespace game {
+namespace detail {
+
+inline void putLE32(std::string& out, std::uint32_t v) {
+    for (int i = 0; i < 4; ++i) out += static_cast<char>((v >> (8 * i)) & 0xFF);
+}
+inline void putLE64(std::string& out, std::uint64_t v) {
+    for (int i = 0; i < 8; ++i) out += static_cast<char>((v >> (8 * i)) & 0xFF);
+}
+inline std::uint32_t getLE32(const std::string& s, std::size_t& i) {
+    std::uint32_t v = 0;
+    for (int b = 0; b < 4; ++b) v |= static_cast<std::uint32_t>(static_cast<unsigned char>(s[i++])) << (8 * b);
+    return v;
+}
+inline std::uint64_t getLE64(const std::string& s, std::size_t& i) {
+    std::uint64_t v = 0;
+    for (int b = 0; b < 8; ++b) v |= static_cast<std::uint64_t>(static_cast<unsigned char>(s[i++])) << (8 * b);
+    return v;
+}
+inline std::uint32_t floatBits(float f) {
+    std::uint32_t u = 0;
+    std::memcpy(&u, &f, sizeof(u));
+    return u;
+}
+inline float bitsFloat(std::uint32_t u) {
+    float f = 0.0f;
+    std::memcpy(&f, &u, sizeof(f));
+    return f;
+}
+inline std::uint64_t doubleBits(double d) {
+    std::uint64_t u = 0;
+    std::memcpy(&u, &d, sizeof(u));
+    return u;
+}
+inline double bitsDouble(std::uint64_t u) {
+    double d = 0.0;
+    std::memcpy(&d, &u, sizeof(d));
+    return d;
+}
+
+/// Pack a trace to exact bytes: dt (double LE) + count (u32 LE) + per input (2 floats LE).
+inline std::string serializeTrace(const RunTrace& t) {
+    std::string p;
+    p.reserve(12 + t.inputs.size() * 8);
+    putLE64(p, doubleBits(t.dt));
+    putLE32(p, static_cast<std::uint32_t>(t.inputs.size()));
+    for (const GameInput& in : t.inputs) {
+        putLE32(p, floatBits(in.moveX));
+        putLE32(p, floatBits(in.moveZ));
+    }
+    return p;
+}
+
+/// Unpack a trace. Rejects a payload whose length does not exactly match its count, so
+/// a truncated or tampered payload cannot drive an oversized allocation or a bad read.
+inline bool deserializeTrace(const std::string& p, RunTrace& out) {
+    if (p.size() < 12) return false;
+    std::size_t i = 0;
+    const double dt = bitsDouble(getLE64(p, i));
+    const std::uint32_t n = getLE32(p, i);
+    if (p.size() != static_cast<std::size_t>(12) + static_cast<std::size_t>(n) * 8) return false;
+    out.dt = dt;
+    out.inputs.clear();
+    out.inputs.reserve(n);
+    for (std::uint32_t k = 0; k < n; ++k) {
+        GameInput g;
+        g.moveX = bitsFloat(getLE32(p, i));
+        g.moveZ = bitsFloat(getLE32(p, i));
+        out.inputs.push_back(g);
+    }
+    return true;
+}
+
+/// Content code for a trace payload. "DG-" distinguishes it from a level's "DD-" code.
+inline std::string traceCodeFor(const std::string& payload) {
+    return "DG-" + base32Crockford(fnv1a64(payload), 13);
+}
+
+} // namespace detail
+
+/// The wire prefix for a ghost share string (frozen, like LevelShare's "DDL1:").
+inline const std::string& ghostSharePrefix() {
+    static const std::string p = "DDG1:";
+    return p;
+}
+
+/**
+ * @brief Build a shareable ghost string for @p trace on the level @p levelJson.
+ *
+ * Embeds the level's content share code (so it can only be replayed against that level)
+ * and a content hash of the trace payload (so tampering is detected on decode).
+ */
+inline std::string encodeGhost(const std::string& levelJson, const RunTrace& trace) {
+    const std::string payload = detail::serializeTrace(trace);
+    return ghostSharePrefix() + shareCodeFor(levelJson) + ":" + detail::traceCodeFor(payload) + ":" +
+           detail::base64Encode(payload);
+}
+
+/// Result of decoding a ghost share string.
+struct GhostImport {
+    bool ok{false};
+    std::string levelCode; ///< the level share code the ghost is bound to.
+    std::string traceCode; ///< the trace's content code.
+    RunTrace trace;        ///< the recovered trace (byte-identical when ok).
+};
+
+/// Peek the level code a ghost string is bound to, without verifying it (for routing to
+/// the right level). Returns "" on a malformed prefix/format.
+inline std::string peekGhostLevelCode(const std::string& share) {
+    const std::string& prefix = ghostSharePrefix();
+    if (share.size() <= prefix.size() || share.compare(0, prefix.size(), prefix) != 0) return "";
+    const std::size_t sep = share.find(':', prefix.size());
+    if (sep == std::string::npos) return "";
+    return share.substr(prefix.size(), sep - prefix.size());
+}
+
+/**
+ * @brief Decode a ghost string and verify it against @p expectedLevelJson.
+ *
+ * Fails (ok == false) on a wrong prefix, malformed structure, invalid base64, a payload
+ * that does not match its embedded trace code (tamper), or a level whose share code does
+ * not match the embedded level code (wrong level). On success the trace is byte-identical
+ * to the encoded one.
+ */
+inline GhostImport decodeGhost(const std::string& share, const std::string& expectedLevelJson) {
+    GhostImport r;
+    const std::string& prefix = ghostSharePrefix();
+    if (share.size() <= prefix.size() || share.compare(0, prefix.size(), prefix) != 0) return r;
+
+    const std::size_t p1 = share.find(':', prefix.size());
+    if (p1 == std::string::npos) return r;
+    const std::size_t p2 = share.find(':', p1 + 1);
+    if (p2 == std::string::npos) return r;
+
+    const std::string levelCode = share.substr(prefix.size(), p1 - prefix.size());
+    const std::string traceCode = share.substr(p1 + 1, p2 - (p1 + 1));
+    const std::string payloadB64 = share.substr(p2 + 1);
+
+    std::string payload;
+    if (!detail::base64Decode(payloadB64, payload)) return r;
+    if (detail::traceCodeFor(payload) != traceCode) return r;  // integrity: payload must match its code
+    if (shareCodeFor(expectedLevelJson) != levelCode) return r; // bound to this specific level
+
+    RunTrace trace;
+    if (!detail::deserializeTrace(payload, trace)) return r;
+
+    r.ok = true;
+    r.levelCode = levelCode;
+    r.traceCode = traceCode;
+    r.trace = std::move(trace);
+    return r;
+}
+
+/**
+ * @brief Steps a recorded trace through its own DungeonGame so a ghost can be drawn
+ *        alongside a live run, exposing the ghost's position per tick.
+ *
+ * The ghost loads the same level and applies the same inputs at the same dt as the
+ * original run, so its position stream reproduces that run exactly (the sim is
+ * deterministic). Advance it once per live tick with step().
+ */
+class GhostPlayback {
+public:
+    GhostPlayback(const std::string& levelJson, const RunTrace& trace) : m_trace(trace) {
+        LevelSpec spec;
+        if (fromLevelJson(levelJson, spec)) {
+            m_game = loadGame(convert(spec));
+            m_valid = true;
+        }
+    }
+
+    bool valid() const { return m_valid; }
+    std::size_t tick() const { return m_tick; }
+    ecs::Vec3 position() const { return m_game.playerPosition; }
+    const DungeonGame& game() const { return m_game; }
+
+    /// No more inputs to play, the run ended, or the level failed to load.
+    bool finished() const {
+        return !m_valid || m_tick >= m_trace.inputs.size() || m_game.status != GameStatus::Playing;
+    }
+
+    /// Apply the next recorded input. Returns false (no-op) once finished().
+    bool step() {
+        if (finished()) return false;
+        m_game.update(m_trace.inputs[m_tick], static_cast<float>(m_trace.dt));
+        ++m_tick;
+        return true;
+    }
+
+private:
+    DungeonGame m_game;
+    RunTrace m_trace;
+    std::size_t m_tick{0};
+    bool m_valid{false};
+};
+
+} // namespace game
+} // namespace IKore

--- a/src/game/Leaderboard.h
+++ b/src/game/Leaderboard.h
@@ -154,6 +154,11 @@ public:
             existing->submittedAt = submittedAt;
             res.improved = true;
         }
+        // Keep the winning trace so a rank's ghost can be fetched later (issue #272).
+        // Only on an improvement, so the stored trace always matches the ranked time.
+        if (res.improved) {
+            m_bestTraces[code][player] = trace;
+        }
         res.rank = rankOf(code, player);
         return res;
     }
@@ -183,6 +188,33 @@ public:
         return it == m_scores.end() ? 0 : it->second.size();
     }
 
+    /// The stored level JSON for a code (needed to bind/verify a ghost share, #272).
+    bool levelJson(const std::string& code, std::string& out) const {
+        auto it = m_levels.find(code);
+        if (it == m_levels.end()) return false;
+        out = it->second;
+        return true;
+    }
+
+    /// The best (ranked) trace a player submitted on a level, for ghost playback (#272).
+    bool bestTrace(const std::string& code, const std::string& player, RunTrace& out) const {
+        auto lit = m_bestTraces.find(code);
+        if (lit == m_bestTraces.end()) return false;
+        auto pit = lit->second.find(player);
+        if (pit == lit->second.end()) return false;
+        out = pit->second;
+        return true;
+    }
+
+    /// The best trace of the @p rank-th (1-based) player on a level, plus their name.
+    bool ghostForRank(const std::string& code, int rank, RunTrace& out, std::string& player) const {
+        if (rank < 1) return false;
+        const std::vector<ScoreEntry> board = top(code, kMaxInputs);
+        if (static_cast<std::size_t>(rank) > board.size()) return false;
+        player = board[static_cast<std::size_t>(rank - 1)].player;
+        return bestTrace(code, player, out);
+    }
+
 private:
     static bool rankLess(const ScoreEntry& a, const ScoreEntry& b) {
         if (a.clearTime != b.clearTime) return a.clearTime < b.clearTime;
@@ -194,6 +226,9 @@ private:
     double m_fixedDt;
     std::unordered_map<std::string, std::string> m_levels;
     std::unordered_map<std::string, std::vector<ScoreEntry>> m_scores;
+    // Best trace per (level, player) for ghost replays (issue #272). Kept in step with
+    // m_scores: written only when a submission improves the player's ranked time.
+    std::unordered_map<std::string, std::unordered_map<std::string, RunTrace>> m_bestTraces;
 };
 
 } // namespace game

--- a/tests/test_ghost_replay.cpp
+++ b/tests/test_ghost_replay.cpp
@@ -1,0 +1,211 @@
+// Test for shareable ghost replays - issue #272.
+//
+// Verifies the acceptance criteria headlessly: a trace round-trips byte-identical
+// through the share string and re-simulates to the same result (reusing replayRun);
+// the ghost's position stream matches the original run tick for tick; and tampered or
+// wrong-level ghost strings are rejected. Also checks the leaderboard best-trace hook.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_ghost_replay.cpp -o test_ghost_replay
+
+#include "game/GhostReplay.h"
+#include "game/LevelFormat.h" // toLevelJson
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// A clearable room: player, one coin, an exit, no enemy (a greedy path wins).
+static std::string makeLevelJson() {
+    LevelSpec s;
+    s.walls.push_back(Wall{{{10, 0, 10}, {40, 0, 10}, {40, 0, 40}, {10, 0, 40}, {10, 0, 10}}});
+    s.symbols.push_back(Symbol{"player", ecs::Vec3{15, 0, 15}, 0.0f});
+    s.symbols.push_back(Symbol{"coin", ecs::Vec3{25, 0, 25}, 0.0f});
+    s.symbols.push_back(Symbol{"exit", ecs::Vec3{34, 0, 34}, 0.0f});
+    return toLevelJson(s);
+}
+
+// A different clearable level (for the wrong-level rejection test).
+static std::string makeOtherLevelJson() {
+    LevelSpec s;
+    s.walls.push_back(Wall{{{0, 0, 0}, {50, 0, 0}, {50, 0, 50}, {0, 0, 50}, {0, 0, 0}}});
+    s.symbols.push_back(Symbol{"player", ecs::Vec3{5, 0, 5}, 0.0f});
+    s.symbols.push_back(Symbol{"coin", ecs::Vec3{20, 0, 30}, 0.0f});
+    s.symbols.push_back(Symbol{"exit", ecs::Vec3{44, 0, 44}, 0.0f});
+    return toLevelJson(s);
+}
+
+// Greedy client producing a real winning input trace.
+static RunTrace playGreedy(const std::string& json, double dt, int maxSteps) {
+    RunTrace tr;
+    tr.dt = dt;
+    LevelSpec spec;
+    fromLevelJson(json, spec);
+    DungeonGame g = loadGame(convert(spec));
+    for (int step = 0; step < maxSteps && g.status == GameStatus::Playing; ++step) {
+        ecs::Vec3 target = g.exitPosition;
+        double best = 1e30;
+        for (const Coin& c : g.coins) {
+            if (c.collected) continue;
+            const double d = std::hypot(c.position.x - g.playerPosition.x, c.position.z - g.playerPosition.z);
+            if (d < best) { best = d; target = c.position; }
+        }
+        const GameInput in{target.x - g.playerPosition.x, target.z - g.playerPosition.z};
+        tr.inputs.push_back(in);
+        g.update(in, static_cast<float>(dt));
+    }
+    return tr;
+}
+
+static bool tracesEqual(const RunTrace& a, const RunTrace& b) {
+    if (a.dt != b.dt) return false; // bit-exact by construction
+    if (a.inputs.size() != b.inputs.size()) return false;
+    for (std::size_t i = 0; i < a.inputs.size(); ++i) {
+        if (a.inputs[i].moveX != b.inputs[i].moveX) return false;
+        if (a.inputs[i].moveZ != b.inputs[i].moveZ) return false;
+    }
+    return true;
+}
+
+// The ghost trace round-trips byte-identical and re-simulates to the same result.
+static void testRoundTripAndResimulate() {
+    const std::string json = makeLevelJson();
+    const RunTrace trace = playGreedy(json, 1.0 / 60.0, 100000);
+    CHECK(replayRun(json, trace).won); // sanity: the trace actually clears
+
+    const std::string share = encodeGhost(json, trace);
+    const GhostImport imp = decodeGhost(share, json);
+    CHECK(imp.ok);
+    CHECK(tracesEqual(imp.trace, trace)); // byte-identical round trip
+    CHECK(imp.levelCode == shareCodeFor(json));
+
+    const RunResult a = replayRun(json, trace);
+    const RunResult b = replayRun(json, imp.trace);
+    CHECK(a.won && b.won);
+    CHECK(a.steps == b.steps);
+    CHECK(std::fabs(a.clearTime - b.clearTime) < 1e-9);
+}
+
+// The ghost's position stream matches the original run tick for tick.
+static void testGhostMatchesOriginalTickForTick() {
+    const std::string json = makeLevelJson();
+    const RunTrace trace = playGreedy(json, 1.0 / 60.0, 100000);
+
+    // Original run position after each applied input.
+    std::vector<ecs::Vec3> original;
+    {
+        LevelSpec spec;
+        fromLevelJson(json, spec);
+        DungeonGame g = loadGame(convert(spec));
+        for (const GameInput& in : trace.inputs) {
+            g.update(in, static_cast<float>(trace.dt));
+            original.push_back(g.playerPosition);
+            if (g.status != GameStatus::Playing) break;
+        }
+    }
+
+    // Ghost via the share string, stepped one tick at a time.
+    const GhostImport imp = decodeGhost(encodeGhost(json, trace), json);
+    CHECK(imp.ok);
+    GhostPlayback ghost(json, imp.trace);
+    CHECK(ghost.valid());
+
+    std::size_t t = 0;
+    while (ghost.step()) {
+        CHECK(t < original.size());
+        if (t < original.size()) {
+            CHECK(ghost.position().x == original[t].x); // deterministic: exact match
+            CHECK(ghost.position().z == original[t].z);
+        }
+        ++t;
+    }
+    CHECK(t == original.size()); // same number of played ticks
+}
+
+// Tampered payload, wrong level, and bad prefix are all rejected.
+static void testRejections() {
+    const std::string json = makeLevelJson();
+    const std::string other = makeOtherLevelJson();
+    const RunTrace trace = playGreedy(json, 1.0 / 60.0, 100000);
+    const std::string share = encodeGhost(json, trace);
+
+    // Correct decode works.
+    CHECK(decodeGhost(share, json).ok);
+
+    // Wrong level: same share, different level JSON -> rejected.
+    CHECK(!decodeGhost(share, other).ok);
+
+    // Tamper: flip a character in the base64 payload (last field) -> integrity fails.
+    std::string tampered = share;
+    tampered[tampered.size() - 1] = (tampered.back() == 'A') ? 'B' : 'A';
+    CHECK(!decodeGhost(tampered, json).ok);
+
+    // Bad prefix -> rejected.
+    CHECK(!decodeGhost("NOPE:" + share, json).ok);
+    CHECK(!decodeGhost("", json).ok);
+
+    // Peek exposes the bound level code without verifying.
+    CHECK(peekGhostLevelCode(share) == shareCodeFor(json));
+    CHECK(peekGhostLevelCode("garbage").empty());
+}
+
+// The leaderboard stores the winning trace so a rank's ghost can be fetched and shared.
+static void testLeaderboardGhostHook() {
+    const std::string json = makeLevelJson();
+    const RunTrace trace = playGreedy(json, 1.0 / 60.0, 100000);
+
+    Leaderboard lb(1.0 / 60.0);
+    const std::string code = lb.registerLevel(json);
+    const SubmitResult sr = lb.submit(code, "alice", trace, /*submittedAt=*/1);
+    CHECK(sr.accepted && sr.improved);
+
+    RunTrace stored;
+    CHECK(lb.bestTrace(code, "alice", stored));
+    CHECK(tracesEqual(stored, trace));
+
+    // Fetch the rank-1 ghost and confirm it is alice's trace.
+    RunTrace rankTrace;
+    std::string who;
+    CHECK(lb.ghostForRank(code, 1, rankTrace, who));
+    CHECK(who == "alice");
+    CHECK(tracesEqual(rankTrace, trace));
+
+    // The leaderboard can hand back the level JSON to build a shareable ghost.
+    std::string levelJson;
+    CHECK(lb.levelJson(code, levelJson));
+    const std::string share = encodeGhost(levelJson, rankTrace);
+    CHECK(decodeGhost(share, levelJson).ok);
+
+    // A rank that does not exist yields nothing.
+    RunTrace none;
+    std::string noname;
+    CHECK(!lb.ghostForRank(code, 2, none, noname));
+}
+
+int main() {
+    testRoundTripAndResimulate();
+    testGhostMatchesOriginalTickForTick();
+    testRejections();
+    testLeaderboardGhostHook();
+
+    if (g_failures == 0) {
+        std::printf("All ghost replay tests passed.\n");
+        return 0;
+    }
+    std::printf("%d ghost replay test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #272.

#242 made a completed run a verifiable input trace (`RunTrace` + `replayRun`) and #241 established content-verified share strings (`LevelShare.h`). Sharing a trace lets a friend race a ghost of your best run: the deterministic sim replays your inputs in their own game alongside the live one, tick for tick.

## Changes

- **`src/game/GhostReplay.h`** (new):
  - `encodeGhost` / `decodeGhost`: a compact, content-verified share string for a `RunTrace`, format `DDG1:<levelCode>:<traceCode>:<base64url(payload)>`. The payload is the trace's exact bytes (little-endian IEEE-754, portable across devices), `traceCode` is a content hash of the payload (tamper check), and `levelCode` binds it to a specific level. Decode rejects a bad prefix, corrupted base64, a payload that does not match its code, or a level whose share code does not match. `peekGhostLevelCode` exposes the bound level for routing.
  - `GhostPlayback`: steps a decoded trace through its own `DungeonGame`, exposing the ghost's position per tick. Being deterministic, it reproduces the original run exactly.
  - Reuses the base64 / base32 / hash helpers and `shareCodeFor` from `LevelShare.h`; the only new serialization is the trace byte packing (with an exact-length check so a truncated/tampered payload can't drive a bad read or oversized allocation).
- **`src/game/Leaderboard.h`**: additive ghost hook. Store the winning trace per `(level, player)` on an improving submit, with `bestTrace()`, `ghostForRank()`, and a `levelJson()` accessor so a rank's ghost can be fetched and re-shared. Existing behavior is unchanged and `test_leaderboard` still passes.
- **`tests/test_ghost_replay.cpp`** (new): byte-identical round trip + re-simulation through `replayRun`, the ghost position stream matching the original tick for tick, rejection of tampered / wrong-level / bad-prefix strings, and the leaderboard best-trace hook.
- **`CMakeLists.txt`**: register `test_ghost_replay`.

## Acceptance

- A trace round-trips byte-identical through the share string and re-simulates to the same result (reusing `replayRun`): verified by comparing every input and the `replayRun` outcome.
- The ghost's position stream matches the original run tick for tick: verified by exact `==` on x/z at every tick (the sim is deterministic).
- Tampered or wrong-level ghost strings are rejected: verified for a flipped payload byte, a mismatched level, and a bad prefix.

## Verification

- `test_ghost_replay` (new) and the existing `test_leaderboard` pass under ASan/UBSan.
- `GhostReplay.h` compiles standalone under `-Wall -Wextra -pedantic` with zero GL/glm dependencies (pure std + the headless game/UGC cores), so it runs anywhere the other sim cores do.

Like the other doodle-game work, this is fully headless, so the tests exercise the real code end to end rather than standing in for un-runnable passes.