### PR TITLE
Animation: load skeletal clips from models so the skinned path deforms (#287)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,8 +284,8 @@ add_executable(scene_graph_demo
 )
 
 # MeshComponent Test executable
-add_executable(test_mesh_component 
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/test_mesh_component.cpp 
+add_executable(test_mesh_component
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tests/test_mesh_component.cpp
     ${CORE_SOURCES}
     ${AUDIO_SOURCES}
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Model.cpp
@@ -293,6 +293,20 @@ add_executable(test_mesh_component
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Texture.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Frustum.cpp
 )
+
+# Skinned skeletal-animation loading test (issue #287): loads the animated glTF and checks
+# the bone palette actually animates. Needs a GL context (Model creates VBOs), so it is a
+# gl-labelled test run under Xvfb.
+add_executable(test_skinned_animation
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_skinned_animation.cpp
+    ${CORE_SOURCES}
+    ${AUDIO_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/Model.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/Shader.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/Texture.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/Frustum.cpp
+)
+target_link_libraries(test_skinned_animation PRIVATE glfw glad glm stb_image assimp OpenGL::GL BulletDynamics BulletCollision LinearMath ${OPENAL_LIBRARIES})
 
 # MeshComponent Minimal Test executable  
 add_executable(test_mesh_component_minimal 
@@ -1043,6 +1057,7 @@ set(GL_TESTS
     test_physics_simple
     test_scene_graph
     test_scripting
+    test_skinned_animation
 )
 
 set(_present_gl_tests "")
@@ -1065,4 +1080,9 @@ endif()
 # src/shaders/ by relative path, so it must run from the repository root (issue #294).
 if(TARGET test_particle_component)
     set_tests_properties(test_particle_component PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+# test_skinned_animation loads assets/models/animated_bone.gltf by relative path (issue #287).
+if(TARGET test_skinned_animation)
+    set_tests_properties(test_skinned_animation PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/assets/models/animated_bone.gltf
+++ b/assets/models/animated_bone.gltf
@@ -1,0 +1,196 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "IKore gen_animated_gltf.py (#287)"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0,
+        1
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "SkinnedQuad",
+      "mesh": 0,
+      "skin": 0
+    },
+    {
+      "name": "Bone0",
+      "translation": [
+        0.0,
+        0.0,
+        0.0
+      ]
+    }
+  ],
+  "meshes": [
+    {
+      "name": "QuadMesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1,
+            "JOINTS_0": 2,
+            "WEIGHTS_0": 3
+          },
+          "indices": 4,
+          "mode": 4
+        }
+      ]
+    }
+  ],
+  "skins": [
+    {
+      "joints": [
+        1
+      ],
+      "inverseBindMatrices": 5,
+      "skeleton": 1
+    }
+  ],
+  "animations": [
+    {
+      "name": "Rotate",
+      "channels": [
+        {
+          "sampler": 0,
+          "target": {
+            "node": 1,
+            "path": "rotation"
+          }
+        }
+      ],
+      "samplers": [
+        {
+          "input": 6,
+          "output": 7,
+          "interpolation": "LINEAR"
+        }
+      ]
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 312,
+      "uri": "data:application/octet-stream;base64,AAAAvwAAAAAAAAAAAAAAPwAAAAAAAAAAAAAAPwAAgD8AAAAAAAAAvwAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAAEAAgAAAAIAAwAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAD8AAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAFe/DPl6DbD8AAAAAAAAAAPMENT/zBDU/"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 48,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 48,
+      "byteLength": 48,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 96,
+      "byteLength": 16,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 112,
+      "byteLength": 64,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 176,
+      "byteLength": 12,
+      "target": 34963
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 188,
+      "byteLength": 64
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 252,
+      "byteLength": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 264,
+      "byteLength": 48
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 4,
+      "type": "VEC3",
+      "min": [
+        -0.5,
+        0.0,
+        0.0
+      ],
+      "max": [
+        0.5,
+        1.0,
+        0.0
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 4,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5121,
+      "count": 4,
+      "type": "VEC4"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5126,
+      "count": 4,
+      "type": "VEC4"
+    },
+    {
+      "bufferView": 4,
+      "componentType": 5123,
+      "count": 6,
+      "type": "SCALAR"
+    },
+    {
+      "bufferView": 5,
+      "componentType": 5126,
+      "count": 1,
+      "type": "MAT4"
+    },
+    {
+      "bufferView": 6,
+      "componentType": 5126,
+      "count": 3,
+      "type": "SCALAR",
+      "min": [
+        0.0
+      ],
+      "max": [
+        1.0
+      ]
+    },
+    {
+      "bufferView": 7,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC4"
+    }
+  ]
+}

--- a/scripts/gen_animated_gltf.py
+++ b/scripts/gen_animated_gltf.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Generate a minimal rigged + animated glTF 2.0 asset (issue #287 follow-up).
+
+The engine had no animated model to exercise the runtime skinned path, so this emits the
+smallest self-contained one: a single-bone quad whose joint rotates about Z from 0 to 90
+degrees over one second. The buffer is embedded as a base64 data URI so the .gltf is a
+single committable file with no external .bin.
+
+Run: python3 scripts/gen_animated_gltf.py > assets/models/animated_bone.gltf
+"""
+import base64
+import json
+import math
+import struct
+import sys
+
+# --- geometry: a quad in the XY plane, every vertex skinned 100% to joint 0 ---------
+positions = [(-0.5, 0.0, 0.0), (0.5, 0.0, 0.0), (0.5, 1.0, 0.0), (-0.5, 1.0, 0.0)]
+normals = [(0.0, 0.0, 1.0)] * 4
+joints = [(0, 0, 0, 0)] * 4              # VEC4 unsigned byte
+weights = [(1.0, 0.0, 0.0, 0.0)] * 4     # VEC4 float
+indices = [0, 1, 2, 0, 2, 3]             # unsigned short
+
+# Inverse bind matrix for joint 0 = identity (its bind pose sits at the origin).
+ibm = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]  # column-major
+
+# Animation: rotate joint 0 about +Z, 0 -> 45 -> 90 degrees at t = 0, 0.5, 1.0 s.
+times = [0.0, 0.5, 1.0]
+
+
+def quat_z(deg):
+    r = math.radians(deg) / 2.0
+    return (0.0, 0.0, math.sin(r), math.cos(r))  # x, y, z, w
+
+
+rotations = [quat_z(0.0), quat_z(45.0), quat_z(90.0)]
+
+# --- pack a single binary buffer, 4-byte aligned per view ---------------------------
+buf = bytearray()
+
+
+def align4():
+    while len(buf) % 4:
+        buf.append(0)
+
+
+def put(fmt, flat):
+    align4()
+    off = len(buf)
+    buf.extend(struct.pack("<" + fmt, *flat))
+    return off, len(buf) - off
+
+
+pos_off, pos_len = put("%df" % (len(positions) * 3), [c for v in positions for c in v])
+nrm_off, nrm_len = put("%df" % (len(normals) * 3), [c for v in normals for c in v])
+jnt_off, jnt_len = put("%dB" % (len(joints) * 4), [c for v in joints for c in v])
+wgt_off, wgt_len = put("%df" % (len(weights) * 4), [c for v in weights for c in v])
+idx_off, idx_len = put("%dH" % len(indices), indices)
+ibm_off, ibm_len = put("16f", ibm)
+tin_off, tin_len = put("%df" % len(times), times)
+tout_off, tout_len = put("%df" % (len(rotations) * 4), [c for q in rotations for c in q])
+
+data_uri = "data:application/octet-stream;base64," + base64.b64encode(bytes(buf)).decode("ascii")
+
+pmin = [min(v[i] for v in positions) for i in range(3)]
+pmax = [max(v[i] for v in positions) for i in range(3)]
+
+gltf = {
+    "asset": {"version": "2.0", "generator": "IKore gen_animated_gltf.py (#287)"},
+    "scene": 0,
+    "scenes": [{"nodes": [0, 1]}],
+    "nodes": [
+        {"name": "SkinnedQuad", "mesh": 0, "skin": 0},
+        {"name": "Bone0", "translation": [0.0, 0.0, 0.0]},
+    ],
+    "meshes": [{
+        "name": "QuadMesh",
+        "primitives": [{
+            "attributes": {"POSITION": 0, "NORMAL": 1, "JOINTS_0": 2, "WEIGHTS_0": 3},
+            "indices": 4,
+            "mode": 4,
+        }],
+    }],
+    "skins": [{"joints": [1], "inverseBindMatrices": 5, "skeleton": 1}],
+    "animations": [{
+        "name": "Rotate",
+        "channels": [{"sampler": 0, "target": {"node": 1, "path": "rotation"}}],
+        "samplers": [{"input": 6, "output": 7, "interpolation": "LINEAR"}],
+    }],
+    "buffers": [{"byteLength": len(buf), "uri": data_uri}],
+    "bufferViews": [
+        {"buffer": 0, "byteOffset": pos_off, "byteLength": pos_len, "target": 34962},
+        {"buffer": 0, "byteOffset": nrm_off, "byteLength": nrm_len, "target": 34962},
+        {"buffer": 0, "byteOffset": jnt_off, "byteLength": jnt_len, "target": 34962},
+        {"buffer": 0, "byteOffset": wgt_off, "byteLength": wgt_len, "target": 34962},
+        {"buffer": 0, "byteOffset": idx_off, "byteLength": idx_len, "target": 34963},
+        {"buffer": 0, "byteOffset": ibm_off, "byteLength": ibm_len},
+        {"buffer": 0, "byteOffset": tin_off, "byteLength": tin_len},
+        {"buffer": 0, "byteOffset": tout_off, "byteLength": tout_len},
+    ],
+    "accessors": [
+        {"bufferView": 0, "componentType": 5126, "count": 4, "type": "VEC3", "min": pmin, "max": pmax},
+        {"bufferView": 1, "componentType": 5126, "count": 4, "type": "VEC3"},
+        {"bufferView": 2, "componentType": 5121, "count": 4, "type": "VEC4"},
+        {"bufferView": 3, "componentType": 5126, "count": 4, "type": "VEC4"},
+        {"bufferView": 4, "componentType": 5123, "count": 6, "type": "SCALAR"},
+        {"bufferView": 5, "componentType": 5126, "count": 1, "type": "MAT4"},
+        {"bufferView": 6, "componentType": 5126, "count": 3, "type": "SCALAR",
+         "min": [times[0]], "max": [times[-1]]},
+        {"bufferView": 7, "componentType": 5126, "count": 3, "type": "VEC4"},
+    ],
+}
+
+sys.stdout.write(json.dumps(gltf, indent=2))
+sys.stdout.write("\n")

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -1,7 +1,8 @@
 #include "Model.h"
 #include "Shader.h"
 #include "core/Logger.h"
-#include <glm/gtc/type_ptr.hpp> // glm::value_ptr for renderSelectable (issue #269)
+#include <glm/gtc/type_ptr.hpp>    // glm::value_ptr for renderSelectable (issue #269)
+#include <glm/gtc/quaternion.hpp>  // glm::quat for animation keyframes (issue #287)
 
 #include <iostream>
 #include <filesystem>
@@ -333,8 +334,57 @@ void Model::loadModel(const std::string& path) {
     if (m_hasAnimations) {
         LOG_INFO("Model has " + std::to_string(scene->mNumAnimations) + " animations");
     }
-    
+
     processNode(scene->mRootNode, scene);
+
+    // Extract the animation clips after the meshes, so m_boneInfoMap (bone ids + offsets,
+    // filled by processMesh) is available to key each animated bone (issue #287).
+    if (m_hasAnimations) {
+        extractAnimations(scene);
+    }
+}
+
+void Model::extractAnimations(const aiScene* scene) {
+    m_animations.clear();
+    for (unsigned int a = 0; a < scene->mNumAnimations; ++a) {
+        const aiAnimation* aiAnim = scene->mAnimations[a];
+        // Assimp reports keyframe times in ticks; convert to seconds so the runtime can
+        // advance the animation by a per-frame dt in seconds.
+        const double tps = aiAnim->mTicksPerSecond != 0.0 ? aiAnim->mTicksPerSecond : 25.0;
+
+        Animation anim;
+        anim.name = aiAnim->mName.length > 0 ? std::string(aiAnim->mName.C_Str())
+                                             : ("animation_" + std::to_string(a));
+        anim.ticksPerSecond = 1.0f; // timestamps below are already in seconds
+        anim.duration = static_cast<float>(aiAnim->mDuration / tps);
+
+        for (unsigned int c = 0; c < aiAnim->mNumChannels; ++c) {
+            const aiNodeAnim* ch = aiAnim->mChannels[c];
+            Bone bone;
+            bone.name = ch->mNodeName.C_Str();
+            auto it = m_boneInfoMap.find(bone.name);
+            bone.id = (it != m_boneInfoMap.end()) ? it->second.id : -1;
+
+            for (unsigned int k = 0; k < ch->mNumPositionKeys; ++k) {
+                const aiVectorKey& key = ch->mPositionKeys[k];
+                bone.positions.push_back({glm::vec3(key.mValue.x, key.mValue.y, key.mValue.z),
+                                          static_cast<float>(key.mTime / tps)});
+            }
+            for (unsigned int k = 0; k < ch->mNumRotationKeys; ++k) {
+                const aiQuatKey& key = ch->mRotationKeys[k];
+                bone.rotations.push_back({glm::quat(key.mValue.w, key.mValue.x, key.mValue.y, key.mValue.z),
+                                          static_cast<float>(key.mTime / tps)});
+            }
+            for (unsigned int k = 0; k < ch->mNumScalingKeys; ++k) {
+                const aiVectorKey& key = ch->mScalingKeys[k];
+                bone.scales.push_back({glm::vec3(key.mValue.x, key.mValue.y, key.mValue.z),
+                                       static_cast<float>(key.mTime / tps)});
+            }
+            anim.bones.push_back(std::move(bone));
+        }
+        anim.boneInfoMap = m_boneInfoMap;
+        m_animations.push_back(std::move(anim));
+    }
 }
 
 void Model::processNode(aiNode* node, const aiScene* scene) {

--- a/src/Model.h
+++ b/src/Model.h
@@ -130,7 +130,8 @@ private:
     std::map<std::string, BoneInfo> m_boneInfoMap;
     int m_boneCounter = 0;
     bool m_hasAnimations = false;
-    
+    std::vector<Animation> m_animations; // animation clips (issue #287)
+
     // Assimp processing
     void loadModel(const std::string& path);
     void processNode(aiNode* node, const aiScene* scene);
@@ -142,6 +143,9 @@ private:
     // Animation processing
     void extractBoneWeightForVertices(std::vector<AnimatedVertex>& vertices, aiMesh* mesh, const aiScene* scene);
     void setBoneIdAndWeights(AnimatedVertex& vertex, int boneID, float weight);
+    // Read the scene's animation channels into Animation clips (issue #287). Keyframe
+    // timestamps are converted from ticks to seconds so the runtime advances them by dt.
+    void extractAnimations(const aiScene* scene);
     
     // Helper functions
     std::string getTextureFilename(aiMaterial* mat, aiTextureType type, unsigned int index = 0);
@@ -185,6 +189,8 @@ public:
     bool hasAnimations() const { return m_hasAnimations; }
     const std::map<std::string, BoneInfo>& getBoneInfoMap() const { return m_boneInfoMap; }
     int getBoneCount() const { return m_boneCounter; }
+    // Animation clips extracted from the model, ready to drive an AnimationComponent (#287).
+    const std::vector<Animation>& getAnimations() const { return m_animations; }
 
     // True if any mesh carries bone weights, i.e. the model needs the skinned vertex
     // path (used to pick the skinned shadow-depth program, issue #266).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -639,7 +639,12 @@ int main() {
     // === Model Loading ===
     LOG_INFO("Loading 3D model...");
     IKore::Model cubeModel;
-    bool modelLoaded = cubeModel.loadFromFile("assets/models/cube.obj");
+    // Prefer the rigged, animated model so the skinned path (issue #287) is exercised; fall
+    // back to the static cube (or primitive geometry) if it is unavailable.
+    bool modelLoaded = cubeModel.loadFromFile("assets/models/animated_bone.gltf");
+    if (!modelLoaded) {
+        modelLoaded = cubeModel.loadFromFile("assets/models/cube.obj");
+    }
     if (!modelLoaded || cubeModel.getMeshes().empty()) {
         LOG_ERROR("Failed to load model - falling back to primitive geometry");
     } else {
@@ -647,10 +652,19 @@ int main() {
     }
 
     // Bone-palette source for the skinned forward + shadow passes (issue #287). An animated
-    // model's AnimationComponent produces the per-frame palette via getBoneTransforms(); it
-    // is advanced in the render loop only when the model has bones. The cube here is static
-    // (no bones), so no palette is uploaded and the render is unchanged.
+    // model's AnimationComponent produces the per-frame palette via getBoneTransforms(), which
+    // is advanced in the render loop when the model has bones. Load the model's animation clips
+    // and play the first so the skinned path actually deforms at runtime; a static model (or
+    // the primitive fallback) adds no palette and renders unchanged.
     IKore::AnimationComponent modelAnimation;
+    if (modelLoaded && cubeModel.hasBones() && !cubeModel.getAnimations().empty()) {
+        modelAnimation.setBoneInfoMap(cubeModel.getBoneInfoMap());
+        for (const auto& clip : cubeModel.getAnimations()) {
+            modelAnimation.addAnimation(clip.name, std::make_unique<IKore::Animation>(clip));
+        }
+        modelAnimation.playAnimation(cubeModel.getAnimations().front().name, /*loop=*/true, /*speed=*/1.0f);
+        LOG_INFO("Playing skinned animation (" + std::to_string(cubeModel.getBoneCount()) + " bone(s))");
+    }
 
     // Delta time tracking
     double lastFrameTime = glfwGetTime();

--- a/tests/test_skinned_animation.cpp
+++ b/tests/test_skinned_animation.cpp
@@ -1,0 +1,107 @@
+// Test for the runtime skeletal-animation loading pipeline - issue #287 follow-up.
+//
+// #287 wired the skinned forward + shadow passes but the engine never loaded an animation
+// clip into an AnimationComponent, so the skinned path was inert. This verifies the new
+// pipeline end to end on the committed animated asset (assets/models/animated_bone.gltf, a
+// single bone rotating 0..90 degrees over one second):
+//   - Model::loadFromFile reports bones + animations and extracts the clip,
+//   - an AnimationComponent driven by that clip produces a bone palette that actually
+//     animates frame to frame (not the bind pose).
+//
+// Needs a GL context (Model creates VBOs on load); runs headlessly on Xvfb + a software GL.
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+
+#include "src/Model.h"
+#include "src/core/components/AnimationComponent.h"
+
+using namespace IKore;
+
+static int g_failures = 0;
+#define CHECK(cond)                                                        \
+    do {                                                                   \
+        if (!(cond)) {                                                     \
+            std::cerr << "FAIL (line " << __LINE__ << "): " #cond << "\n"; \
+            ++g_failures;                                                  \
+        }                                                                  \
+    } while (0)
+
+static bool mat4Differs(const glm::mat4& a, const glm::mat4& b, float eps = 1e-4f) {
+    for (int i = 0; i < 4; ++i)
+        for (int j = 0; j < 4; ++j)
+            if (std::fabs(a[i][j] - b[i][j]) > eps) return true;
+    return false;
+}
+
+int main() {
+    // Headless GL context (Model::loadFromFile creates GL buffers). Skip cleanly if no
+    // display/context is available so the job stays reliable.
+    if (!glfwInit()) { std::cout << "skip: GLFW init failed (no display?)\n"; return 0; }
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+    GLFWwindow* win = glfwCreateWindow(64, 64, "anim-test", nullptr, nullptr);
+    if (!win) { std::cout << "skip: no GL context\n"; glfwTerminate(); return 0; }
+    glfwMakeContextCurrent(win);
+    if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+        std::cout << "skip: could not load GL\n";
+        glfwDestroyWindow(win);
+        glfwTerminate();
+        return 0;
+    }
+
+    {
+        Model model;
+        const bool loaded = model.loadFromFile("assets/models/animated_bone.gltf");
+        CHECK(loaded);
+        CHECK(model.hasBones());
+        CHECK(model.hasAnimations());
+        CHECK(model.getBoneCount() >= 1);
+        CHECK(!model.getAnimations().empty());
+
+        if (loaded && !model.getAnimations().empty() && !model.getBoneInfoMap().empty()) {
+            // The extracted clip should carry the rotation keyframes.
+            const Animation& clip = model.getAnimations().front();
+            CHECK(clip.duration > 0.0f);
+            CHECK(!clip.bones.empty());
+            CHECK(!clip.bones.front().rotations.empty());
+
+            // Drive an AnimationComponent with the model's clip + bone map.
+            AnimationComponent anim;
+            anim.setBoneInfoMap(model.getBoneInfoMap());
+            for (const auto& a : model.getAnimations()) {
+                anim.addAnimation(a.name, std::make_unique<Animation>(a));
+            }
+            anim.playAnimation(clip.name, /*loop=*/true, /*speed=*/1.0f);
+
+            const int boneId = model.getBoneInfoMap().begin()->second.id;
+            CHECK(boneId >= 0);
+
+            // Sample the palette near t=0 (bind pose) and near t=0.5s (rotated ~45 deg).
+            anim.update(0.0001f);
+            const glm::mat4 atStart = anim.getBoneTransforms()[static_cast<std::size_t>(boneId)];
+            for (int i = 0; i < 50; ++i) anim.update(0.01f); // advance ~0.5 s
+            const glm::mat4 atMid = anim.getBoneTransforms()[static_cast<std::size_t>(boneId)];
+
+            // The bone palette must actually change over time (the whole point of #287).
+            CHECK(mat4Differs(atStart, atMid));
+            // And at ~0.5 s the bone is posed away from the identity bind pose.
+            CHECK(mat4Differs(atMid, glm::mat4(1.0f)));
+        }
+    }
+
+    glfwDestroyWindow(win);
+    glfwTerminate();
+
+    if (g_failures == 0) {
+        std::cout << "All skinned animation tests passed.\n";
+        return 0;
+    }
+    std::cout << g_failures << " skinned animation test(s) failed.\n";
+    return 1;
+}


### PR DESCRIPTION
Follow-up to #287.

#287 wired the skinned forward + shadow passes, but the engine only ever loaded skinned *meshes* (bone weights) - it never read the animation *clips* into an `AnimationComponent`, and no animated asset shipped, so the skinned path was inert at runtime. This adds the missing loading pipeline plus a minimal animated asset, making the skinned path actually deform.

## Changes

- **`assets/models/animated_bone.gltf`** (new) + **`scripts/gen_animated_gltf.py`** (new): a tiny rigged, self-contained glTF (a single-bone quad whose joint rotates 0..90 degrees over one second), emitted by a committed generator script (buffer embedded as a base64 data URI).
- **`Model`**: `extractAnimations()` reads each `aiAnimation`'s channels into the engine's `Bone`/`Animation` structures (position/rotation/scale keyframes), converting keyframe times from ticks to seconds so the runtime advances them by a per-frame `dt`; `getAnimations()` exposes the clips.
- **`main.cpp`**: prefer the animated model, and load its clips into the `AnimationComponent` + play the first, so the #287 skinned forward + shadow path deforms the mesh per frame. A static model (or the primitive fallback) is unchanged.
- **`tests/test_skinned_animation.cpp`** (new, `gl`-labelled): loads the asset headlessly (GLFW context under Xvfb), checks bones + animations are present and the clip was extracted, drives an `AnimationComponent`, and asserts the bone palette actually changes between `t=0` and `t~0.5s` (i.e. it is not the bind pose).

## Verification

Under `xvfb-run` + llvmpipe: `test_skinned_animation` passes and the full `gl` suite is green (`100% tests passed, 0 tests failed out of 18`); the `IKore` engine builds with the sample wiring.

## Notes

The on-screen deformation still isn't pixel-verified headlessly (the standing rendering caveat), but the animation pipeline that feeds it - Model clip extraction through to the animating bone palette - is now covered by a headless test.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_