### PR TITLE
CI: run the GL/audio tests under a virtual display (Xvfb) (#294)

### DIFF
--- a/.github/workflows/gl-tests.yml
+++ b/.github/workflows/gl-tests.yml
@@ -1,0 +1,56 @@
+name: GL/Audio Tests
+
+# Runs the GL / audio test targets under a virtual display (issue #294). The unit-test
+# gate (tests.yml, #286) runs the headless, deterministic tests; the tests that link the
+# engine's GL / GLFW / OpenAL / Bullet stack were excluded because they need a display or
+# an audio device. This closes that gap by running them under Xvfb with a software GL
+# (mesa/llvmpipe) and a null OpenAL device, gating PRs on them via the `gl` CTest label.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  gl-tests:
+    name: GL/audio tests (Xvfb)
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libxrandr-dev \
+          libxinerama-dev \
+          libxcursor-dev \
+          libxi-dev \
+          libxext-dev \
+          libx11-dev \
+          mesa-common-dev \
+          libgl1-mesa-dev \
+          libglu1-mesa-dev \
+          libgl1-mesa-dri \
+          libopenal-dev \
+          xvfb \
+          pkg-config
+
+    - name: Configure
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+
+    - name: Build GL/audio test suite
+      run: cmake --build build --target gl_tests -j$(nproc)
+
+    - name: Run GL/audio tests under Xvfb
+      working-directory: build
+      env:
+        # Force the software rasterizer (llvmpipe) and a null audio device so the job is
+        # reliable on a runner with no GPU or sound card.
+        LIBGL_ALWAYS_SOFTWARE: "1"
+        GALLIUM_DRIVER: llvmpipe
+        ALSOFT_DRIVERS: "null"
+      run: xvfb-run -a ctest -L gl --output-on-failure --timeout 180

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,10 @@ add_executable(test_openal_3d_audio
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/EntityTypes.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/Transform.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/TransformableEntities.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/core/EntityDebugSystem.cpp
+    # EntityDebugSystem.cpp is intentionally omitted (issue #294): it is a graphics
+    # (glad/GL) source that this audio-only test never references, and compiling it here
+    # broke the build with "glad/glad.h: No such file or directory" since this target does
+    # not link glad. Excluding it keeps the target true to its "no graphics deps" comment.
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/Component.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/core/components/AudioComponent.cpp
     ${AUDIO_SOURCES}
@@ -999,4 +1002,58 @@ endforeach()
 # the GL/audio-linked tests) before running `ctest -L headless`.
 if(_present_headless_tests)
     add_custom_target(headless_tests DEPENDS ${_present_headless_tests})
+endif()
+
+# --- GL / audio tests (issue #294) -------------------------------------------------
+#
+# These tests link the engine's GL / GLFW / OpenAL / Bullet stack and were excluded from
+# the headless gate because they need a display or an audio device. They are registered
+# here under the `gl` label so CI can run them under a virtual display (Xvfb) + a software
+# GL (mesa/llvmpipe) + a null OpenAL device: `ctest -L gl`.
+#
+# Triaged to run headlessly under that setup. Any test that genuinely cannot (documented
+# below) is quarantined by leaving it out of this list rather than being silently dropped.
+set(GL_TESTS
+    test_ai_brain
+    test_ai_component
+    test_animation_component
+    test_audio_compressed
+    test_event_system
+    test_event_system_simple
+    test_material_component
+    test_mesh_component
+    test_mesh_component_geometry
+    test_mesh_component_minimal
+    test_network_component
+    test_openal_3d_audio
+    # Quarantined (issue #294): test_particle_component segfaults headlessly. Adding a
+    # ParticleComponent runs ParticleSystem::initializeBuffers, which calls live GL
+    # functions (glGenBuffers, ...) on attach; the test never creates a GL context, so
+    # those glad function pointers are null and it crashes. Re-enable once the test creates
+    # a GL context (a hidden GLFW window + gladLoad) before attaching the component.
+    # test_particle_component
+    test_physics_component
+    test_physics_simple
+    test_scene_graph
+    # Quarantined (issue #294): test_scripting does not build. src/scripting/ScriptSystem.cpp
+    # fails to compile with an ambiguous 'Entity' reference (the legacy IKore::Entity vs the
+    # archetype IKore::ecs::Entity), a pre-existing scripting/ECS namespace collision that is
+    # out of scope for this CI-gating change. Re-enable once ScriptSystem.cpp is fixed.
+    # test_scripting
+)
+
+set(_present_gl_tests "")
+foreach(_t ${GL_TESTS})
+    if(TARGET ${_t})
+        add_test(NAME ${_t} COMMAND ${_t})
+        set_tests_properties(${_t} PROPERTIES LABELS gl)
+        list(APPEND _present_gl_tests ${_t})
+    else()
+        message(WARNING "GL_TESTS lists '${_t}' but no such target exists")
+    endif()
+endforeach()
+
+# Aggregate target so CI can build just the GL/audio tests before running `ctest -L gl`.
+if(_present_gl_tests)
+    add_custom_target(gl_tests DEPENDS ${_present_gl_tests})
 endif()


### PR DESCRIPTION
Closes #294.

The unit-test gate (`tests.yml`, #286) runs the headless, deterministic tests; the tests that link the engine's GL / GLFW / OpenAL / Bullet stack were excluded because they need a display or an audio device. This closes that coverage gap.

## Changes

- **`CMakeLists.txt`**: register the excluded tests under a new `gl` CTest label (a `GL_TESTS` list + `foreach` + a `gl_tests` aggregate target, mirroring the headless block).
- **`.github/workflows/gl-tests.yml`** (new): installs Xvfb + a software GL (mesa/llvmpipe) + a null OpenAL device and runs `ctest -L gl --output-on-failure` under `xvfb-run`, gating push and pull_request to `main`.

## Triage (fix or quarantine, never silently dropped)

- **Fixed `test_openal_3d_audio`**: it compiled `src/core/EntityDebugSystem.cpp` (a glad/GL source it never references) yet did not link glad, so it failed with `glad/glad.h: No such file or directory`. Removed that dead graphics source, matching the target's own "no graphics deps" comment.
- **Quarantined `test_scripting`**: `src/scripting/ScriptSystem.cpp` does not compile (ambiguous `Entity` between the legacy `IKore::Entity` and the archetype `IKore::ecs::Entity`), a pre-existing namespace collision that is out of scope for this CI-gating change. Documented inline with a re-enable note.
- **Quarantined `test_particle_component`**: it segfaults headlessly because adding a `ParticleComponent` runs `ParticleSystem::initializeBuffers`, which calls live GL functions on attach while the test never creates a GL context (null glad pointers). Documented inline; re-enable once the test creates a context first.

## Acceptance

- The previously-excluded GL/audio tests build and run in CI and gate PRs (15 of the 17 are now gated under the `gl` label).
- The two that cannot run as-is are quarantined with a documented reason in `CMakeLists.txt`, not dropped.
- The job is reliable: the gated tests are pure-logic or use the null audio device (none require real GPU rendering), and the software GL / null OpenAL setup removes any device dependency.

## Verification

Ran the exact job steps locally under `xvfb-run` + `LIBGL_ALWAYS_SOFTWARE=1` (llvmpipe) + `ALSOFT_DRIVERS=null`: the 15 gated GL/audio tests build and pass (`100% tests passed, 0 tests failed out of 15`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_