### PR TITLE
Doodle: async ghost race mode (#292)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,6 +658,12 @@ add_executable(test_ghost_replay
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ghost_replay.cpp
 )
 
+# Async ghost race: live run vs a shared ghost, lead + finish order, level-bound (#292)
+# - header-only.
+add_executable(test_ghost_race
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ghost_race.cpp
+)
+
 # Audio decode core: robust WAV/PCM parser + tone generator (#258) - header-only.
 add_executable(test_audio_decode
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_audio_decode.cpp
@@ -913,6 +919,7 @@ set(HEADLESS_TESTS
     test_file_watcher
     test_frame_graph
     test_geojson_importer
+    test_ghost_race
     test_ghost_replay
     test_glyph_net
     test_hud_framework

--- a/src/game/GhostRace.h
+++ b/src/game/GhostRace.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include "game/GhostReplay.h"  // GhostPlayback, decodeGhost, RunTrace
+#include "game/DungeonGame.h"  // DungeonGame, GameInput, loadGame, GameStatus
+#include "game/DoodleScene.h"  // LevelSpec, convert
+#include "game/LevelFormat.h"  // fromLevelJson
+
+#include <cmath>
+#include <string>
+
+/**
+ * @file GhostRace.h
+ * @brief Race a live run against a shared ghost, tick for tick (issue #292).
+ *
+ * #272 made a completed run a shareable, content-verified ghost (GhostReplay). This
+ * steps a live DungeonGame and a decoded GhostPlayback in lockstep at the fixed dt, so
+ * a player races a friend's best asynchronously: each tick exposes who is ahead, by how
+ * much, and the finish order. Because the sim is deterministic, the ghost reproduces the
+ * original run exactly, so the race is reproducible and verifiable.
+ *
+ * The race is bound to the level: constructing from a share string rejects a wrong-level
+ * or tampered ghost (via decodeGhost). Header-only, std only, no wall clock.
+ */
+namespace IKore {
+namespace game {
+
+/// A racer's standing at the current tick.
+struct RaceStanding {
+    float progress{0.0f}; ///< higher is further along (coins collected, then nearer the exit).
+    bool finished{false}; ///< the racer's game ended (won or lost).
+    bool won{false};
+    int finishTick{-1};   ///< tick at which the racer won (-1 if not yet).
+};
+
+/// A live game racing a ghost of a previous run over the same level.
+class GhostRace {
+public:
+    /// Race @p ghostTrace on @p levelJson. valid() is false if the level fails to load.
+    GhostRace(const std::string& levelJson, const RunTrace& ghostTrace, float dt)
+        : m_ghost(levelJson, ghostTrace), m_dt(dt) {
+        LevelSpec spec;
+        if (fromLevelJson(levelJson, spec) && m_ghost.valid()) {
+            m_live = loadGame(convert(spec));
+            m_valid = true;
+        }
+    }
+
+    /**
+     * @brief Build a race from a ghost share string, verified against @p levelJson.
+     *        valid() is false if the string is a wrong prefix, tampered, or a wrong
+     *        level (decodeGhost rejects it).
+     */
+    static GhostRace fromShare(const std::string& levelJson, const std::string& share, float dt) {
+        const GhostImport imp = decodeGhost(share, levelJson);
+        if (!imp.ok) return GhostRace(); // invalid
+        return GhostRace(levelJson, imp.trace, dt);
+    }
+
+    bool valid() const { return m_valid; }
+    int tick() const { return m_tick; }
+
+    /// True once the race is over: either racer won, or both games ended, or the ghost ran out.
+    bool finished() const {
+        if (!m_valid) return true;
+        if (m_live.won() || m_ghost.game().won()) return true;
+        const bool liveDone = m_live.status != GameStatus::Playing;
+        const bool ghostDone = m_ghost.finished();
+        return liveDone && ghostDone;
+    }
+
+    /// Advance the live game by @p liveInput and the ghost by one tick. False if finished.
+    bool step(const GameInput& liveInput) {
+        if (finished()) return false;
+        if (m_live.status == GameStatus::Playing) {
+            m_live.update(liveInput, m_dt);
+            if (m_live.won() && m_liveFinishTick < 0) m_liveFinishTick = m_tick + 1;
+        }
+        m_ghost.step();
+        if (m_ghost.game().won() && m_ghostFinishTick < 0) m_ghostFinishTick = m_tick + 1;
+        ++m_tick;
+        return true;
+    }
+
+    ecs::Vec3 livePosition() const { return m_live.playerPosition; }
+    ecs::Vec3 ghostPosition() const { return m_ghost.position(); }
+
+    RaceStanding liveStanding() const { return standing(m_live, m_liveFinishTick); }
+    RaceStanding ghostStanding() const { return standing(m_ghost.game(), m_ghostFinishTick); }
+
+    /// Live progress minus ghost progress: > 0 means the live run is ahead this tick.
+    float lead() const { return liveStanding().progress - ghostStanding().progress; }
+
+    /// Who is ahead this tick: 1 live, -1 ghost, 0 tie.
+    int leader() const {
+        const float d = lead();
+        if (d > 1e-4f) return 1;
+        if (d < -1e-4f) return -1;
+        return 0;
+    }
+
+    /// Race winner once finished(): 1 live, -1 ghost, 0 tie/undecided. The earlier
+    /// finish tick wins; if neither finished, the higher progress wins.
+    int winner() const {
+        const bool lw = m_liveFinishTick >= 0, gw = m_ghostFinishTick >= 0;
+        if (lw && gw) return m_liveFinishTick < m_ghostFinishTick ? 1
+                            : (m_ghostFinishTick < m_liveFinishTick ? -1 : 0);
+        if (lw) return 1;
+        if (gw) return -1;
+        return leader();
+    }
+
+private:
+    GhostRace() : m_ghost("", RunTrace{}), m_dt(1.0f / 60.0f) {}
+
+    static RaceStanding standing(const DungeonGame& g, int finishTick) {
+        RaceStanding s;
+        s.finished = g.status != GameStatus::Playing;
+        s.won = g.won();
+        s.finishTick = finishTick;
+        // Progress: each collected coin dominates, then nearness to the exit.
+        float exitDist = 0.0f;
+        if (g.hasExit) {
+            const float dx = g.exitPosition.x - g.playerPosition.x;
+            const float dz = g.exitPosition.z - g.playerPosition.z;
+            exitDist = std::sqrt(dx * dx + dz * dz);
+        }
+        s.progress = static_cast<float>(g.coinsCollected) * 1000.0f - exitDist + (g.won() ? 1e6f : 0.0f);
+        return s;
+    }
+
+    DungeonGame m_live;
+    GhostPlayback m_ghost;
+    float m_dt;
+    bool m_valid{false};
+    int m_tick{0};
+    int m_liveFinishTick{-1};
+    int m_ghostFinishTick{-1};
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_ghost_race.cpp
+++ b/tests/test_ghost_race.cpp
@@ -1,0 +1,149 @@
+// Test for the async ghost race mode - issue #292.
+//
+// Verifies the acceptance criteria headlessly: a live run and a decoded ghost step
+// tick for tick with a deterministic lead and finish order; the race is bound to the
+// level so a wrong-level or tampered ghost is rejected before it starts.
+//
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_ghost_race.cpp -o test_ghost_race
+
+#include "game/GhostRace.h"
+#include "game/LevelFormat.h" // toLevelJson
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static const float kDt = 1.0f / 60.0f;
+
+static std::string makeLevelJson() {
+    LevelSpec s;
+    s.walls.push_back(Wall{{{0, 0, 0}, {40, 0, 0}, {40, 0, 40}, {0, 0, 40}, {0, 0, 0}}});
+    s.symbols.push_back(Symbol{"player", ecs::Vec3{6, 0, 6}, 0.0f});
+    s.symbols.push_back(Symbol{"coin", ecs::Vec3{20, 0, 20}, 0.0f});
+    s.symbols.push_back(Symbol{"exit", ecs::Vec3{34, 0, 34}, 0.0f});
+    return toLevelJson(s);
+}
+
+static std::string makeOtherLevelJson() {
+    LevelSpec s;
+    s.walls.push_back(Wall{{{0, 0, 0}, {50, 0, 0}, {50, 0, 50}, {0, 0, 50}, {0, 0, 0}}});
+    s.symbols.push_back(Symbol{"player", ecs::Vec3{5, 0, 5}, 0.0f});
+    s.symbols.push_back(Symbol{"coin", ecs::Vec3{25, 0, 30}, 0.0f});
+    s.symbols.push_back(Symbol{"exit", ecs::Vec3{44, 0, 44}, 0.0f});
+    return toLevelJson(s);
+}
+
+static RunTrace playGreedy(const std::string& json, double dt, int maxSteps) {
+    RunTrace tr;
+    tr.dt = dt;
+    LevelSpec spec;
+    fromLevelJson(json, spec);
+    DungeonGame g = loadGame(convert(spec));
+    for (int step = 0; step < maxSteps && g.status == GameStatus::Playing; ++step) {
+        ecs::Vec3 target = g.exitPosition;
+        double best = 1e30;
+        for (const Coin& c : g.coins) {
+            if (c.collected) continue;
+            const double d = std::hypot(c.position.x - g.playerPosition.x, c.position.z - g.playerPosition.z);
+            if (d < best) { best = d; target = c.position; }
+        }
+        const GameInput in{target.x - g.playerPosition.x, target.z - g.playerPosition.z};
+        tr.inputs.push_back(in);
+        g.update(in, static_cast<float>(dt));
+    }
+    return tr;
+}
+
+// Racing the ghost's own inputs ties it exactly: same finish tick, ~zero lead throughout.
+static void testIdenticalRunTies() {
+    const std::string json = makeLevelJson();
+    const RunTrace ghost = playGreedy(json, kDt, 100000);
+
+    GhostRace race(json, ghost, kDt);
+    CHECK(race.valid());
+
+    std::size_t i = 0;
+    float maxAbsLead = 0.0f;
+    while (!race.finished() && i < ghost.inputs.size()) {
+        race.step(ghost.inputs[i]); // live replays the ghost's own inputs
+        maxAbsLead = std::max(maxAbsLead, std::fabs(race.lead()));
+        ++i;
+    }
+    CHECK(race.winner() == 0);            // a dead heat
+    CHECK(maxAbsLead < 1e-3f);            // never ahead or behind at any tick
+    CHECK(race.liveStanding().won && race.ghostStanding().won);
+    CHECK(race.liveStanding().finishTick == race.ghostStanding().finishTick);
+}
+
+// An idle live run loses: the ghost finishes, the live run never leads.
+static void testIdleLiveLoses() {
+    const std::string json = makeLevelJson();
+    const RunTrace ghost = playGreedy(json, kDt, 100000);
+
+    GhostRace race(json, ghost, kDt);
+    CHECK(race.valid());
+    int sawLiveLeadTicks = 0;
+    while (!race.finished()) {
+        race.step(GameInput{0.0f, 0.0f}); // live stands still
+        if (race.leader() == 1) ++sawLiveLeadTicks;
+    }
+    CHECK(race.winner() == -1);          // the ghost wins
+    CHECK(race.ghostStanding().won);
+    CHECK(!race.liveStanding().won);
+    CHECK(sawLiveLeadTicks == 0);        // an idle player is never ahead
+}
+
+// The race is bound to the level via the share string: correct level accepted,
+// wrong-level and tampered strings rejected.
+static void testShareBinding() {
+    const std::string json = makeLevelJson();
+    const std::string other = makeOtherLevelJson();
+    const RunTrace ghost = playGreedy(json, kDt, 100000);
+    const std::string share = encodeGhost(json, ghost);
+
+    // Correct level: valid race that ties when replaying the same inputs.
+    GhostRace ok = GhostRace::fromShare(json, share, kDt);
+    CHECK(ok.valid());
+
+    // Wrong level: rejected.
+    GhostRace wrong = GhostRace::fromShare(other, share, kDt);
+    CHECK(!wrong.valid());
+
+    // Tampered payload: rejected.
+    std::string tampered = share;
+    tampered[tampered.size() - 1] = (tampered.back() == 'A') ? 'B' : 'A';
+    GhostRace bad = GhostRace::fromShare(json, tampered, kDt);
+    CHECK(!bad.valid());
+
+    // A finished/invalid race is a safe no-op.
+    CHECK(wrong.finished());
+    CHECK(!wrong.step(GameInput{1.0f, 0.0f}));
+}
+
+int main() {
+    testIdenticalRunTies();
+    testIdleLiveLoses();
+    testShareBinding();
+
+    if (g_failures == 0) {
+        std::printf("All ghost race tests passed.\n");
+        return 0;
+    }
+    std::printf("%d ghost race test(s) failed.\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #292.

#272 made a completed run a shareable, content-verified ghost (`GhostReplay` + `GhostPlayback`). This races that ghost live alongside your own run, turning a leaderboard time into a head-to-head.

## Changes

- **`src/game/GhostRace.h`** (new): steps a live `DungeonGame` and a decoded `GhostPlayback` in lockstep at the fixed dt, exposing per-tick lead (coins collected, then nearness to the exit), who is ahead (`leader()`), the finish order, and the overall `winner()`. `fromShare()` decodes a ghost share string and rejects a wrong-level or tampered one via `decodeGhost`, so a race cannot run against the wrong level.
- **`tests/test_ghost_race.cpp`** (new): replaying the ghost's own inputs ties it (same finish tick, zero lead throughout); an idle live run loses and never leads; the share binding accepts the correct level and rejects wrong-level and tampered strings.
- **`CMakeLists.txt`**: register `test_ghost_race` (headless).

## Acceptance

- The live run and the ghost advance tick for tick; lead and finish order are deterministic and reproduce on re-simulation (the sim is deterministic).
- A wrong-level or tampered ghost is rejected before the race starts (`valid() == false`, and an invalid race is a safe no-op).
- Fully headless and deterministic, covered by unit tests (registered in the headless CTest gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_