### PR TITLE
Enable C language so the root CMake project configures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(POLICY CMP0072)
     cmake_policy(SET CMP0072 NEW)
 endif()
 
-project(IKoreEngine LANGUAGES CXX)
+project(IKoreEngine LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Summary

The root `CMakeLists.txt` builds `lua_static` from Lua's raw `.c` sources at
root scope (Lua is fetched as source, not as a subproject that enables C).
Because the top-level `project()` declared only `CXX`, CMake failed the generate
step with:

```
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
CMAKE_C_COMPILE_OBJECT
```

This broke configuration on `main`: the "Unit Tests" gate (and the multi-OS
builds) could not even reach the build step. The most recent `tests.yml` run on
`main` concluded in failure for this reason.

## Change

Declare `project(IKoreEngine LANGUAGES C CXX)`. This is a one-line, additive fix:

- It enables C so `lua_static` (and any other root-scope `.c` target) compiles.
- It leaves the existing `cmake_policy(VERSION 3.10)` / `CMP0072` handling
  untouched.

## Verification

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` now reaches `Generating done`
  (exit 0); previously it failed the generate step.
- `cmake --build build --target headless_tests` and `ctest -L headless` run the
  full header-only suite.

This unblocks the open PRs that currently fail CI only because `main` cannot
configure.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_