### PR TITLE
Doodle: bridge the game modes to the rollback netcode core (#291)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,11 @@ add_executable(test_rollback
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_rollback.cpp
 )
 
+# Doodle game adapter for the rollback netcode core (#291) - header-only.
+add_executable(test_doodle_rollback
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_doodle_rollback.cpp
+)
+
 # Desync detection + diagnostics + input-log replay (Milestone 14 / #161) - header-only.
 add_executable(test_desync
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_desync.cpp
@@ -898,6 +903,7 @@ set(HEADLESS_TESTS
     test_desync
     test_determinism
     test_doodle_library
+    test_doodle_rollback
     test_doodle_scene
     test_dungeon_game
     test_ecs_benchmark

--- a/src/game/DoodleRollback.h
+++ b/src/game/DoodleRollback.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "game/DungeonGame.h"  // DungeonGame, GameInput, loadGame, GameStatus
+#include "game/DoodleScene.h"  // LevelSpec, convert
+#include "game/LevelFormat.h"  // fromLevelJson
+#include "core/sim/StateHash.h" // sim::StateHash (desync digest)
+#include "net/Rollback.h"      // net::RollbackSession (the netcode core it plugs into)
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+/**
+ * @file DoodleRollback.h
+ * @brief Adapter that lets the rollback netcode core drive the doodle game (issue #291).
+ *
+ * The GGPO-style RollbackSession (#160) is templated on a value-type State snapshotted
+ * per frame and a small Input; the doodle game (DungeonGame, #164) is deterministic but
+ * was never wired to it. This provides that bridge so a doodle level can be played
+ * online (co-op race / versus, #293) with prediction and rollback:
+ *
+ *   - DoodleNetState: one DungeonGame per player, all loaded from the same level. It is
+ *     a copyable value type (the rollback snapshot) with exact equality, so a session
+ *     can snapshot/restore/resimulate it and detect divergence.
+ *   - doodleStep(): the deterministic per-frame step - advance each player's game by
+ *     that player's input for the frame - matching RollbackSession's StepFn shape.
+ *   - stateDigest(): a StateHash over the state for desync detection.
+ *
+ * The single-player DungeonGame is untouched; this is purely additive. DungeonGame is
+ * float-deterministic (the same replay assumption the leaderboards/#242 rely on), so
+ * snapshot/restore/resim reproduce identical state on a given platform.
+ * Header-only, std only.
+ */
+namespace IKore {
+namespace game {
+
+/// One independent doodle game per player (all the same level), as a rollback State.
+struct DoodleNetState {
+    std::vector<DungeonGame> games;
+
+    /// Exact equality over the mutated state of every player's game, so two sessions
+    /// (or a session and a no-network reference) can be compared for convergence.
+    bool operator==(const DoodleNetState& o) const {
+        if (games.size() != o.games.size()) return false;
+        for (std::size_t i = 0; i < games.size(); ++i) {
+            const DungeonGame& a = games[i];
+            const DungeonGame& b = o.games[i];
+            if (a.status != b.status || a.coinsCollected != b.coinsCollected) return false;
+            if (a.playerPosition.x != b.playerPosition.x || a.playerPosition.z != b.playerPosition.z) return false;
+            if (a.coins.size() != b.coins.size() || a.enemies.size() != b.enemies.size()) return false;
+            for (std::size_t c = 0; c < a.coins.size(); ++c) {
+                if (a.coins[c].collected != b.coins[c].collected) return false;
+            }
+            for (std::size_t e = 0; e < a.enemies.size(); ++e) {
+                if (a.enemies[e].position.x != b.enemies[e].position.x ||
+                    a.enemies[e].position.z != b.enemies[e].position.z) return false;
+            }
+        }
+        return true;
+    }
+    bool operator!=(const DoodleNetState& o) const { return !(*this == o); }
+};
+
+namespace detail {
+/// Fold a float's bit pattern into a StateHash (DungeonGame is float, StateHash is
+/// integer; hashing the raw bits keeps the digest exact same-platform for desync checks).
+inline void hashFloat(sim::StateHash& h, float f) {
+    std::uint32_t bits = 0;
+    std::memcpy(&bits, &f, sizeof(bits));
+    h.addU32(bits);
+}
+} // namespace detail
+
+/**
+ * @brief Build the initial rollback state for @p levelJson and @p numPlayers.
+ *        Each player gets an independent game of the same level. Empty games vector if
+ *        the level fails to parse.
+ */
+inline DoodleNetState makeDoodleNetState(const std::string& levelJson, int numPlayers) {
+    DoodleNetState s;
+    if (numPlayers < 1) numPlayers = 1;
+    LevelSpec spec;
+    if (!fromLevelJson(levelJson, spec)) return s;
+    const DungeonGame base = loadGame(convert(spec));
+    s.games.assign(static_cast<std::size_t>(numPlayers), base);
+    return s;
+}
+
+/// The rollback step: advance each player's game by that player's input for the frame.
+/// A deterministic pure function of (state, inputs), matching RollbackSession::StepFn.
+inline void doodleStep(DoodleNetState& state, const std::vector<GameInput>& inputs, int /*frame*/,
+                       float dt) {
+    for (std::size_t p = 0; p < state.games.size(); ++p) {
+        const GameInput in = p < inputs.size() ? inputs[p] : GameInput{};
+        state.games[p].update(in, dt);
+    }
+}
+
+/// A ready-to-use StepFn bound to a fixed timestep (what RollbackSession takes).
+inline net::RollbackSession<DoodleNetState, GameInput>::StepFn makeDoodleStepFn(float dt) {
+    return [dt](DoodleNetState& s, const std::vector<GameInput>& in, int frame) {
+        doodleStep(s, in, frame, dt);
+    };
+}
+
+/// A digest of the whole state for desync detection (bit-exact same-platform).
+inline std::uint64_t stateDigest(const DoodleNetState& state) {
+    sim::StateHash h;
+    for (const DungeonGame& g : state.games) {
+        h.addI32(static_cast<std::int32_t>(g.status));
+        h.addI32(g.coinsCollected);
+        detail::hashFloat(h, g.playerPosition.x);
+        detail::hashFloat(h, g.playerPosition.z);
+        for (const Coin& c : g.coins) h.addU32(c.collected ? 1u : 0u);
+        for (const Enemy& e : g.enemies) {
+            detail::hashFloat(h, e.position.x);
+            detail::hashFloat(h, e.position.z);
+        }
+    }
+    return h.digest();
+}
+
+} // namespace game
+} // namespace IKore

--- a/src/game/DungeonGame.h
+++ b/src/game/DungeonGame.h
@@ -32,6 +32,10 @@ enum class GameStatus { Playing, Won, Lost };
 struct GameInput {
     float moveX{0.0f};
     float moveZ{0.0f};
+
+    /// Exact equality, so a rollback session can detect a mispredicted input (#291).
+    bool operator==(const GameInput& o) const { return moveX == o.moveX && moveZ == o.moveZ; }
+    bool operator!=(const GameInput& o) const { return !(*this == o); }
 };
 
 struct Coin {

--- a/tests/test_doodle_rollback.cpp
+++ b/tests/test_doodle_rollback.cpp
@@ -1,0 +1,170 @@
+// Test for the doodle rollback adapter - issue #291.
+//
+// Verifies the doodle game plugs into the GGPO-style rollback core (net/Rollback.h,
+// #160): two RollbackSessions driving a DoodleNetState exchange inputs over a delayed,
+// lossy channel and, once all inputs are delivered, reach state identical to a
+// no-network reference; mispredictions roll back and resimulate to exactly the
+// reference; and a correctly-predicted stream never rolls back. Mirrors test_rollback
+// with the doodle sim substituted, so it is headless and deterministic.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_doodle_rollback.cpp -o test_doodle_rollback
+
+#include "game/DoodleRollback.h"
+#include "game/LevelFormat.h" // toLevelJson
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+using IKore::net::RollbackSession;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static const float kDt = 1.0f / 60.0f;
+
+// A room with a player, a coin, an exit, and a chasing enemy, so the per-frame state
+// (position, coins, enemy) is rich enough for a misprediction to visibly diverge.
+static std::string makeLevelJson() {
+    LevelSpec s;
+    s.walls.push_back(Wall{{{0, 0, 0}, {40, 0, 0}, {40, 0, 40}, {0, 0, 40}, {0, 0, 0}}});
+    s.symbols.push_back(Symbol{"player", ecs::Vec3{6, 0, 6}, 0.0f});
+    s.symbols.push_back(Symbol{"coin", ecs::Vec3{20, 0, 20}, 0.0f});
+    s.symbols.push_back(Symbol{"exit", ecs::Vec3{34, 0, 34}, 0.0f});
+    s.symbols.push_back(Symbol{"enemy", ecs::Vec3{30, 0, 8}, 0.0f});
+    return toLevelJson(s);
+}
+
+// A tiny deterministic PRNG so both peers and the reference script identical inputs.
+static std::uint64_t rng(std::uint64_t& s) {
+    s += 0x9E3779B97F4A7C15ULL;
+    std::uint64_t z = s;
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+static std::vector<GameInput> scriptInputs(std::uint64_t seed, int n) {
+    std::vector<GameInput> v(static_cast<std::size_t>(n));
+    std::uint64_t s = seed;
+    for (int f = 0; f < n; ++f) {
+        v[static_cast<std::size_t>(f)].moveX = static_cast<float>(static_cast<int>(rng(s) % 3) - 1); // -1,0,1
+        v[static_cast<std::size_t>(f)].moveZ = static_cast<float>(static_cast<int>(rng(s) % 3) - 1);
+    }
+    return v;
+}
+
+// Ground truth: run the shared step with all inputs authoritative (no prediction).
+static DoodleNetState referenceRun(const std::string& json, const std::vector<GameInput>& p0,
+                                   const std::vector<GameInput>& p1, int n) {
+    DoodleNetState st = makeDoodleNetState(json, 2);
+    for (int f = 0; f < n; ++f) {
+        std::vector<GameInput> in = {p0[static_cast<std::size_t>(f)], p1[static_cast<std::size_t>(f)]};
+        doodleStep(st, in, f, kDt);
+    }
+    return st;
+}
+
+// Two sessions exchanging inputs `delay` frames late (and, when lossy, some deliveries
+// dropped then flushed at the end) converge to the reference.
+static void runConvergence(const std::string& json, std::uint64_t seedA, std::uint64_t seedB,
+                           int n, int delay, bool lossy) {
+    const std::vector<GameInput> p0 = scriptInputs(seedA, n);
+    const std::vector<GameInput> p1 = scriptInputs(seedB, n);
+    const DoodleNetState ref = referenceRun(json, p0, p1, n);
+
+    RollbackSession<DoodleNetState, GameInput> A(2, 0, makeDoodleNetState(json, 2), makeDoodleStepFn(kDt));
+    RollbackSession<DoodleNetState, GameInput> B(2, 1, makeDoodleNetState(json, 2), makeDoodleStepFn(kDt));
+
+    for (int f = 0; f < n; ++f) {
+        A.advanceFrame(p0[static_cast<std::size_t>(f)]);
+        B.advanceFrame(p1[static_cast<std::size_t>(f)]);
+        const int df = f - delay;
+        if (df >= 0) {
+            const bool drop = lossy && ((df % 5) == 0); // drop 1 in 5, redelivered later
+            if (!drop) {
+                A.addRemoteInput(1, df, p1[static_cast<std::size_t>(df)]);
+                B.addRemoteInput(0, df, p0[static_cast<std::size_t>(df)]);
+            }
+        }
+    }
+    // Flush every remaining authoritative input (late tail + dropped frames).
+    for (int f = 0; f < n; ++f) {
+        A.addRemoteInput(1, f, p1[static_cast<std::size_t>(f)]);
+        B.addRemoteInput(0, f, p0[static_cast<std::size_t>(f)]);
+    }
+
+    CHECK(A.state() == ref);
+    CHECK(B.state() == ref);
+    CHECK(stateDigest(A.state()) == stateDigest(ref));
+    CHECK(stateDigest(B.state()) == stateDigest(ref));
+}
+
+static void testConvergesUnderLatency() {
+    runConvergence(makeLevelJson(), 111, 222, 240, /*delay=*/4, /*lossy=*/false);
+}
+
+static void testConvergesUnderLatencyAndLoss() {
+    runConvergence(makeLevelJson(), 333, 444, 240, /*delay=*/6, /*lossy=*/true);
+}
+
+// Mispredictions actually happen (the varying stream cannot be predicted) yet the
+// final state is exactly the reference: rollback corrected the divergence.
+static void testMispredictionRollsBackToReference() {
+    const std::string json = makeLevelJson();
+    const int n = 180, delay = 5;
+    const std::vector<GameInput> p0 = scriptInputs(9, n);
+    const std::vector<GameInput> p1 = scriptInputs(10, n);
+    const DoodleNetState ref = referenceRun(json, p0, p1, n);
+
+    RollbackSession<DoodleNetState, GameInput> A(2, 0, makeDoodleNetState(json, 2), makeDoodleStepFn(kDt));
+    for (int f = 0; f < n; ++f) {
+        A.advanceFrame(p0[static_cast<std::size_t>(f)]);
+        const int df = f - delay;
+        if (df >= 0) A.addRemoteInput(1, df, p1[static_cast<std::size_t>(df)]);
+    }
+    for (int f = 0; f < n; ++f) A.addRemoteInput(1, f, p1[static_cast<std::size_t>(f)]);
+
+    CHECK(A.rollbackCount() > 0);   // the delayed, varying remote stream forced rollbacks
+    CHECK(A.state() == ref);        // and it still landed exactly on the reference
+}
+
+// A remote stream equal to the default input is predicted correctly from the start
+// (before any input, prediction is the default), so no rollback ever occurs.
+static void testCorrectPredictionNeverRollsBack() {
+    const std::string json = makeLevelJson();
+    const int n = 120, delay = 4;
+    const std::vector<GameInput> p0 = scriptInputs(7, n);
+    std::vector<GameInput> p1(static_cast<std::size_t>(n), GameInput{}); // matches the default prediction
+
+    RollbackSession<DoodleNetState, GameInput> A(2, 0, makeDoodleNetState(json, 2), makeDoodleStepFn(kDt));
+    for (int f = 0; f < n; ++f) {
+        A.advanceFrame(p0[static_cast<std::size_t>(f)]);
+        const int df = f - delay;
+        if (df >= 0) A.addRemoteInput(1, df, p1[static_cast<std::size_t>(df)]);
+    }
+    CHECK(A.rollbackCount() == 0); // repeat-last-input predicted the default stream exactly
+}
+
+int main() {
+    testConvergesUnderLatency();
+    testConvergesUnderLatencyAndLoss();
+    testMispredictionRollsBackToReference();
+    testCorrectPredictionNeverRollsBack();
+
+    if (g_failures == 0) {
+        std::printf("All doodle rollback tests passed.\n");
+        return 0;
+    }
+    std::printf("%d doodle rollback test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #291.

#160 shipped a GGPO-style `RollbackSession<State, Input>` (`src/net/Rollback.h`) on the deterministic sim core; the doodle game modes (`DungeonGame` #164) were never wired to it, so they could not be played online. This adds the adapter.

## Changes

- **`src/game/DoodleRollback.h`** (new):
  - `DoodleNetState` - one `DungeonGame` per player, all the same level; a copyable value type (the rollback snapshot) with exact equality over every player's mutated state (position, coins, enemies, status), so a session can snapshot/restore/resimulate and detect divergence.
  - `doodleStep` / `makeDoodleStepFn` - the deterministic per-frame step (advance each player's game by that player's input), matching `RollbackSession::StepFn`.
  - `stateDigest` - a `StateHash` over the state (float bits folded in) for desync detection.
- **`src/game/DungeonGame.h`** - `GameInput::operator==` / `!=` so a session can detect a mispredicted input. The single-player game is otherwise untouched.
- **`tests/test_doodle_rollback.cpp`** (new) - mirrors `test_rollback` with the doodle sim.
- **`CMakeLists.txt`** - register `test_doodle_rollback` (headless).

## Acceptance

- Two `RollbackSession`s advancing a doodle game over a delayed, lossy channel converge to byte-identical state matching a no-network reference.
- Mispredictions roll back and resimulate to exactly the reference (`rollbackCount > 0`, final state == reference).
- A correctly-predicted (default) stream never rolls back.
- Existing single-player `DungeonGame` behavior is unchanged (purely additive).

## Verification

- `test_doodle_rollback` passes under ASan/UBSan; it is registered in the headless CTest suite so the CI gate (#286) runs it.
- Determinism note: `DungeonGame` is float-based, so snapshot/restore/resim is bit-exact on a given platform (the same replay assumption the leaderboards / #242 rely on); the digest hashes the float bits for same-platform desync detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_