### PR TITLE
Scripting: qualify ecs::Entity in ScriptSystem, un-quarantine test_scripting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1047,11 +1047,7 @@ set(GL_TESTS
     test_physics_component
     test_physics_simple
     test_scene_graph
-    # Quarantined (issue #294): test_scripting does not build. src/scripting/ScriptSystem.cpp
-    # fails to compile with an ambiguous 'Entity' reference (the legacy IKore::Entity vs the
-    # archetype IKore::ecs::Entity), a pre-existing scripting/ECS namespace collision that is
-    # out of scope for this CI-gating change. Re-enable once ScriptSystem.cpp is fixed.
-    # test_scripting
+    test_scripting
 )
 
 set(_present_gl_tests "")

--- a/src/scripting/ScriptSystem.cpp
+++ b/src/scripting/ScriptSystem.cpp
@@ -69,31 +69,31 @@ void ScriptSystem::registerBindings() {
         "angular", &Velocity::angular);
 
     // Entity is an opaque handle (index + generation), read-only from Lua.
-    lua.new_usertype<Entity>("Entity",
-        "index", sol::readonly(&Entity::index),
-        "generation", sol::readonly(&Entity::generation));
+    lua.new_usertype<ecs::Entity>("Entity",
+        "index", sol::readonly(&ecs::Entity::index),
+        "generation", sol::readonly(&ecs::Entity::generation));
 
     // --- world: entity + component API ------------------------------------
     sol::table world = lua["world"].get_or_create<sol::table>();
     world.set_function("create", [this]() { return m_registry.create(); });
-    world.set_function("destroy", [this](Entity e) { m_registry.destroy(e); });
-    world.set_function("valid", [this](Entity e) { return m_registry.isValid(e); });
+    world.set_function("destroy", [this](ecs::Entity e) { m_registry.destroy(e); });
+    world.set_function("valid", [this](ecs::Entity e) { return m_registry.isValid(e); });
 
-    world.set_function("add_transform", [this](Entity e, sol::optional<Transform> t) {
+    world.set_function("add_transform", [this](ecs::Entity e, sol::optional<Transform> t) {
         m_registry.add<Transform>(e, t.value_or(Transform{}));
     });
-    world.set_function("has_transform", [this](Entity e) { return m_registry.has<Transform>(e); });
-    world.set_function("get_transform", [this](Entity e) { return m_registry.get<Transform>(e); });
-    world.set_function("set_transform", [this](Entity e, Transform t) {
+    world.set_function("has_transform", [this](ecs::Entity e) { return m_registry.has<Transform>(e); });
+    world.set_function("get_transform", [this](ecs::Entity e) { return m_registry.get<Transform>(e); });
+    world.set_function("set_transform", [this](ecs::Entity e, Transform t) {
         if (m_registry.has<Transform>(e)) m_registry.get<Transform>(e) = t;
     });
 
-    world.set_function("add_velocity", [this](Entity e, sol::optional<Velocity> v) {
+    world.set_function("add_velocity", [this](ecs::Entity e, sol::optional<Velocity> v) {
         m_registry.add<Velocity>(e, v.value_or(Velocity{}));
     });
-    world.set_function("has_velocity", [this](Entity e) { return m_registry.has<Velocity>(e); });
-    world.set_function("get_velocity", [this](Entity e) { return m_registry.get<Velocity>(e); });
-    world.set_function("set_velocity", [this](Entity e, Velocity v) {
+    world.set_function("has_velocity", [this](ecs::Entity e) { return m_registry.has<Velocity>(e); });
+    world.set_function("get_velocity", [this](ecs::Entity e) { return m_registry.get<Velocity>(e); });
+    world.set_function("set_velocity", [this](ecs::Entity e, Velocity v) {
         if (m_registry.has<Velocity>(e)) m_registry.get<Velocity>(e) = v;
     });
 


### PR DESCRIPTION
Follow-up to #294 / #307.

`test_scripting` was quarantined from the GL/audio gate (#294) because `src/scripting/ScriptSystem.cpp` did not compile: inside `namespace IKore` with `using namespace IKore::ecs;`, an unqualified `Entity` is ambiguous between the legacy `IKore::Entity` and the archetype `IKore::ecs::Entity` whenever the legacy header is also visible in the translation unit (as it is in the test build).

## Changes

- **`src/scripting/ScriptSystem.cpp`**: ScriptSystem binds the data-oriented ECS registry, so every `Entity` there is the archetype entity. Qualified those references as `ecs::Entity` (the Lua usertype name string `"Entity"` and comments are unchanged). This resolves the ambiguity regardless of what else the translation unit includes.
- **`CMakeLists.txt`**: re-enabled `test_scripting` in the `GL_TESTS` list (removed the quarantine).

## Verification

- `test_scripting` compiles, passes standalone (`All scripting tests passed.`), and passes as part of the `gl` suite under `xvfb-run` + llvmpipe + null audio (`100% tests passed, 0 tests failed out of 16`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_