### PR TITLE
CI: sanitizer job for the headless test suite (ASan/UBSan) (#296)

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,56 @@
+name: Sanitizers
+
+# Runs the headless unit-test suite under AddressSanitizer + UndefinedBehaviorSanitizer
+# as a separate PR gate (issue #296). The tests are developed under ASan/UBSan locally
+# (several real bugs were caught that way), but the plain unit-test gate (tests.yml, #286)
+# builds them without sanitizers, so a memory/UB regression could slip through. This
+# builds the same `headless_tests` target with -fsanitize=address,undefined and
+# -fno-sanitize-recover=all (so any error aborts) and runs it via CTest. It is kept
+# separate from the plain gate so a sanitizer failure is clearly attributable.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  sanitize-headless:
+    name: Headless tests (ASan/UBSan)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libxrandr-dev \
+          libxinerama-dev \
+          libxcursor-dev \
+          libxi-dev \
+          libxext-dev \
+          libx11-dev \
+          mesa-common-dev \
+          libgl1-mesa-dev \
+          libglu1-mesa-dev \
+          libopenal-dev \
+          pkg-config
+
+    - name: Configure (ASan/UBSan)
+      run: >
+        cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g"
+        -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+
+    - name: Build headless test suite
+      run: cmake --build build --target headless_tests -j$(nproc)
+
+    - name: Run headless tests under sanitizers
+      working-directory: build
+      env:
+        ASAN_OPTIONS: detect_leaks=1:abort_on_error=1
+        UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+      run: ctest -L headless --output-on-failure


### PR DESCRIPTION
Closes #296.

The headless tests are developed and run under AddressSanitizer / UndefinedBehaviorSanitizer locally (several real bugs were caught that way, e.g. the left-shift UB in #259 and a heap overflow in the #266 test), but the plain unit-test gate (`tests.yml`, #286) builds them without sanitizers, so a memory/UB regression could slip through.

## Changes

- **`.github/workflows/sanitizers.yml`** (new): a separate job that
  - configures the `headless_tests` target with `-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g` (and the sanitizers on the link line), so any error aborts rather than being recovered;
  - builds the target and runs `ctest -L headless --output-on-failure` with strict `ASAN_OPTIONS`/`UBSAN_OPTIONS`;
  - triggers on push and pull_request to `main`.

It is kept separate from the plain gate so a sanitizer failure is clearly attributable, and the plain (non-sanitized) unit-test gate remains as its own check.

## Acceptance

- An ASan/UBSan error in any headless test fails CI (`-fno-sanitize-recover=all` + `halt_on_error`).
- The job runs on push and pull_request to `main`.
- The plain unit-test gate is untouched and remains its own check.

## Verification

Ran the exact job steps locally: the full 74-test headless suite builds under the sanitizer flags and passes `ctest -L headless` with zero sanitizer errors (`100% tests passed, 0 tests failed out of 74`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_