### PR TITLE
CI: run the headless unit-test suite as a PR gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Unit Tests
+
+# Runs the headless unit-test suite as a PR gate. The test_* executables were built
+# by the other workflows but never executed, so an assertion regression could not fail
+# CI. This builds only the header-only / deterministic tests (the `headless_tests`
+# target) and runs them via CTest; GL/GLFW/OpenAL/Bullet-linked tests are excluded as
+# they need a display or audio device.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  headless-tests:
+    name: Headless unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libxrandr-dev \
+          libxinerama-dev \
+          libxcursor-dev \
+          libxi-dev \
+          libxext-dev \
+          libx11-dev \
+          mesa-common-dev \
+          libgl1-mesa-dev \
+          libglu1-mesa-dev \
+          libopenal-dev \
+          pkg-config
+
+    - name: Configure
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+
+    - name: Build headless test suite
+      run: cmake --build build --target headless_tests -j$(nproc)
+
+    - name: Run headless tests
+      working-directory: build
+      run: ctest -L headless --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ project(IKoreEngine LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Register unit tests with CTest so the headless suite can gate PRs (see the
+# HEADLESS_TESTS block at the end of this file and .github/workflows/tests.yml).
+enable_testing()
+
 include(FetchContent)
 
 # GLFW
@@ -867,3 +871,106 @@ if (APPLE)
 endif()
 
 install(TARGETS IKore RUNTIME DESTINATION bin)
+
+# ---------------------------------------------------------------------------
+# Headless unit-test gate (issue: wire the test suite into CI as a PR check).
+#
+# These test_* targets are header-only / deterministic - they need no GL context,
+# window, or audio device - so they run anywhere and gate every PR. Registered with
+# CTest under the "headless" label and aggregated into the `headless_tests` target so
+# CI can build + run just this subset:
+#     cmake --build build --target headless_tests -j
+#     ctest --test-dir build -L headless --output-on-failure
+# GL/GLFW/OpenAL/Bullet-linked tests are intentionally excluded (they need a display
+# or device). When adding a new headless test, add its target name here.
+# ---------------------------------------------------------------------------
+set(HEADLESS_TESTS
+    test_app_shell
+    test_archetype_ecs
+    test_audio_decode
+    test_audio_streaming
+    test_benchmark
+    test_crowd
+    test_cv_robust
+    test_data_export
+    test_debug_console
+    test_debug_text
+    test_desync
+    test_determinism
+    test_doodle_library
+    test_doodle_scene
+    test_dungeon_game
+    test_ecs_benchmark
+    test_ecs_query
+    test_ecs_systems
+    test_entity_inspector
+    test_file_watcher
+    test_frame_graph
+    test_geojson_importer
+    test_ghost_replay
+    test_glyph_net
+    test_hud_framework
+    test_ibl_brdf
+    test_input_map
+    test_leaderboard
+    test_level_catalog
+    test_level_format
+    test_level_review
+    test_level_share
+    test_log_system
+    test_menu_system
+    test_navmesh
+    test_normal_mapping
+    test_particle_emit
+    test_particle_sim
+    test_pbr_brdf
+    test_pbr_material
+    test_pbr_textures
+    test_perf_stats
+    test_picking
+    test_quest_gen
+    test_rectify
+    test_render_pass_graph
+    test_rollback
+    test_scene_author
+    test_scene_hierarchy
+    test_settings
+    test_shadow_cascade_build
+    test_shadow_cascades
+    test_shadow_filtering
+    test_simulation
+    test_skinned_shadow
+    test_skinning
+    test_ssao_kernel
+    test_svg_floorplan
+    test_symbol_recognizer
+    test_symbols
+    test_timeline
+    test_tmx_importer
+    test_tone_mapping
+    test_tonemap_chain
+    test_topology
+    test_tour_camera
+    test_tower_defense
+    test_ui_scaling
+    test_vectorize
+    test_vertical_slice
+    test_weekly_challenge
+)
+
+set(_present_headless_tests "")
+foreach(_t ${HEADLESS_TESTS})
+    if(TARGET ${_t})
+        add_test(NAME ${_t} COMMAND ${_t})
+        set_tests_properties(${_t} PROPERTIES LABELS headless)
+        list(APPEND _present_headless_tests ${_t})
+    else()
+        message(WARNING "HEADLESS_TESTS lists '${_t}' but no such target exists")
+    endif()
+endforeach()
+
+# Aggregate target so CI can build only the headless suite (skipping the engine and
+# the GL/audio-linked tests) before running `ctest -L headless`.
+if(_present_headless_tests)
+    add_custom_target(headless_tests DEPENDS ${_present_headless_tests})
+endif()


### PR DESCRIPTION
## Problem

The `test_*` executables are built by the existing workflows (they are default CMake targets) but **never executed**, so a runtime assertion regression could not fail CI. Only compile errors were caught. Everything shipped in the recent rendering (#265-#270) and doodle-game (#271-#274) work has a unit test, but none of them actually gate a PR.

## Change

- **`CMakeLists.txt`**: `enable_testing()`, and register the 71 header-only / deterministic test targets under the `headless` CTest label, aggregated into a `headless_tests` target. Each name is guarded by `if(TARGET ...)` so a stale entry warns instead of breaking configure. GL/GLFW/OpenAL/Bullet-linked tests are intentionally excluded - they need a display or audio device and cannot run on a headless runner.
- **`.github/workflows/tests.yml`**: a new "Unit Tests" job that installs the GL/X dev packages (needed to configure the project), builds only the `headless_tests` target (skipping the engine and the GL/audio tests), and runs `ctest -L headless --output-on-failure`.

## Why only 71 of the 88 tests

I compiled and ran every `tests/test_*.cpp` with a plain `g++ -std=c++17 -I src`. 71 compile and pass with no GL context / window / audio device (all the math, rendering-math, ECS, CV, and game-logic cores); 17 link GL/GLFW/OpenAL/Bullet and need a display or device, so they stay out of the headless gate. Result: **71 pass, 0 fail, 17 excluded.**

## Verification

- All 71 listed tests compile and pass headlessly (`g++ -std=c++17 -I src`), zero failures.
- Every listed name maps to a real `add_executable`, and no headless-passing test was omitted (checked both directions against the CMake targets).
- The CTest registration block (foreach + `add_test` + `LABELS headless` + missing-target guard + `add_custom_target`) was validated end to end in an isolated CMake project: configure succeeded, the missing-target guard warned without erroring, `headless_tests` built, and `ctest -L headless` ran the labeled tests and reported them under the `headless` label.

A full local configure of the real project stops in the fetched deps (a missing X dev package / C-toolchain quirk in this sandbox) before reaching the new block; that same configure + build already succeeds in the existing CI jobs, so the workflow will run there.

## Follow-ups (not in this PR)

- When adding a new headless test, add its target name to the `HEADLESS_TESTS` list.
- The 17 GL/audio tests could later run under a virtual display (e.g. Xvfb) if desired.