### PR TITLE
Fix pre-existing build breaks so the IKore engine target compiles

### DIFF
--- a/src/CascadedShadowMap.h
+++ b/src/CascadedShadowMap.h
@@ -24,7 +24,7 @@ namespace IKore {
 
 class CascadedShadowMap {
 public:
-    static const int kMaxCascades = 4;
+    static constexpr int kMaxCascades = 4;
 
     explicit CascadedShadowMap(int cascadeCount = 4, int resolution = 2048);
     ~CascadedShadowMap();

--- a/src/core/InputMap.h
+++ b/src/core/InputMap.h
@@ -26,13 +26,13 @@ namespace IKore {
 
 enum class InputDevice { None, Keyboard, Mouse, Gamepad };
 
-struct InputBinding {
+struct InputMapBinding {
     InputDevice device{InputDevice::None};
     int code{-1};
 
     bool bound() const { return device != InputDevice::None; }
-    bool operator==(const InputBinding& o) const { return device == o.device && code == o.code; }
-    bool operator!=(const InputBinding& o) const { return !(*this == o); }
+    bool operator==(const InputMapBinding& o) const { return device == o.device && code == o.code; }
+    bool operator!=(const InputMapBinding& o) const { return !(*this == o); }
 };
 
 inline const char* deviceName(InputDevice device) {
@@ -53,21 +53,21 @@ inline InputDevice deviceFromName(const std::string& name) {
 }
 
 /// Serialize a binding as "device:code", or "none" when unbound.
-inline std::string toString(const InputBinding& binding) {
+inline std::string toString(const InputMapBinding& binding) {
     if (!binding.bound()) return "none";
     return std::string(deviceName(binding.device)) + ":" + std::to_string(binding.code);
 }
 
 /// Parse a "device:code" binding; returns an unbound binding on anything invalid.
-inline InputBinding bindingFromString(const std::string& text) {
+inline InputMapBinding bindingFromString(const std::string& text) {
     const std::size_t colon = text.find(':');
-    if (colon == std::string::npos) return InputBinding{};
+    if (colon == std::string::npos) return InputMapBinding{};
     const InputDevice device = deviceFromName(text.substr(0, colon));
-    if (device == InputDevice::None) return InputBinding{};
+    if (device == InputDevice::None) return InputMapBinding{};
     try {
-        return InputBinding{device, std::stoi(text.substr(colon + 1))};
+        return InputMapBinding{device, std::stoi(text.substr(colon + 1))};
     } catch (...) {
-        return InputBinding{};
+        return InputMapBinding{};
     }
 }
 
@@ -75,7 +75,7 @@ class InputMap {
 public:
     /// Register an action with a default binding. Duplicate names are ignored.
     /// Registration order is preserved for the panel.
-    void addAction(const std::string& name, InputBinding defaultBinding = {}) {
+    void addAction(const std::string& name, InputMapBinding defaultBinding = {}) {
         if (m_index.count(name) != 0) return;
         m_index.emplace(name, m_actions.size());
         m_actions.push_back(Action{name, defaultBinding, defaultBinding});
@@ -84,25 +84,25 @@ public:
     bool hasAction(const std::string& name) const { return m_index.count(name) != 0; }
     std::size_t actionCount() const { return m_actions.size(); }
     const std::string& actionName(std::size_t i) const { return m_actions[i].name; }
-    InputBinding bindingAt(std::size_t i) const { return m_actions[i].binding; }
+    InputMapBinding bindingAt(std::size_t i) const { return m_actions[i].binding; }
 
     /// Current binding for @p action (unbound if the action is unknown).
-    InputBinding binding(const std::string& action) const {
+    InputMapBinding binding(const std::string& action) const {
         const Action* a = find(action);
-        return a ? a->binding : InputBinding{};
+        return a ? a->binding : InputMapBinding{};
     }
 
     /// Rebind @p action; takes effect immediately. No-op if the action is unknown.
-    void rebind(const std::string& action, InputBinding binding) {
+    void rebind(const std::string& action, InputMapBinding binding) {
         if (Action* a = find(action)) a->binding = binding;
     }
 
     void unbind(const std::string& action) {
-        if (Action* a = find(action)) a->binding = InputBinding{};
+        if (Action* a = find(action)) a->binding = InputMapBinding{};
     }
 
     /// The first action bound to @p binding, or "" (never matches unbound).
-    std::string actionFor(InputBinding binding) const {
+    std::string actionFor(InputMapBinding binding) const {
         if (!binding.bound()) return std::string();
         for (const Action& a : m_actions) {
             if (a.binding == binding) return a.name;
@@ -190,8 +190,8 @@ public:
 private:
     struct Action {
         std::string name;
-        InputBinding binding;
-        InputBinding def;
+        InputMapBinding binding;
+        InputMapBinding def;
     };
 
     Action* find(const std::string& name) {

--- a/src/core/LogSystem.h
+++ b/src/core/LogSystem.h
@@ -26,22 +26,22 @@
  */
 namespace IKore {
 
-enum class LogLevel { Trace, Debug, Info, Warning, Error };
+enum class LogViewerLevel { Trace, Debug, Info, Warning, Error };
 
-inline const char* logLevelName(LogLevel level) {
+inline const char* logLevelName(LogViewerLevel level) {
     switch (level) {
-        case LogLevel::Trace: return "TRACE";
-        case LogLevel::Debug: return "DEBUG";
-        case LogLevel::Info: return "INFO";
-        case LogLevel::Warning: return "WARN";
-        case LogLevel::Error: return "ERROR";
+        case LogViewerLevel::Trace: return "TRACE";
+        case LogViewerLevel::Debug: return "DEBUG";
+        case LogViewerLevel::Info: return "INFO";
+        case LogViewerLevel::Warning: return "WARN";
+        case LogViewerLevel::Error: return "ERROR";
     }
     return "?";
 }
 
 struct LogRecord {
     std::uint64_t index{0};
-    LogLevel level{LogLevel::Info};
+    LogViewerLevel level{LogViewerLevel::Info};
     std::string category;
     std::string message;
 
@@ -68,11 +68,11 @@ public:
     explicit LogSystem(std::size_t capacity = 1000)
         : m_capacity(capacity == 0 ? 1 : capacity) {}
 
-    void setMinLevel(LogLevel level) { m_minLevel = level; }
-    LogLevel minLevel() const { return m_minLevel; }
+    void setMinLevel(LogViewerLevel level) { m_minLevel = level; }
+    LogViewerLevel minLevel() const { return m_minLevel; }
 
     /// Log a message. Dropped on one branch if below the minimum level.
-    void log(LogLevel level, const std::string& category, const std::string& message) {
+    void log(LogViewerLevel level, const std::string& category, const std::string& message) {
         if (static_cast<int>(level) < static_cast<int>(m_minLevel)) return;
 
         LogRecord record{m_nextIndex++, level, category, message};
@@ -83,7 +83,7 @@ public:
 
         if (m_file.is_open()) {
             m_file << record.format() << "\n";
-            if (level == LogLevel::Error) m_file.flush(); // errors persist immediately
+            if (level == LogViewerLevel::Error) m_file.flush(); // errors persist immediately
         }
         for (const Sink& sink : m_sinks) {
             if (sink) sink(record);
@@ -91,19 +91,19 @@ public:
     }
 
     void trace(const std::string& category, const std::string& message) {
-        log(LogLevel::Trace, category, message);
+        log(LogViewerLevel::Trace, category, message);
     }
     void debug(const std::string& category, const std::string& message) {
-        log(LogLevel::Debug, category, message);
+        log(LogViewerLevel::Debug, category, message);
     }
     void info(const std::string& category, const std::string& message) {
-        log(LogLevel::Info, category, message);
+        log(LogViewerLevel::Info, category, message);
     }
     void warning(const std::string& category, const std::string& message) {
-        log(LogLevel::Warning, category, message);
+        log(LogViewerLevel::Warning, category, message);
     }
     void error(const std::string& category, const std::string& message) {
-        log(LogLevel::Error, category, message);
+        log(LogViewerLevel::Error, category, message);
     }
 
     /// Bounded ring of recent records, oldest first (the viewer's tail).
@@ -112,9 +112,9 @@ public:
     std::uint64_t totalLogged() const { return m_nextIndex; }
 
     /// Cumulative count of records at or above @p level (a cheap summary stat).
-    std::size_t countAtLeast(LogLevel level) const {
+    std::size_t countAtLeast(LogViewerLevel level) const {
         std::size_t total = 0;
-        for (int i = static_cast<int>(level); i <= static_cast<int>(LogLevel::Error); ++i) {
+        for (int i = static_cast<int>(level); i <= static_cast<int>(LogViewerLevel::Error); ++i) {
             total += m_levelCounts[i];
         }
         return total;
@@ -126,7 +126,7 @@ public:
     }
 
     /// Snapshot of ring records at or above @p minLevel, optionally one category.
-    std::vector<LogRecord> filter(LogLevel minLevel, const std::string& category = "") const {
+    std::vector<LogRecord> filter(LogViewerLevel minLevel, const std::string& category = "") const {
         std::vector<LogRecord> out;
         for (const LogRecord& r : m_records) {
             if (static_cast<int>(r.level) < static_cast<int>(minLevel)) continue;
@@ -170,7 +170,7 @@ private:
     std::ofstream m_file;
     std::size_t m_capacity;
     std::uint64_t m_nextIndex{0};
-    LogLevel m_minLevel{LogLevel::Trace};
+    LogViewerLevel m_minLevel{LogViewerLevel::Trace};
     std::size_t m_levelCounts[5]{0, 0, 0, 0, 0};
 };
 

--- a/src/ui/DebugUI.cpp
+++ b/src/ui/DebugUI.cpp
@@ -172,25 +172,25 @@ static bool isBindableGamepad(ImGuiKey key) {
 
 // Poll for the next pressed input this frame, to capture a rebind. Mouse buttons
 // and gamepad buttons are checked explicitly; everything else is treated as a key.
-static InputBinding captureInput() {
+static InputMapBinding captureInput() {
     for (int b = 0; b < 5; ++b) {
-        if (ImGui::IsMouseClicked(b)) return InputBinding{InputDevice::Mouse, b};
+        if (ImGui::IsMouseClicked(b)) return InputMapBinding{InputDevice::Mouse, b};
     }
     for (ImGuiKey g : kBindableGamepad) {
-        if (ImGui::IsKeyPressed(g, false)) return InputBinding{InputDevice::Gamepad, static_cast<int>(g)};
+        if (ImGui::IsKeyPressed(g, false)) return InputMapBinding{InputDevice::Gamepad, static_cast<int>(g)};
     }
     for (int k = ImGuiKey_NamedKey_BEGIN; k < ImGuiKey_NamedKey_END; ++k) {
         const ImGuiKey key = static_cast<ImGuiKey>(k);
         if (!ImGui::IsKeyPressed(key, false)) continue;
         if (key >= ImGuiKey_MouseLeft && key <= ImGuiKey_MouseWheelY) continue; // handled above
         if (isBindableGamepad(key)) continue;                                   // handled above
-        return InputBinding{InputDevice::Keyboard, static_cast<int>(key)};
+        return InputMapBinding{InputDevice::Keyboard, static_cast<int>(key)};
     }
-    return InputBinding{};
+    return InputMapBinding{};
 }
 
 // Human-readable label for a binding, for the panel.
-static std::string bindingLabel(const InputBinding& binding) {
+static std::string bindingLabel(const InputMapBinding& binding) {
     if (!binding.bound()) return "(unbound)";
     if (binding.device == InputDevice::Mouse) {
         switch (binding.code) {
@@ -207,7 +207,7 @@ static std::string bindingLabel(const InputBinding& binding) {
 
 // Whether the input a binding refers to is currently held (shows rebinds taking
 // effect immediately).
-static bool bindingActive(const InputBinding& binding) {
+static bool bindingActive(const InputMapBinding& binding) {
     if (!binding.bound()) return false;
     if (binding.device == InputDevice::Mouse) return ImGui::IsMouseDown(binding.code);
     return ImGui::IsKeyDown(static_cast<ImGuiKey>(binding.code));
@@ -783,7 +783,7 @@ void DebugUI::renderInputBindings() {
         if (ImGui::IsKeyPressed(ImGuiKey_Escape, false)) {
             m_rebinding = -1;
         } else {
-            const InputBinding captured = captureInput();
+            const InputMapBinding captured = captureInput();
             if (captured.bound()) {
                 m_inputMap.rebind(m_inputMap.actionName(static_cast<std::size_t>(m_rebinding)), captured);
                 m_rebinding = -1;
@@ -793,7 +793,7 @@ void DebugUI::renderInputBindings() {
 
     for (int i = 0; i < static_cast<int>(m_inputMap.actionCount()); ++i) {
         const std::string& name = m_inputMap.actionName(static_cast<std::size_t>(i));
-        const InputBinding binding = m_inputMap.bindingAt(static_cast<std::size_t>(i));
+        const InputMapBinding binding = m_inputMap.bindingAt(static_cast<std::size_t>(i));
         const bool conflict = m_inputMap.hasConflict(name);
 
         ImGui::PushID(i);
@@ -931,13 +931,13 @@ void DebugUI::renderBenchmark() {
     ImGui::End();
 }
 
-static ImVec4 colorForLogLevel(LogLevel level) {
+static ImVec4 colorForLogLevel(LogViewerLevel level) {
     switch (level) {
-        case LogLevel::Trace: return ImVec4(0.55f, 0.55f, 0.55f, 1.0f);
-        case LogLevel::Debug: return ImVec4(0.65f, 0.75f, 0.95f, 1.0f);
-        case LogLevel::Info: return ImVec4(0.85f, 0.85f, 0.85f, 1.0f);
-        case LogLevel::Warning: return ImVec4(0.95f, 0.80f, 0.35f, 1.0f);
-        case LogLevel::Error: return ImVec4(0.95f, 0.40f, 0.40f, 1.0f);
+        case LogViewerLevel::Trace: return ImVec4(0.55f, 0.55f, 0.55f, 1.0f);
+        case LogViewerLevel::Debug: return ImVec4(0.65f, 0.75f, 0.95f, 1.0f);
+        case LogViewerLevel::Info: return ImVec4(0.85f, 0.85f, 0.85f, 1.0f);
+        case LogViewerLevel::Warning: return ImVec4(0.95f, 0.80f, 0.35f, 1.0f);
+        case LogViewerLevel::Error: return ImVec4(0.95f, 0.40f, 0.40f, 1.0f);
     }
     return ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
 }
@@ -974,10 +974,10 @@ void DebugUI::renderLog() {
 
     ImGui::Text("Total: %llu    Warnings+: %zu    Errors: %zu",
                 static_cast<unsigned long long>(m_log.totalLogged()),
-                m_log.countAtLeast(LogLevel::Warning), m_log.countAtLeast(LogLevel::Error));
+                m_log.countAtLeast(LogViewerLevel::Warning), m_log.countAtLeast(LogViewerLevel::Error));
     ImGui::Separator();
 
-    const LogLevel minLevel = static_cast<LogLevel>(m_logFilterLevel);
+    const LogViewerLevel minLevel = static_cast<LogViewerLevel>(m_logFilterLevel);
     const std::string catFilter =
         m_logCategoryIndex > 0 ? cats[static_cast<std::size_t>(m_logCategoryIndex - 1)] : std::string();
 

--- a/src/ui/DebugUI.h
+++ b/src/ui/DebugUI.h
@@ -186,7 +186,7 @@ private:
     // Logging + in-engine viewer (#63): structured logs feed the console (#54) and a
     // file sink; the viewer filters by level/category and tails in real time.
     LogSystem m_log;
-    int m_logFilterLevel{0};   // index into LogLevel for the viewer's min level
+    int m_logFilterLevel{0};   // index into LogViewerLevel for the viewer's min level
     int m_logCategoryIndex{0}; // 0 = all categories
     bool m_logAutoScroll{true};
     float m_logClock{0.0f};    // paces the demo heartbeat log

--- a/tests/test_input_map.cpp
+++ b/tests/test_input_map.cpp
@@ -49,11 +49,11 @@ static void testRegisterAndRebind() {
     CHECK(!map.hasAction("Nope"));
     CHECK(map.actionName(0) == "MoveForward"); // registration order preserved
 
-    CHECK(map.binding("MoveForward") == (InputBinding{InputDevice::Keyboard, KEY_W}));
+    CHECK(map.binding("MoveForward") == (InputMapBinding{InputDevice::Keyboard, KEY_W}));
 
     // Rebinding takes effect immediately.
     map.rebind("MoveForward", {InputDevice::Keyboard, KEY_S});
-    CHECK(map.binding("MoveForward") == (InputBinding{InputDevice::Keyboard, KEY_S}));
+    CHECK(map.binding("MoveForward") == (InputMapBinding{InputDevice::Keyboard, KEY_S}));
 
     // Unbind clears it; unbound never matches a reverse lookup.
     map.unbind("Fire");
@@ -63,7 +63,7 @@ static void testRegisterAndRebind() {
     // Duplicate registration is ignored.
     map.addAction("Jump", {InputDevice::Keyboard, 999});
     CHECK(map.actionCount() == 3);
-    CHECK(map.binding("Jump") == (InputBinding{InputDevice::Keyboard, KEY_SPACE}));
+    CHECK(map.binding("Jump") == (InputMapBinding{InputDevice::Keyboard, KEY_SPACE}));
 }
 
 static void testReverseLookup() {
@@ -104,16 +104,16 @@ static void testResetToDefaults() {
     InputMap map;
     map.addAction("Jump", {InputDevice::Keyboard, KEY_SPACE});
     map.rebind("Jump", {InputDevice::Gamepad, 0});
-    CHECK(map.binding("Jump") == (InputBinding{InputDevice::Gamepad, 0}));
+    CHECK(map.binding("Jump") == (InputMapBinding{InputDevice::Gamepad, 0}));
     map.resetToDefaults();
-    CHECK(map.binding("Jump") == (InputBinding{InputDevice::Keyboard, KEY_SPACE}));
+    CHECK(map.binding("Jump") == (InputMapBinding{InputDevice::Keyboard, KEY_SPACE}));
 }
 
 static void testBindingStringRoundTrip() {
-    const InputBinding key{InputDevice::Keyboard, 65};
-    const InputBinding mouse{InputDevice::Mouse, 2};
-    const InputBinding pad{InputDevice::Gamepad, 7};
-    const InputBinding none{};
+    const InputMapBinding key{InputDevice::Keyboard, 65};
+    const InputMapBinding mouse{InputDevice::Mouse, 2};
+    const InputMapBinding pad{InputDevice::Gamepad, 7};
+    const InputMapBinding none{};
 
     CHECK(bindingFromString(toString(key)) == key);
     CHECK(bindingFromString(toString(mouse)) == mouse);
@@ -138,15 +138,15 @@ static void testSerializeRoundTrip() {
     b.addAction("Fire");
     b.addAction("Menu");
     b.load(text);
-    CHECK(b.binding("MoveForward") == (InputBinding{InputDevice::Keyboard, KEY_W}));
-    CHECK(b.binding("Fire") == (InputBinding{InputDevice::Mouse, 1}));
-    CHECK(b.binding("Menu") == (InputBinding{InputDevice::Gamepad, 4}));
+    CHECK(b.binding("MoveForward") == (InputMapBinding{InputDevice::Keyboard, KEY_W}));
+    CHECK(b.binding("Fire") == (InputMapBinding{InputDevice::Mouse, 1}));
+    CHECK(b.binding("Menu") == (InputMapBinding{InputDevice::Gamepad, 4}));
 
     // Unknown actions in the text are ignored.
     InputMap c;
     c.addAction("MoveForward");
     c.load("MoveForward=keyboard:5\nUnknownAction=mouse:3\n");
-    CHECK(c.binding("MoveForward") == (InputBinding{InputDevice::Keyboard, 5}));
+    CHECK(c.binding("MoveForward") == (InputMapBinding{InputDevice::Keyboard, 5}));
     CHECK(!c.hasAction("UnknownAction"));
 }
 
@@ -164,8 +164,8 @@ static void testPersistAcrossSessions() {
     second.addAction("Jump", {InputDevice::Keyboard, KEY_SPACE});
     second.addAction("Fire", {InputDevice::Mouse, 0});
     CHECK(second.loadFromFile(path));
-    CHECK(second.binding("Jump") == (InputBinding{InputDevice::Gamepad, 1}));
-    CHECK(second.binding("Fire") == (InputBinding{InputDevice::Mouse, 0}));
+    CHECK(second.binding("Jump") == (InputMapBinding{InputDevice::Gamepad, 1}));
+    CHECK(second.binding("Fire") == (InputMapBinding{InputDevice::Mouse, 0}));
 
     CHECK(!second.loadFromFile("no_such_input_file_54321.ini"));
 

--- a/tests/test_log_system.cpp
+++ b/tests/test_log_system.cpp
@@ -44,7 +44,7 @@ static void testLevelsCategoriesAndFormat() {
 
     CHECK(log.records().size() == 3);
     CHECK(log.totalLogged() == 3);
-    CHECK(log.records()[0].level == LogLevel::Info);
+    CHECK(log.records()[0].level == LogViewerLevel::Info);
     CHECK(log.records()[0].category == "engine");
     CHECK(log.records()[0].message == "started");
     CHECK(log.records()[0].index == 0);
@@ -54,13 +54,13 @@ static void testLevelsCategoriesAndFormat() {
     CHECK(log.records()[1].format() == "[WARN] [render] shader cache miss");
 
     // Level names.
-    CHECK(std::string(logLevelName(LogLevel::Error)) == "ERROR");
-    CHECK(std::string(logLevelName(LogLevel::Trace)) == "TRACE");
+    CHECK(std::string(logLevelName(LogViewerLevel::Error)) == "ERROR");
+    CHECK(std::string(logLevelName(LogViewerLevel::Trace)) == "TRACE");
 }
 
 static void testMinLevelThreshold() {
     LogSystem log;
-    log.setMinLevel(LogLevel::Warning);
+    log.setMinLevel(LogViewerLevel::Warning);
     log.trace("x", "t");
     log.debug("x", "d");
     log.info("x", "i");     // all three below Warning -> dropped
@@ -69,8 +69,8 @@ static void testMinLevelThreshold() {
 
     CHECK(log.records().size() == 2);
     CHECK(log.totalLogged() == 2); // dropped messages are not counted
-    CHECK(log.records()[0].level == LogLevel::Warning);
-    CHECK(log.records()[1].level == LogLevel::Error);
+    CHECK(log.records()[0].level == LogViewerLevel::Warning);
+    CHECK(log.records()[1].level == LogViewerLevel::Error);
 }
 
 static void testRingCapacityVsTotal() {
@@ -98,9 +98,9 @@ static void testCountsAndCategories() {
     log.warning("a", "3");
     log.error("c", "4");
 
-    CHECK(log.countAtLeast(LogLevel::Warning) == 2); // warning + error
-    CHECK(log.countAtLeast(LogLevel::Error) == 1);
-    CHECK(log.countAtLeast(LogLevel::Trace) == 4);   // everything
+    CHECK(log.countAtLeast(LogViewerLevel::Warning) == 2); // warning + error
+    CHECK(log.countAtLeast(LogViewerLevel::Error) == 1);
+    CHECK(log.countAtLeast(LogViewerLevel::Trace) == 4);   // everything
 
     const std::vector<std::string> cats = log.categories();
     CHECK(cats.size() == 3);
@@ -115,13 +115,13 @@ static void testFilter() {
     log.error("render", "e1");
 
     // By level only.
-    CHECK(log.filter(LogLevel::Warning).size() == 3);
+    CHECK(log.filter(LogViewerLevel::Warning).size() == 3);
     // By level and category.
-    const std::vector<LogRecord> renderWarnPlus = log.filter(LogLevel::Warning, "render");
+    const std::vector<LogRecord> renderWarnPlus = log.filter(LogViewerLevel::Warning, "render");
     CHECK(renderWarnPlus.size() == 2);
     CHECK(renderWarnPlus[0].message == "w1" && renderWarnPlus[1].message == "e1");
     // Category with a low threshold picks up everything in that category.
-    CHECK(log.filter(LogLevel::Trace, "render").size() == 3);
+    CHECK(log.filter(LogViewerLevel::Trace, "render").size() == 3);
 }
 
 static void testSinksFeedConsole() {
@@ -130,7 +130,7 @@ static void testSinksFeedConsole() {
     log.addSink([&consoleLines](const LogRecord& r) { consoleLines.push_back(r.format()); });
 
     log.info("engine", "hello");
-    log.setMinLevel(LogLevel::Warning);
+    log.setMinLevel(LogViewerLevel::Warning);
     log.info("engine", "dropped"); // below threshold: sink must NOT fire
     log.error("engine", "boom");
 


### PR DESCRIPTION
## Summary

The `IKore` engine target did not build on `main` due to three pre-existing, independent issues. This fixes all three so the engine (and the full test suite) compiles and links.

## Changes

- **Duplicate `IKore::InputBinding`**: both `InputComponent.h` and `core/InputMap.h` defined a namespace-scope `struct InputBinding`, so any translation unit that included both (e.g. `main.cpp`, `DebugUI.cpp`) failed with `redefinition of 'struct IKore::InputBinding'`. Renamed the self-contained #60 input-map struct to `InputMapBinding` (in `InputMap.h` and its consumers `DebugUI.cpp` and `tests/test_input_map.cpp`).
- **Duplicate `IKore::LogLevel`**: both `Logger.h` and `core/LogSystem.h` defined an `enum class LogLevel` with different enumerators (`DEBUG/INFO/...` vs `Trace/Debug/...`), colliding in the same translation units. Renamed the #60 log-viewer's enum to `LogViewerLevel` (in `LogSystem.h` and its consumers `DebugUI` and `tests/test_log_system.cpp`).
- **Undefined reference to `CascadedShadowMap::kMaxCascades`**: the `static const int` was ODR-used by `std::clamp` (a by-reference parameter) but never defined out-of-line, giving a link error. Made it `static constexpr`, which is implicitly inline in C++17.

These are pure renames plus one storage-class change - no behavior change.

## Verification

- The `IKore` engine target compiles and links (previously it failed at compile on the collisions and at link on `kMaxCascades`).
- A full build of every target succeeds, except the pre-existing `test_scripting` (an unrelated ambiguous-`Entity` compile error in `ScriptSystem.cpp` that is already quarantined from the CI gates in #294).
- The headless and GL/audio test suites both build.
