### PR TITLE
Doodle: weekly challenge rotation with its own leaderboard (#273)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,12 @@ add_executable(test_level_catalog
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_catalog.cpp
 )
 
+# Weekly challenge rotation + per-week leaderboard: deterministic week/selection,
+# replay-verified submits, week-rollover isolation (#273) - header-only.
+add_executable(test_weekly_challenge
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_weekly_challenge.cpp
+)
+
 # UGC Phase 5: stable share codes + level browser (Milestone 17 / #241) - header-only.
 add_executable(test_level_share
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_share.cpp

--- a/src/game/WeeklyChallenge.h
+++ b/src/game/WeeklyChallenge.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "game/Leaderboard.h"    // Leaderboard, RunTrace, ScoreEntry, SubmitResult, replay verification
+#include "game/LevelCatalog.h"   // LevelCatalog, LevelEntry, weeklyPrompt
+#include "game/LevelShare.h"     // shareCodeFor (content code that keys a board)
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @file WeeklyChallenge.h
+ * @brief Weekly challenge rotation with its own leaderboard (issue #273).
+ *
+ * Closes the weekly retention loop the concept doc describes by combining three
+ * existing cores: the UGC catalog (#174), content share codes (#241), and the
+ * replay-verified leaderboards (#242). Each week has a rotating drawing prompt and a
+ * featured level chosen deterministically from the catalog, plus its own competition
+ * board; runs are verified exactly as in #242 (this reuses Leaderboard unchanged).
+ *
+ *   - weekIndexAt(): the week number for a caller-supplied timestamp (no wall clock),
+ *     with week bounds and time-remaining helpers.
+ *   - selectFeatured(): the week's level, picked from the catalog by a total order
+ *     (most stars, then newest, then code) and rotated by week index, so every
+ *     instance with the same catalog agrees on the week's level.
+ *   - current(): the query API - prompt + featured level + time remaining.
+ *   - submit()/standings(): a per-week board keyed by (week index, level code). A new
+ *     week starts a fresh board; prior weeks stay queryable.
+ *
+ * Deterministic: same catalog + timestamps + traces yield the same selection and
+ * standings on any instance. Header-only, std only, no wall clock.
+ */
+namespace IKore {
+namespace game {
+
+/// Seconds in a week (7 * 24 * 3600); the default rotation period.
+inline constexpr std::int64_t kSecondsPerWeek = 604800;
+
+/// The current challenge: which week, its prompt, the featured level, and timing.
+struct WeeklyChallengeInfo {
+    bool valid{false};       ///< false when the catalog has no level to feature.
+    int weekIndex{0};
+    std::string prompt;
+    LevelEntry level;        ///< the featured level for the week.
+    std::int64_t weekStart{0};   ///< inclusive start timestamp.
+    std::int64_t weekEnd{0};     ///< exclusive end timestamp.
+    std::int64_t timeRemaining{0}; ///< weekEnd - now (seconds left in the week).
+};
+
+class WeeklyChallenge {
+public:
+    /**
+     * @param secondsPerWeek Rotation period.
+     * @param epoch          Timestamp of week 0's start (the rotation anchor).
+     * @param fixedDt        Fixed timestep the per-week boards verify against (#242).
+     */
+    explicit WeeklyChallenge(std::int64_t secondsPerWeek = kSecondsPerWeek, std::int64_t epoch = 0,
+                             double fixedDt = 1.0 / 60.0)
+        : m_secondsPerWeek(secondsPerWeek > 0 ? secondsPerWeek : kSecondsPerWeek),
+          m_epoch(epoch), m_fixedDt(fixedDt) {}
+
+    /// Week index for @p now (floored; can be negative before the epoch).
+    int weekIndexAt(std::int64_t now) const {
+        const std::int64_t rel = now - m_epoch;
+        // Floor division toward negative infinity so pre-epoch times index correctly.
+        std::int64_t q = rel / m_secondsPerWeek;
+        if (rel % m_secondsPerWeek != 0 && ((rel < 0) != (m_secondsPerWeek < 0))) --q;
+        return static_cast<int>(q);
+    }
+
+    std::int64_t weekStart(int weekIndex) const {
+        return m_epoch + static_cast<std::int64_t>(weekIndex) * m_secondsPerWeek;
+    }
+    std::int64_t weekEnd(int weekIndex) const { return weekStart(weekIndex) + m_secondsPerWeek; }
+    std::int64_t timeRemaining(std::int64_t now) const { return weekEnd(weekIndexAt(now)) - now; }
+    double fixedDt() const { return m_fixedDt; }
+
+    /**
+     * @brief Pick the featured level for @p weekIndex from @p catalog deterministically.
+     *
+     * Orders all catalog entries by a total order - most stars, then newest, then code
+     * ascending (so ties never depend on sort stability) - and rotates the pick by the
+     * week index. False (out untouched) if the catalog is empty.
+     */
+    static bool selectFeatured(const LevelCatalog& catalog, int weekIndex, LevelEntry& out) {
+        const std::size_t n = catalog.size();
+        if (n == 0) return false;
+        std::vector<LevelEntry> all = catalog.browseNew(n); // all entries, any order
+        std::sort(all.begin(), all.end(), featuredLess);
+        int i = weekIndex % static_cast<int>(all.size());
+        if (i < 0) i += static_cast<int>(all.size());
+        out = all[static_cast<std::size_t>(i)];
+        return true;
+    }
+
+    /// The current challenge for @p now against @p catalog (query API).
+    WeeklyChallengeInfo current(const LevelCatalog& catalog, std::int64_t now) const {
+        WeeklyChallengeInfo info;
+        info.weekIndex = weekIndexAt(now);
+        info.prompt = LevelCatalog::weeklyPrompt(info.weekIndex);
+        info.weekStart = weekStart(info.weekIndex);
+        info.weekEnd = weekEnd(info.weekIndex);
+        info.timeRemaining = info.weekEnd - now;
+        info.valid = selectFeatured(catalog, info.weekIndex, info.level);
+        return info;
+    }
+
+    /// The content code that keys a week's board (the featured level's share code).
+    static std::string challengeLevelCode(const LevelEntry& level) {
+        return shareCodeFor(level.levelJson);
+    }
+
+    /**
+     * @brief Submit a run for the week-of-@p now's featured level.
+     *
+     * Registers the featured level in that week's board (idempotent) and delegates to
+     * Leaderboard::submit, so the run is replay-verified exactly as in #242: a run that
+     * does not clear, uses the wrong timestep, or desyncs is rejected and never ranked.
+     * Rejected (or no featured level) yields an unaccepted SubmitResult.
+     */
+    SubmitResult submit(const LevelCatalog& catalog, std::int64_t now, const std::string& player,
+                        const RunTrace& trace, std::int64_t submittedAt, double claimedTime = -1.0) {
+        SubmitResult res;
+        const WeeklyChallengeInfo info = current(catalog, now);
+        if (!info.valid) {
+            res.reason = "no featured level";
+            return res;
+        }
+        Leaderboard& board = m_boards.emplace(info.weekIndex, Leaderboard(m_fixedDt)).first->second;
+        const std::string code = board.registerLevel(info.level.levelJson); // idempotent (content code)
+        m_weekCode[info.weekIndex] = code;
+        return board.submit(code, player, trace, submittedAt, claimedTime);
+    }
+
+    /// Standings for a week (current or past). Empty for a week with no submissions.
+    std::vector<ScoreEntry> standings(int weekIndex, std::size_t limit = 50) const {
+        auto bit = m_boards.find(weekIndex);
+        auto cit = m_weekCode.find(weekIndex);
+        if (bit == m_boards.end() || cit == m_weekCode.end()) return {};
+        return bit->second.top(cit->second, limit);
+    }
+
+    /// Standings for the week containing @p now.
+    std::vector<ScoreEntry> currentStandings(std::int64_t now, std::size_t limit = 50) const {
+        return standings(weekIndexAt(now), limit);
+    }
+
+    /// Whether a board exists for @p weekIndex (i.e. it has had at least one submission).
+    bool hasBoard(int weekIndex) const { return m_boards.count(weekIndex) > 0; }
+
+private:
+    // "Better" (featured-first) total order: most stars, then newest, then code asc.
+    static bool featuredLess(const LevelEntry& a, const LevelEntry& b) {
+        if (a.stars != b.stars) return a.stars > b.stars;
+        if (a.publishedAt != b.publishedAt) return a.publishedAt > b.publishedAt;
+        return a.code < b.code;
+    }
+
+    std::int64_t m_secondsPerWeek;
+    std::int64_t m_epoch;
+    double m_fixedDt;
+    std::unordered_map<int, Leaderboard> m_boards;   ///< per-week competition boards.
+    std::unordered_map<int, std::string> m_weekCode; ///< week index -> featured level code.
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_weekly_challenge.cpp
+++ b/tests/test_weekly_challenge.cpp
@@ -1,0 +1,186 @@
+// Test for the weekly challenge rotation + per-week leaderboard - issue #273.
+//
+// Verifies the acceptance criteria headlessly: the same inputs (catalog + timestamps)
+// produce the same weekly selection and standings; submissions are replay-verified
+// exactly as in #242 so rejected runs never appear; and week rollover starts a fresh
+// board while prior weeks stay queryable.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_weekly_challenge.cpp -o test_weekly_challenge
+
+#include "game/WeeklyChallenge.h"
+#include "game/LevelFormat.h" // toLevelJson
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// A clearable room with the coin/exit at caller-chosen spots (so each level's JSON,
+// and thus its content code, differs).
+static std::string makeLevelJson(float coinX, float exitX) {
+    LevelSpec s;
+    s.walls.push_back(Wall{{{0, 0, 0}, {50, 0, 0}, {50, 0, 50}, {0, 0, 50}, {0, 0, 0}}});
+    s.symbols.push_back(Symbol{"player", ecs::Vec3{5, 0, 5}, 0.0f});
+    s.symbols.push_back(Symbol{"coin", ecs::Vec3{coinX, 0, 25}, 0.0f});
+    s.symbols.push_back(Symbol{"exit", ecs::Vec3{exitX, 0, 44}, 0.0f});
+    return toLevelJson(s);
+}
+
+static RunTrace playGreedy(const std::string& json, double dt, int maxSteps) {
+    RunTrace tr;
+    tr.dt = dt;
+    LevelSpec spec;
+    fromLevelJson(json, spec);
+    DungeonGame g = loadGame(convert(spec));
+    for (int step = 0; step < maxSteps && g.status == GameStatus::Playing; ++step) {
+        ecs::Vec3 target = g.exitPosition;
+        double best = 1e30;
+        for (const Coin& c : g.coins) {
+            if (c.collected) continue;
+            const double d = std::hypot(c.position.x - g.playerPosition.x, c.position.z - g.playerPosition.z);
+            if (d < best) { best = d; target = c.position; }
+        }
+        const GameInput in{target.x - g.playerPosition.x, target.z - g.playerPosition.z};
+        tr.inputs.push_back(in);
+        g.update(in, static_cast<float>(dt));
+    }
+    return tr;
+}
+
+// Publish three distinct clearable levels with distinct star counts (so the featured
+// ranking is total-ordered and rotation is observable).
+static LevelCatalog makeCatalog() {
+    LevelCatalog cat;
+    const std::string a = cat.publish("ann", "Aaa", makeLevelJson(20, 44), /*publishedAt=*/100);
+    const std::string b = cat.publish("bob", "Bbb", makeLevelJson(25, 40), /*publishedAt=*/200);
+    const std::string c = cat.publish("cid", "Ccc", makeLevelJson(30, 36), /*publishedAt=*/300);
+    for (int i = 0; i < 3; ++i) cat.star(a);
+    for (int i = 0; i < 2; ++i) cat.star(b);
+    cat.star(c);
+    return cat;
+}
+
+// Week index is a deterministic floor of caller time; bounds and remaining follow.
+static void testWeekIndexAndTiming() {
+    WeeklyChallenge wc(100, 0, 1.0 / 60.0);
+    CHECK(wc.weekIndexAt(0) == 0);
+    CHECK(wc.weekIndexAt(99) == 0);
+    CHECK(wc.weekIndexAt(100) == 1);
+    CHECK(wc.weekIndexAt(250) == 2);
+    CHECK(wc.weekIndexAt(-1) == -1);   // floored toward negative
+    CHECK(wc.weekIndexAt(-100) == -1);
+    CHECK(wc.weekIndexAt(-101) == -2);
+    CHECK(wc.weekStart(2) == 200);
+    CHECK(wc.weekEnd(2) == 300);
+    CHECK(wc.timeRemaining(250) == 50); // weekEnd(2)=300 - 250
+}
+
+// The same catalog + week yields the same featured level and prompt on any instance.
+static void testDeterministicSelection() {
+    const LevelCatalog cat = makeCatalog();
+    WeeklyChallenge wc1(100, 0), wc2(100, 0);
+
+    const WeeklyChallengeInfo a = wc1.current(cat, 50);   // week 0
+    const WeeklyChallengeInfo b = wc2.current(cat, 50);   // week 0, separate instance
+    CHECK(a.valid && b.valid);
+    CHECK(a.weekIndex == 0 && b.weekIndex == 0);
+    CHECK(a.level.code == b.level.code);
+    CHECK(a.prompt == b.prompt);
+    CHECK(a.prompt == LevelCatalog::weeklyPrompt(0));
+    // Highest-starred level (ann's, 3 stars) is featured in week 0.
+    CHECK(a.level.author == "ann");
+
+    // Rotation: a later week features a different level (weekIndex mod count).
+    const WeeklyChallengeInfo w1 = wc1.current(cat, 150); // week 1
+    CHECK(w1.level.code != a.level.code);
+    CHECK(w1.prompt == LevelCatalog::weeklyPrompt(1));
+
+    // An empty catalog has no featured level.
+    LevelCatalog empty;
+    CHECK(!wc1.current(empty, 50).valid);
+}
+
+// Submissions are replay-verified as in #242: winners rank, rejects never appear.
+static void testSubmitReplayVerified() {
+    const LevelCatalog cat = makeCatalog();
+    WeeklyChallenge wc(100, 0, 1.0 / 60.0);
+
+    const WeeklyChallengeInfo info = wc.current(cat, 10); // week 0
+    CHECK(info.valid);
+    const RunTrace win = playGreedy(info.level.levelJson, 1.0 / 60.0, 100000);
+
+    const SubmitResult ok = wc.submit(cat, 10, "alice", win, /*submittedAt=*/1);
+    CHECK(ok.accepted && ok.improved);
+    CHECK(wc.currentStandings(10).size() == 1);
+    CHECK(wc.currentStandings(10)[0].player == "alice");
+
+    // An idle trace does not clear -> rejected, standings unchanged.
+    RunTrace idle;
+    idle.dt = 1.0 / 60.0;
+    for (int i = 0; i < 100; ++i) idle.inputs.push_back(GameInput{0.0f, 0.0f});
+    const SubmitResult bad = wc.submit(cat, 10, "mallory", idle, 2);
+    CHECK(!bad.accepted);
+    CHECK(wc.currentStandings(10).size() == 1); // mallory never appears
+
+    // Wrong timestep -> rejected by the reused Leaderboard verification.
+    RunTrace wrongDt = win;
+    wrongDt.dt = 1.0 / 30.0;
+    const SubmitResult bad2 = wc.submit(cat, 10, "carol", wrongDt, 3);
+    CHECK(!bad2.accepted);
+    CHECK(wc.currentStandings(10).size() == 1);
+}
+
+// Week rollover: a new week is a fresh board; prior weeks remain queryable.
+static void testWeekRolloverIsolation() {
+    const LevelCatalog cat = makeCatalog();
+    WeeklyChallenge wc(100, 0, 1.0 / 60.0);
+
+    // Week 0 submission.
+    const WeeklyChallengeInfo w0 = wc.current(cat, 10);
+    const RunTrace win0 = playGreedy(w0.level.levelJson, 1.0 / 60.0, 100000);
+    CHECK(wc.submit(cat, 10, "alice", win0, 1).accepted);
+
+    // Week 1 submission (different featured level).
+    const WeeklyChallengeInfo w1 = wc.current(cat, 110);
+    CHECK(w1.weekIndex == 1);
+    CHECK(w1.level.code != w0.level.code);
+    const RunTrace win1 = playGreedy(w1.level.levelJson, 1.0 / 60.0, 100000);
+    CHECK(wc.submit(cat, 110, "bob", win1, 2).accepted);
+
+    // Each board is independent, and the earlier week is still queryable after rollover.
+    CHECK(wc.standings(0).size() == 1);
+    CHECK(wc.standings(0)[0].player == "alice");
+    CHECK(wc.standings(1).size() == 1);
+    CHECK(wc.standings(1)[0].player == "bob");
+    CHECK(wc.hasBoard(0) && wc.hasBoard(1));
+    CHECK(!wc.hasBoard(2));                 // untouched week has no board
+    CHECK(wc.standings(2).empty());
+}
+
+int main() {
+    testWeekIndexAndTiming();
+    testDeterministicSelection();
+    testSubmitReplayVerified();
+    testWeekRolloverIsolation();
+
+    if (g_failures == 0) {
+        std::printf("All weekly challenge tests passed.\n");
+        return 0;
+    }
+    std::printf("%d weekly challenge test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #273.

`LevelCatalog::weeklyPrompt` (#174) rotates drawing prompts, but nothing tied a week to a featured level or a competition. This ties them together, closing the weekly retention loop by combining the UGC catalog (#174), content share codes (#241), and the replay-verified leaderboards (#242).

## Changes

- **`src/game/WeeklyChallenge.h`** (new, headless core):
  - `weekIndexAt()` / `weekStart` / `weekEnd` / `timeRemaining`: a deterministic week number from a caller-supplied timestamp (floored toward negative for pre-epoch times), with no wall clock.
  - `selectFeatured()`: the week's level, chosen from the catalog by a total order (most stars, then newest, then code ascending so ties never depend on sort stability) and rotated by week index, so every instance with the same catalog agrees on the week's level.
  - `current()`: the query API - prompt + featured level + time remaining.
  - `submit()` / `standings()`: a per-week board keyed by (week index, level code), held in a map of `Leaderboard` reused unchanged, so runs are replay-verified exactly as in #242. A new week gets a fresh board; prior weeks stay queryable.
- **`tests/test_weekly_challenge.cpp`** (new): week index + timing (including negatives), the same catalog/week yielding the same featured level and prompt across two instances plus weekly rotation, replay-verified submits (winner ranks; idle and wrong-`dt` runs rejected and absent), and week-rollover board isolation.
- **`CMakeLists.txt`**: register `test_weekly_challenge`.

## Acceptance

- Same inputs produce the same weekly selection and standings on any instance: verified by two separate `WeeklyChallenge` instances agreeing on the featured level code and prompt for the same catalog + week.
- Submissions are replay-verified exactly as in #242; rejected runs never appear: verified that a non-clearing idle trace and a wrong-timestep trace are both rejected and never enter the standings, while a real winning trace ranks.
- Week rollover starts a fresh board while prior weeks remain queryable: verified that a week-0 and a week-1 submission land on independent boards and week 0 is still queryable after time moves into week 1.

## Verification

- `test_weekly_challenge` (new) passes under ASan/UBSan; `Leaderboard` and `LevelCatalog` are reused unchanged, so their existing tests are unaffected.
- `WeeklyChallenge.h` compiles standalone under `-Wall -Wextra -pedantic` with zero GL/glm dependencies.

Fully headless, so the test exercises the real selection/verification/rollover logic end to end.