### PR TITLE
Doodle CV Phase 2b: hard shadow edges and gradient-lit backgrounds (#274)

### DIFF
--- a/src/cv/Robust.h
+++ b/src/cv/Robust.h
@@ -196,18 +196,92 @@ inline std::vector<float> estimateBackgroundColor(const Image& img, int border =
     return bg;
 }
 
-/// Foreground (paper) mask: pixels whose color is far from the background by more
-/// than @p threshold (L1 over channels). Works for colored or dark paper, not just
-/// bright paper, as long as it contrasts the surface it sits on.
+/**
+ * @brief Per-corner background color estimate, robust to a lit gradient (issue #274).
+ *
+ * A single border mean is wrong when the table is unevenly lit: one side reads
+ * bright, the other dark, so the mean matches neither and the dark side of the table
+ * is mistaken for paper. Instead sample the mean color of each of the four corner
+ * blocks; backgroundColorAt() bilinearly interpolates them, so the estimate tracks a
+ * gradient across the frame. On a uniform background all four corners are equal and
+ * the estimate is the same constant as the old border mean.
+ */
+struct BackgroundField {
+    std::vector<float> tl, tr, bl, br; ///< per-channel corner means.
+    int channels{0};
+};
+
+inline BackgroundField estimateBackgroundField(const Image& img, int border = 2) {
+    BackgroundField f;
+    f.channels = std::max(1, img.channels);
+    f.tl.assign(static_cast<std::size_t>(f.channels), 0.0f);
+    f.tr = f.bl = f.br = f.tl;
+    if (img.width <= 0 || img.height <= 0 || img.channels <= 0) return f;
+    if (border < 1) border = 1;
+
+    // Average the border ring - which excludes any clutter sitting on the paper's
+    // interior, like the old single mean did - but bucket each ring pixel to its
+    // nearest corner so a lit gradient across the table is tracked per corner.
+    std::vector<float> sum[4]; // TL, TR, BL, BR
+    long cnt[4] = {0, 0, 0, 0};
+    for (int i = 0; i < 4; ++i) sum[i].assign(static_cast<std::size_t>(img.channels), 0.0f);
+    std::vector<float> ringAll(static_cast<std::size_t>(img.channels), 0.0f);
+    long ringCnt = 0;
+    const int hx = img.width / 2, hy = img.height / 2;
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            const bool ring = x < border || y < border || x >= img.width - border || y >= img.height - border;
+            if (!ring) continue;
+            const int q = (x < hx ? 0 : 1) + (y < hy ? 0 : 2); // 0 TL,1 TR,2 BL,3 BR
+            for (int c = 0; c < img.channels; ++c) {
+                const float v = static_cast<float>(img.at(x, y, c));
+                sum[q][static_cast<std::size_t>(c)] += v;
+                ringAll[static_cast<std::size_t>(c)] += v;
+            }
+            ++cnt[q];
+            ++ringCnt;
+        }
+    }
+    if (ringCnt > 0) for (float& v : ringAll) v /= static_cast<float>(ringCnt);
+    auto finalize = [&](int q, std::vector<float>& out) {
+        if (cnt[q] > 0) {
+            for (int c = 0; c < img.channels; ++c)
+                out[static_cast<std::size_t>(c)] = sum[q][static_cast<std::size_t>(c)] / static_cast<float>(cnt[q]);
+        } else {
+            out = ringAll; // a corner with no ring pixels falls back to the global mean
+        }
+    };
+    finalize(0, f.tl);
+    finalize(1, f.tr);
+    finalize(2, f.bl);
+    finalize(3, f.br);
+    return f;
+}
+
+/// Bilinearly interpolate the corner background color for channel @p c at (x, y).
+inline float backgroundColorAt(const BackgroundField& f, int x, int y, int W, int H, int c) {
+    const float u = W > 1 ? static_cast<float>(x) / static_cast<float>(W - 1) : 0.0f;
+    const float v = H > 1 ? static_cast<float>(y) / static_cast<float>(H - 1) : 0.0f;
+    const std::size_t ch = static_cast<std::size_t>(c);
+    const float top = f.tl[ch] * (1.0f - u) + f.tr[ch] * u;
+    const float bot = f.bl[ch] * (1.0f - u) + f.br[ch] * u;
+    return top * (1.0f - v) + bot * v;
+}
+
+/// Foreground (paper) mask: pixels whose color is far from the local background by
+/// more than @p threshold (L1 over channels). The background is the per-corner
+/// bilinear estimate (issue #274), so it works for colored or dark paper AND survives
+/// a lit gradient across the table, not just a uniform surface.
 inline Mask foregroundMask(const Image& img, float threshold = 60.0f, int border = 2) {
     Mask m(img.width, img.height);
     if (img.width <= 0 || img.height <= 0 || img.channels <= 0) return m;
-    const std::vector<float> bg = estimateBackgroundColor(img, border);
+    const BackgroundField bg = estimateBackgroundField(img, border);
     for (int y = 0; y < img.height; ++y) {
         for (int x = 0; x < img.width; ++x) {
             float dist = 0.0f;
             for (int c = 0; c < img.channels; ++c) {
-                dist += std::fabs(static_cast<float>(img.at(x, y, c)) - bg[static_cast<std::size_t>(c)]);
+                dist += std::fabs(static_cast<float>(img.at(x, y, c)) -
+                                  backgroundColorAt(bg, x, y, img.width, img.height, c));
             }
             if (dist > threshold) m.set(x, y, 1);
         }
@@ -342,6 +416,63 @@ inline Polyline mergeCollinear(const Polyline& poly, float angleTolDeg = 12.0f) 
     return out;
 }
 
+// ---------------------------------------------------------------------------
+// Shadow-edge suppression (edge-profile discrimination)
+// ---------------------------------------------------------------------------
+namespace detail {
+
+/// Dilate a mask by a box radius @p r (out-of-bounds treated as 0).
+inline Mask dilateMask(const Mask& m, int r) {
+    if (r <= 0) return m;
+    Mask out(m.width, m.height);
+    for (int y = 0; y < m.height; ++y) {
+        for (int x = 0; x < m.width; ++x) {
+            bool on = false;
+            for (int dy = -r; dy <= r && !on; ++dy) {
+                for (int dx = -r; dx <= r; ++dx) {
+                    if (m.get(x + dx, y + dy)) { on = true; break; }
+                }
+            }
+            if (on) out.set(x, y, 1);
+        }
+    }
+    return out;
+}
+
+/**
+ * @brief Mask of "stroke-like" pixels: luminance valleys, darker than the paper on
+ *        BOTH sides along x or along y (issue #274).
+ *
+ * A pen stroke is a thin dark line flanked by lighter paper on both sides (a local
+ * minimum). A hard cast-shadow EDGE is a monotonic step - bright on one side, dark on
+ * the other - so it is never a two-sided valley and is excluded. The flanks are probed
+ * at @p probe pixels (larger than the stroke half-width, so they land on paper, not on
+ * the stroke itself). Run on the original luminance, where the shadow edge is a clean
+ * step; on the flattened image both far sides read white, which would hide the step.
+ */
+inline Mask strokeValleyMask(const Image& img, int probe = 4, float minContrast = 18.0f) {
+    Mask m(img.width, img.height);
+    if (img.width <= 0 || img.height <= 0) return m;
+    auto lum = [&](int x, int y) {
+        if (x < 0) x = 0;
+        if (y < 0) y = 0;
+        if (x > img.width - 1) x = img.width - 1;
+        if (y > img.height - 1) y = img.height - 1;
+        return img.luminance(x, y);
+    };
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = 0; x < img.width; ++x) {
+            const float c = lum(x, y);
+            const bool hValley = (lum(x - probe, y) - c > minContrast) && (lum(x + probe, y) - c > minContrast);
+            const bool vValley = (lum(x, y - probe) - c > minContrast) && (lum(x, y + probe) - c > minContrast);
+            if (hValley || vValley) m.set(x, y, 1);
+        }
+    }
+    return m;
+}
+
+} // namespace detail
+
 /// Knobs for the robust pipeline; @c vec reuses the Phase 1 vectorization options.
 struct RobustOptions {
     int illumRadius{15};
@@ -349,6 +480,12 @@ struct RobustOptions {
     float maxSkewDeg{12.0f};
     float collinearTolDeg{18.0f};
     float closeLoopFactor{1.5f}; ///< close a polyline if its ends are within this * grid.
+    // Shadow-edge suppression (issue #274): keep only ink that is a luminance valley
+    // in the original image, so a hard shadow edge (a monotonic step) is not vectorized
+    // as a wall. Disable to get the pre-#274 behavior.
+    bool suppressShadowEdges{true};
+    int shadowProbe{4};            ///< flank distance for the valley test (> stroke half-width).
+    float shadowMinContrast{18.0f}; ///< min luminance drop from paper to ink on both sides.
     VectorizeOptions vec{};
 };
 
@@ -360,15 +497,35 @@ struct RobustOptions {
  */
 inline std::vector<Polyline> vectorizeWallsRobust(const Image& img, const RobustOptions& opt = {}) {
     Image work = flattenIllumination(img, opt.illumRadius);
+    Image orig = img; // original luminance for the edge-profile test (kept aligned with work)
     if (opt.deskew) {
         Mask pre = binarizeAdaptive(work, opt.vec.adaptiveRadius, opt.vec.threshC);
         denoise(pre, opt.vec.minComponentArea);
         const float skew = estimateSkewAngle(pre, opt.maxSkewDeg);
-        if (std::fabs(skew) > 0.25f) work = deskewImage(work, skew);
+        if (std::fabs(skew) > 0.25f) {
+            work = deskewImage(work, skew);
+            orig = deskewImage(orig, skew);
+        }
     }
 
     Mask bin = binarizeAdaptive(work, opt.vec.adaptiveRadius, opt.vec.threshC);
     denoise(bin, opt.vec.minComponentArea);
+
+    // Shadow-edge suppression (issue #274): a hard cast-shadow edge survives illumination
+    // flattening as a dark band, which would vectorize into a false wall. Keep only ink
+    // that is a luminance valley in the original image (dark with lighter paper on both
+    // sides); a shadow edge is a monotonic step, so it is dropped while pen strokes stay.
+    if (opt.suppressShadowEdges) {
+        Mask keep = detail::strokeValleyMask(orig, opt.shadowProbe, opt.shadowMinContrast);
+        keep = detail::dilateMask(keep, 1); // forgive 1px misalignment vs the binarized ink
+        for (int y = 0; y < bin.height; ++y) {
+            for (int x = 0; x < bin.width; ++x) {
+                if (bin.get(x, y) && !keep.get(x, y)) bin.set(x, y, 0);
+            }
+        }
+        denoise(bin, opt.vec.minComponentArea);
+    }
+
     const Mask skeleton = thinZhangSuen(bin);
     const std::vector<Polyline> traced = tracePolylines(skeleton);
 

--- a/tests/test_cv_robust.cpp
+++ b/tests/test_cv_robust.cpp
@@ -68,6 +68,44 @@ static Image makeRoom(int W, int H, int x0, int y0, int x1, int y1,
     return img;
 }
 
+// A HARD cast-shadow band: a vertical stripe darkened by a step (sharp edges), the
+// kind that survives illumination flattening as false vertical wall lines (issue #274).
+static void applyShadowBand(Image& img, int xa, int xb, float factor) {
+    for (int y = 0; y < img.height; ++y) {
+        for (int x = xa; x <= xb && x < img.width; ++x) {
+            for (int c = 0; c < img.channels; ++c) img.set(x, y, c, clampByte(img.at(x, y, c) * factor));
+        }
+    }
+}
+
+// A table with a strong horizontal lighting gradient (bright left -> dark right),
+// with a flat kraft sheet + room outline composited in the center. The gradient
+// destabilizes a single border-mean background estimate (issue #274).
+static Image makeGradientTablePhoto(int W, int H) {
+    Image photo(W, H, 3);
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            const float g = 240.0f - (x / static_cast<float>(W - 1)) * 90.0f; // 240..150
+            photo.set(x, y, 0, clampByte(g));
+            photo.set(x, y, 1, clampByte(g));
+            photo.set(x, y, 2, clampByte(g + 2.0f));
+        }
+    }
+    // Flat kraft sheet in the center (unaffected by the table's lighting).
+    const int px0 = W / 4, py0 = H / 4, px1 = W - W / 4, py1 = H - H / 4;
+    for (int y = py0; y < py1; ++y) {
+        for (int x = px0; x < px1; ++x) { photo.set(x, y, 0, 185); photo.set(x, y, 1, 150); photo.set(x, y, 2, 110); }
+    }
+    // Room outline inside the sheet (dark ink, 3px).
+    auto ink = [&](int x, int y) {
+        if (x >= 0 && y >= 0 && x < W && y < H) { photo.set(x, y, 0, 30); photo.set(x, y, 1, 26); photo.set(x, y, 2, 22); }
+    };
+    const int rx0 = px0 + 8, ry0 = py0 + 8, rx1 = px1 - 8, ry1 = py1 - 8;
+    for (int x = rx0; x <= rx1; ++x) for (int t = -1; t <= 1; ++t) { ink(x, ry0 + t); ink(x, ry1 + t); }
+    for (int y = ry0; y <= ry1; ++y) for (int t = -1; t <= 1; ++t) { ink(rx0 + t, y); ink(rx1 + t, y); }
+    return photo;
+}
+
 // Smooth, edge-free uneven lighting (linear gradient * soft radial vignette).
 static void applySmoothLighting(Image& img) {
     const int W = img.width, H = img.height;
@@ -309,6 +347,71 @@ static void testCorpusOffAngleColoredPaperPhoto() {
     CHECK(!phase1Clean); // Phase 2 is the improvement
 }
 
+// New Phase 2b corpus case: a hard cast-shadow band across the paper (issue #274).
+// The shadow edges must not become false walls; the room comes out single and clean.
+static void testCorpusCastShadowBand() {
+    Image room = makeRoom(130, 130, 30, 30, 95, 90, 250, 250, 248);
+    applyShadowBand(room, 55, 75, 0.4f); // vertical band, hard edges at x=55 and x=75
+
+    RobustOptions opt;
+    opt.vec.gridSize = 8.0f;
+    opt.vec.minComponentArea = 8;
+
+    const std::vector<Polyline> walls = vectorizeWallsRobust(room, opt);
+    const Topology t = buildTopology(walls, 8.0f, 2);
+    CHECK(t.interiorRoomCount() == 1);   // one clean room, not split by the shadow edges
+    CHECK(t.ambiguousGaps == 0);
+    const Polyline* best = longestPolyline(walls);
+    CHECK(best != nullptr && isClosed(*best));
+    if (best) CHECK(isAxisAlignedOnGrid(*best, 8.0f));
+
+    // Without suppression the shadow edges leak in, so the result is strictly worse
+    // (extra rooms, ambiguous gaps, or a non-clean single room) - the fix is real.
+    RobustOptions off = opt;
+    off.suppressShadowEdges = false;
+    const std::vector<Polyline> wallsOff = vectorizeWallsRobust(room, off);
+    const Topology tOff = buildTopology(wallsOff, 8.0f, 2);
+    const bool cleanOff = tOff.interiorRoomCount() == 1 && tOff.ambiguousGaps == 0;
+    CHECK(!cleanOff);
+}
+
+// New Phase 2b corpus case: a strong lighting gradient across the table (issue #274).
+// The per-corner background estimate isolates the sheet where a single mean cannot.
+static void testCorpusGradientLitTable() {
+    const Image photo = makeGradientTablePhoto(160, 160);
+
+    // The single border mean is stranded mid-gradient, so a bright table pixel reads
+    // as far from it (a naive detector would mark the table as foreground)...
+    const std::vector<float> singleMean = estimateBackgroundColor(photo, 2);
+    float dTable = 0.0f;
+    for (int c = 0; c < 3; ++c) dTable += std::fabs(static_cast<float>(photo.at(6, 80, c)) - singleMean[static_cast<std::size_t>(c)]);
+    CHECK(dTable > 60.0f); // single mean misclassifies the lit table corner
+
+    // ...but the per-corner field tracks the gradient, so the table is background and
+    // only the sheet is foreground.
+    const Mask fg = foregroundMask(photo, 60.0f);
+    CHECK(fg.get(6, 80) == 0);   // bright-left table: background
+    CHECK(fg.get(154, 80) == 0); // dark-right table: background
+    CHECK(fg.get(80, 80) == 1);  // the sheet: foreground
+
+    // The paper quad is recovered tightly around the sheet ([40,40]..[119,119]).
+    const Quad q = detectPaperQuadRobust(photo, 60.0f);
+    CHECK(nearf(q.tl.x, 40, 6) && nearf(q.tl.y, 40, 6));
+    CHECK(nearf(q.br.x, 119, 6) && nearf(q.br.y, 119, 6));
+
+    // End to end: rectify -> vectorize -> topology yields one clean, closed room.
+    const Image rect = rectifyRobust(photo, 100, 60.0f);
+    RobustOptions opt;
+    opt.vec.gridSize = 8.0f;
+    opt.vec.minComponentArea = 8;
+    const std::vector<Polyline> walls = vectorizeWallsRobust(rect, opt);
+    const Topology t = buildTopology(walls, 8.0f, 2);
+    CHECK(t.interiorRoomCount() == 1);
+    CHECK(t.ambiguousGaps == 0);
+    const Polyline* best = longestPolyline(walls);
+    CHECK(best != nullptr && isClosed(*best));
+}
+
 int main() {
     testFlattenCancelsShadow();
     testSkewEstimateAndDeskew();
@@ -318,6 +421,8 @@ int main() {
     testCorpusCleanRoomUnchanged();
     testCorpusUnevenLitTintedRoom();
     testCorpusOffAngleColoredPaperPhoto();
+    testCorpusCastShadowBand();
+    testCorpusGradientLitTable();
 
     if (g_failures == 0) {
         std::printf("All CV robustness tests passed.\n");


### PR DESCRIPTION
Closes #274.

#239 shipped the Phase 2 robustness layer (`src/cv/Robust.h`) and flagged two remaining hard modes: a hard cast-shadow EDGE across the paper reads as an object boundary and vectorizes into false wall lines, and a gradient-lit background destabilizes the single border-mean background estimate in `detectPaperQuadRobust`. This closes both, keeping the corpus headless and deterministic.

## Changes

- **`src/cv/Robust.h`**:
  - **Shadow-edge suppression before vectorization.** `detail::strokeValleyMask` keeps only ink that is a luminance *valley* in the original image (darker than the paper on **both** sides along x or y). A pen stroke is a two-sided valley and is kept; a hard cast-shadow edge is a monotonic *step* (bright one side, dark the other) and is dropped. `vectorizeWallsRobust` carries the deskewed original luminance, computes the valley keep-mask, and intersects it with the binarized flattened ink. Gated by `RobustOptions::suppressShadowEdges` (probe distance and min contrast are tunable). This is the "edge width/contrast profiling" the issue suggested.
  - **Gradient-robust background.** `estimateBackgroundField` samples the border ring bucketed by nearest corner (so interior clutter is still excluded, exactly like the old mean), and `backgroundColorAt` bilinearly interpolates the four corners, so `foregroundMask` tracks a lit gradient across the table instead of a single mean. On a uniform background all four corners are equal, so the estimate is the same constant as before and existing results are unchanged.
- **`tests/test_cv_robust.cpp`**: two new end-to-end corpus cases:
  - a hard cast-shadow band, with a with/without-suppression contrast proving the fix is real (without suppression the shadow edges split the room / add ambiguous gaps);
  - a strong gradient-lit table, showing the single border mean misclassifies the lit table as foreground while the per-corner field isolates the sheet.
  Each yields one clean, closed room with no false walls and no ambiguous gaps.

## Acceptance

- Both new corpus cases yield a single clean, closed room with no false walls and no ambiguous gaps (`interiorRoomCount() == 1`, `ambiguousGaps == 0`, closed + axis-aligned).
- The existing Phase 2 corpus is unchanged: all prior primitive and corpus tests still pass (the corner field reduces to the old mean on uniform backgrounds; suppression keeps valley strokes untouched).
- Everything remains headless and deterministic - the two scenes are synthesized procedurally, no external image files.

## Verification

- `test_cv_robust` (extended) passes under ASan/UBSan (`g++ -std=c++17 -fsanitize=address,undefined`).
- `Robust.h` compiles standalone under `-Wall -Wextra -pedantic` with zero GL/glm dependencies.
- I let the tests drive the tuning: the first draft sampled a corner *block* that swallowed the existing clutter-speck test, so the corner estimate now samples the border ring by quadrant (clutter-excluding) rather than a solid block.