### PR TITLE
Rendering: cascaded shadow maps on by default with an auto-tuned split (#289)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,12 +85,13 @@ IKore::ParticleSystemManager* g_particleManager = nullptr;
 // Global shadow map manager for keyboard callbacks
 IKore::ShadowMapManager* g_shadowManager = nullptr;
 
-// Cascaded shadow maps for the directional light (issue #265). Opt-in: while
-// g_useCascadedShadows is false the directional light keeps the original single map
-// and the render is unchanged. Toggle with K; cycle the split lambda with J.
+// Cascaded shadow maps for the directional light (issue #265), on by default (issue #289):
+// the cascade count and split lambda are derived from the camera near/far at startup (see
+// the CSM setup in main). Toggle back to the single directional map with K (count == 1 also
+// degrades to that single-map behavior); cycle the split lambda with J.
 IKore::CascadedShadowMap* g_cascadedShadowMap = nullptr;
-bool g_useCascadedShadows = false;
-float g_cascadeSplitLambda = 0.5f;   // 0 uniform .. 1 logarithmic split
+bool g_useCascadedShadows = true;
+float g_cascadeSplitLambda = 0.5f;   // 0 uniform .. 1 logarithmic split; derived at startup
 float g_cascadeBlendBand = 2.0f;     // view-depth width of the cross-cascade seam blend
 
 // Global frustum culler for rendering optimization
@@ -578,10 +579,19 @@ int main() {
         LOG_INFO("Directional shadow map created successfully");
     }
 
-    // Cascaded shadow map for the directional light (issue #265). Additive and
-    // opt-in: it is only used while g_useCascadedShadows is true (toggle with K), so
-    // the default path stays the single directional map above.
-    IKore::CascadedShadowMap cascadedShadowMap(4 /* cascades */, 2048);
+    // Cascaded shadow map for the directional light (issue #265), on by default (issue
+    // #289). Derive a sensible cascade count and split lambda from the camera depth range:
+    // a larger far/near benefits from more cascades and a more logarithmic split (sharper
+    // near field); a small range degrades toward a single fitted map. This is parameter
+    // selection only - the split/fit math stays in the tested render::ShadowCascades core
+    // (computeCascades, below). Toggle back to the single map with K.
+    const float csmDepthRatio = camera.farPlane / std::max(camera.nearPlane, 1e-4f);
+    int csmCascadeCount = 1;
+    if (csmDepthRatio >= 500.0f)      csmCascadeCount = 4;
+    else if (csmDepthRatio >= 100.0f) csmCascadeCount = 3;
+    else if (csmDepthRatio >= 20.0f)  csmCascadeCount = 2;
+    g_cascadeSplitLambda = 0.4f + 0.1f * static_cast<float>(csmCascadeCount); // 0.5 .. 0.8
+    IKore::CascadedShadowMap cascadedShadowMap(csmCascadeCount, 2048);
     if (!cascadedShadowMap.initialize()) {
         LOG_WARNING("Failed to create cascaded shadow map - CSM path will be unavailable");
     } else {


### PR DESCRIPTION
Closes #289.

#265 wired cascaded shadow maps into the GPU shadow path but left them behind a default-off toggle (`K`), so the directional light defaulted to the single shadow map and near-field shadows stayed blocky. This makes CSM the default.

## Changes

- **Default on**: `g_useCascadedShadows` now defaults to `true`, so the directional light uses the cascade path out of the box.
- **Auto-tuned from the camera near/far**: at startup the cascade count and split lambda are derived from the camera depth range (`far/near`) - a larger range gets more cascades and a more logarithmic split (sharper near field), a small range degrades toward a single fitted map (count in `[1, 4]`, lambda in `[0.5, 0.8]`). This is parameter selection only; the split/fit math stays in the tested `render::ShadowCascades` core (`computeCascades`), and the shader still mirrors `selectCascade`.
- **Single-map path preserved**: toggle `K` flips back to the single map, `count == 1` already degrades to a single fitted map, and the cross-cascade blend (`cascadeBlendBand`) is retained so there is no seam popping.

## Acceptance

- Directional shadows use CSM by default; the near field is sharper (more cascades + logarithmic split for the default camera range).
- The single-map path remains available and unchanged when selected (`K`, or `count == 1`).
- All split/fit math stays in the tested core; no new fit math is added.

## Verification

- C++-only change (no shader edit needed - the shader already mirrors `selectCascade`).
- Uses existing, verified APIs (`Camera::nearPlane`/`farPlane`, the `CascadedShadowMap(count, resolution)` constructor from #265).
- Note: as with the other renderer wiring, a full engine build could not be exercised due to pre-existing, unrelated build breaks on `main` (duplicate `IKore::InputBinding` across `InputComponent.h`/`InputMap.h` and duplicate `IKore::LogLevel` across `Logger.h`/`LogSystem.h`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_