### PR TITLE
Rendering: image-based lighting on by default, plus an intensity tunable (#288)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,11 +67,14 @@ IKore::PostProcessor* g_postProcessor = nullptr;
 // Global skybox pointer for keyboard callbacks
 IKore::Skybox* g_skybox = nullptr;
 
-// Image-based lighting for the PBR ambient term (issue #270). Generated at load from
-// the skybox cubemap; g_iblEnabled (toggle B) gates the IBL ambient so the constant-
-// ambient fallback stays available and is used whenever no environment is present.
+// Image-based lighting for the PBR ambient term (issue #270). Generated at load from the
+// skybox cubemap and on by default whenever a valid environment exists (issue #288);
+// g_iblEnabled (toggle B) forces the constant-ambient fallback, which is also used
+// automatically whenever no environment is present. g_iblIntensity scales the environment
+// ambient (an exposure control, keys [ and ]).
 IKore::IblEnvironment* g_ibl = nullptr;
 bool g_iblEnabled = true;
+float g_iblIntensity = 1.0f;
 
 // Global debug UI pointer for keyboard callbacks (F1 toggles the overlay)
 IKore::DebugUI* g_debugUI = nullptr;
@@ -111,6 +114,8 @@ void mouse_callback(GLFWwindow* window, double xpos, double ypos);
 void scroll_callback(GLFWwindow* window, double xoffset, double yoffset);
 void framebuffer_size_callback(GLFWwindow* window, int width, int height);
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods);
+// (Re)generate the IBL environment from the current skybox cubemap (issue #288).
+void regenerateIblFromSkybox();
 
 int main() {
     // Initialize logging system
@@ -226,15 +231,15 @@ int main() {
     g_skybox = &skybox; // Set global pointer for keyboard callbacks
 
     // Generate image-based lighting from the skybox cubemap (issue #270): irradiance,
-    // prefiltered specular, and the BRDF LUT for the PBR ambient term. Opt-in and only
-    // used when valid; PBR materials fall back to constant ambient otherwise.
+    // prefiltered specular, and the BRDF LUT for the PBR ambient term. On by default when a
+    // valid environment exists (issue #288); PBR materials fall back to constant ambient
+    // when generation fails or no skybox is present. g_ibl is always published so the
+    // environment can be regenerated when the skybox changes; iblOn additionally checks
+    // isValid().
     IKore::IblEnvironment iblEnv;
+    g_ibl = &iblEnv;
     if (skyboxLoaded && skybox.isLoaded()) {
-        if (iblEnv.generate(skybox.getTextureID())) {
-            g_ibl = &iblEnv;
-        } else {
-            LOG_WARNING("IBL generation failed - PBR uses constant ambient");
-        }
+        regenerateIblFromSkybox();
     }
 
     // === Particle System Initialization ===
@@ -989,6 +994,7 @@ int main() {
                 pbrShaderPtr->setInt("brdfLUT", 7);
                 const bool iblOn = g_ibl && g_ibl->isValid() && g_iblEnabled;
                 pbrShaderPtr->setInt("useIBL", iblOn ? 1 : 0);
+                pbrShaderPtr->setFloat("iblIntensity", g_iblIntensity);
                 if (iblOn) {
                     glActiveTexture(GL_TEXTURE5);
                     glBindTexture(GL_TEXTURE_CUBE_MAP, g_ibl->irradianceMap());
@@ -1219,6 +1225,19 @@ void framebuffer_size_callback(GLFWwindow* /*window*/, int width, int height) {
     }
 }
 
+// (Re)generate the IBL environment from the current skybox cubemap (issue #288). Called at
+// load and whenever the skybox changes so the PBR ambient stays in sync with the
+// environment. A no-op when there is no loaded skybox, in which case PBR keeps the
+// constant-ambient fallback (g_ibl stays not-valid).
+void regenerateIblFromSkybox() {
+    if (!g_ibl || !g_skybox || !g_skybox->isLoaded()) return;
+    if (g_ibl->generate(g_skybox->getTextureID())) {
+        LOG_INFO("IBL environment (re)generated from skybox");
+    } else {
+        LOG_WARNING("IBL generation failed - PBR uses constant ambient");
+    }
+}
+
 // Keyboard callback for toggling post-processing effects
 void key_callback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action, int /*mods*/) {
     if (action == GLFW_PRESS) {
@@ -1272,6 +1291,8 @@ void key_callback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action,
             // Toggle Skybox
             g_skybox->setEnabled(!g_skybox->isEnabled());
             LOG_INFO("Skybox " + std::string(g_skybox->isEnabled() ? "enabled" : "disabled"));
+            // The environment changed: refresh IBL from the current skybox cubemap (issue #288).
+            if (g_skybox->isEnabled()) regenerateIblFromSkybox();
         }
         else if (key == GLFW_KEY_5 && g_skybox) {
             // Decrease skybox intensity
@@ -1348,6 +1369,16 @@ void key_callback(GLFWwindow* /*window*/, int key, int /*scancode*/, int action,
             // Toggle image-based lighting for the PBR ambient term (issue #270).
             g_iblEnabled = !g_iblEnabled;
             LOG_INFO("Image-based lighting " + std::string(g_iblEnabled ? "enabled" : "disabled"));
+        }
+        else if (key == GLFW_KEY_LEFT_BRACKET) {
+            // Decrease the IBL ambient intensity/exposure (issue #288).
+            g_iblIntensity = std::max(0.0f, g_iblIntensity - 0.1f);
+            LOG_INFO("IBL intensity: " + std::to_string(g_iblIntensity));
+        }
+        else if (key == GLFW_KEY_RIGHT_BRACKET) {
+            // Increase the IBL ambient intensity/exposure (issue #288).
+            g_iblIntensity = std::min(4.0f, g_iblIntensity + 0.1f);
+            LOG_INFO("IBL intensity: " + std::to_string(g_iblIntensity));
         }
         else if (key == GLFW_KEY_C) {
             // Toggle frustum culling

--- a/src/shaders/pbr.frag
+++ b/src/shaders/pbr.frag
@@ -59,6 +59,8 @@ uniform samplerCube prefilterMap;
 uniform sampler2D brdfLUT;
 uniform bool useIBL;
 uniform float maxReflectionLod;
+// Exposure/intensity scale for the IBL ambient (issue #288); 1.0 leaves #270 unchanged.
+uniform float iblIntensity;
 
 const float PI = 3.14159265359;
 
@@ -178,7 +180,7 @@ void main() {
         vec2 envBRDF = texture(brdfLUT, vec2(NdotV, roughness)).rg;
         vec3 specularIBL = prefiltered * (F * envBRDF.x + envBRDF.y);
 
-        ambient = (kD * diffuseIBL + specularIBL) * ao;
+        ambient = (kD * diffuseIBL + specularIBL) * ao * iblIntensity;
     } else {
         ambient = vec3(0.03) * albedo * ao;
     }


### PR DESCRIPTION
Closes #288.

#270 shipped image-based lighting (irradiance map, prefiltered specular, BRDF LUT via `render::IblEnvironment`) for the PBR ambient term. This completes the "on by default" story and the remaining acceptance items.

## Changes

- **On by default when an environment exists**: `g_ibl` is now always published (set to the `IblEnvironment`), and `iblOn = g_ibl->isValid() && g_iblEnabled` with `g_iblEnabled` defaulting on. With no skybox or a generation failure the environment is not valid, so PBR keeps the constant ambient - byte-identical to before - and toggle `B` still forces that fallback.
- **IBL intensity/exposure tunable**: a new `iblIntensity` uniform in `pbr.frag` scales the environment ambient (`1.0` leaves #270 unchanged), driven by `g_iblIntensity` and adjustable with keys `[` and `]`.
- **Regenerate the IBL when the skybox changes**: generation is factored into `regenerateIblFromSkybox()` (called at load) and re-run when the skybox is re-enabled, so the ambient stays in sync with the current cubemap.

The resolve math in `pbr.frag` still mirrors the tested `render::IblBrdf` core; the only shader change is multiplying the existing IBL ambient by `iblIntensity`.

## Acceptance

- With a skybox present, PBR materials use environment irradiance and reflection by default.
- With no skybox (or a generation failure) the output matches the constant-ambient look exactly (the `else` branch of the shader is unchanged).
- The toggle (`B`) still forces the constant-ambient path; the resolve math stays mirrored by `render::IblBrdf`.

## Verification

- `pbr.frag` validated with `glslangValidator` (exit 0).
- Changes are localized and use existing renderer APIs (`Shader::setFloat`, `IblEnvironment::generate`, `Skybox::getTextureID`/`isLoaded`/`isEnabled`), matching adjacent code.
- Note: a full engine build could not be exercised because the engine target has pre-existing, unrelated build breaks on `main` - a duplicate `IKore::InputBinding` across `InputComponent.h` and `InputMap.h`, and a duplicate `IKore::LogLevel` across `Logger.h` and `LogSystem.h`. This is consistent with the headless-unverifiable caveat these rendering issues carry (GPU output is checked by mirroring a tested core and validating GLSL).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_