### PR TITLE
Tests: give test_particle_component a headless GL context, un-quarantine it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1038,12 +1038,7 @@ set(GL_TESTS
     test_mesh_component_minimal
     test_network_component
     test_openal_3d_audio
-    # Quarantined (issue #294): test_particle_component segfaults headlessly. Adding a
-    # ParticleComponent runs ParticleSystem::initializeBuffers, which calls live GL
-    # functions (glGenBuffers, ...) on attach; the test never creates a GL context, so
-    # those glad function pointers are null and it crashes. Re-enable once the test creates
-    # a GL context (a hidden GLFW window + gladLoad) before attaching the component.
-    # test_particle_component
+    test_particle_component
     test_physics_component
     test_physics_simple
     test_scene_graph
@@ -1064,4 +1059,10 @@ endforeach()
 # Aggregate target so CI can build just the GL/audio tests before running `ctest -L gl`.
 if(_present_gl_tests)
     add_custom_target(gl_tests DEPENDS ${_present_gl_tests})
+endif()
+
+# test_particle_component initializes the real particle system, which loads its shaders from
+# src/shaders/ by relative path, so it must run from the repository root (issue #294).
+if(TARGET test_particle_component)
+    set_tests_properties(test_particle_component PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/tests/test_particle_component.cpp
+++ b/tests/test_particle_component.cpp
@@ -3,6 +3,9 @@
 #include <chrono>
 #include <thread>
 
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
 #include "src/core/Entity.h"
 #include "src/core/components/ParticleComponent.h"
 #include "src/core/components/TransformComponent.h"
@@ -11,7 +14,33 @@ using namespace IKore;
 
 int main() {
     std::cout << "==== Particle Component Test ====" << std::endl;
-    
+
+    // Attaching a ParticleComponent issues live GL calls (ParticleSystem::initializeBuffers
+    // creates the VBO/VAO), so the test needs a current GL context. Create a hidden offscreen
+    // window; in CI this runs on Xvfb + a software GL. If no context can be created (e.g. no
+    // display at all), skip rather than fail so the job stays reliable.
+    if (!glfwInit()) {
+        std::cout << "GLFW init failed (no display?); skipping particle GL test" << std::endl;
+        return 0;
+    }
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+    GLFWwindow* glContext = glfwCreateWindow(64, 64, "particle-test", nullptr, nullptr);
+    if (!glContext) {
+        std::cout << "GL context creation failed (no display?); skipping particle GL test" << std::endl;
+        glfwTerminate();
+        return 0;
+    }
+    glfwMakeContextCurrent(glContext);
+    if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+        std::cout << "Failed to load GL functions; skipping particle GL test" << std::endl;
+        glfwDestroyWindow(glContext);
+        glfwTerminate();
+        return 0;
+    }
+
     // Create an entity
     auto entity = std::make_shared<Entity>();
     
@@ -88,5 +117,13 @@ int main() {
     std::cout << "Removed particle component" << std::endl;
     
     std::cout << "Particle Component test completed successfully" << std::endl;
+
+    // Release everything that owns GL resources (ParticleSystem frees its VBO/VAO in its
+    // destructor) while the context is still current, then tear the context down. Doing this
+    // in the wrong order frees GL objects with no current context and crashes.
+    particleComponent.reset();
+    entity.reset();
+    glfwDestroyWindow(glContext);
+    glfwTerminate();
     return 0;
 }


### PR DESCRIPTION
Follow-up to #294.

`test_particle_component` was quarantined from the GL/audio gate because it segfaulted headlessly: attaching a `ParticleComponent` runs `ParticleSystem::initializeBuffers`, which issues live GL calls (`glGenBuffers`, ...), but the test never created a GL context, so the glad function pointers were null.

## Changes

- **Create a hidden offscreen GL context** at the start of the test (GLFW hidden window + `gladLoad`, mirroring the engine's init); under CI this runs on Xvfb + a software GL. If no context can be created (no display), the test skips rather than fails, keeping the job reliable.
- **Tear the context down only after releasing** the entity and particle component, so `ParticleSystem` frees its VBO/VAO while the context is still current (freeing GL objects after `glfwTerminate` was a second crash the backtrace revealed).
- **Run the test from the repo root** via `WORKING_DIRECTORY`, since the particle system loads its shaders from `src/shaders/` by relative path.
- **Re-enable** `test_particle_component` in the `GL_TESTS` list.

## Verification

Under `xvfb-run` + llvmpipe + null audio: `test_particle_component` passes, and the full `gl` suite is green (`100% tests passed, 0 tests failed out of 17`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_