### PR TITLE
Import: turn GeoJSON/OSM map data into a playable world (#313)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,6 +613,11 @@ add_executable(test_dungeon_game
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dungeon_game.cpp
 )
 
+# GeoJSON/OSM map data -> playable DungeonGame world (#313) - header-only.
+add_executable(test_city_game
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_city_game.cpp
+)
+
 # Headless tower-defense mode on the room topology: doorway-graph pathing, tower
 # damage, lives, win/lose, determinism (#271) - header-only.
 add_executable(test_tower_defense
@@ -956,6 +961,7 @@ set(HEADLESS_TESTS
     test_audio_decode
     test_audio_streaming
     test_benchmark
+    test_city_game
     test_crowd
     test_cv_robust
     test_data_export

--- a/src/game/CityGame.h
+++ b/src/game/CityGame.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "game/DungeonGame.h"      // SceneDescription, EntitySpawn, DungeonGame, loadGame
+#include "world/GeoJsonImporter.h" // world::City / Building / Road
+
+#include <cmath>
+#include <cstddef>
+
+/**
+ * @file CityGame.h
+ * @brief Turn an imported GeoJSON/OSM City into a playable world (issue #313).
+ *
+ * The GeoJSON importer (#150) parses a map extract into a renderer-agnostic City
+ * (building footprints, road centerlines, intersections). This bridges that data
+ * into the deterministic DungeonGame loop (#164) so an imported map is immediately
+ * walkable and clearable without a renderer:
+ *   - each building footprint becomes a solid wall collision box (an obstacle the
+ *     player slides against), reusing the same world::Box / DungeonGame collision,
+ *   - the road network provides the walkable placements: the player spawns on the
+ *     first road, coins are dropped on the road graph (intersections, else road
+ *     midpoints), and the exit is the road endpoint farthest from the spawn.
+ *
+ * So the output is a SceneDescription (wallBoxes + EntitySpawns) fed straight into
+ * loadGame(), i.e. the same playable contract as a hand-drawn Doodlebound level.
+ * Header-only, dependency-free (std + the header-only importer / game types), so it
+ * is unit-testable headless and deterministic.
+ */
+namespace IKore {
+namespace game {
+
+struct CityGameOptions {
+    float wallHeight{3.0f};        ///< building obstacle height (collision is XZ-only, but kept sensible).
+    bool coinsAtIntersections{true}; ///< drop coins at road intersections; else at road midpoints.
+    bool coinsAtRoadMidpoints{true}; ///< fallback when there are no intersections.
+};
+
+namespace detail {
+
+/// Squared XZ distance between two points.
+inline float distSqXZ(const ecs::Vec3& a, const ecs::Vec3& b) {
+    const float dx = a.x - b.x, dz = a.z - b.z;
+    return dx * dx + dz * dz;
+}
+
+} // namespace detail
+
+/**
+ * @brief Convert an imported City into a playable SceneDescription.
+ *
+ * Buildings become wall boxes; the road network seeds the player spawn, coins, and
+ * exit. Determinism: buildings/roads/intersections are visited in City order, so the
+ * same City always yields byte-identical spawns.
+ */
+inline SceneDescription cityToScene(const world::City& city, const CityGameOptions& opt = {}) {
+    SceneDescription scene;
+
+    const float wallHeight = opt.wallHeight > 0.0f ? opt.wallHeight : 1.0f;
+    for (const world::Building& b : city.buildings) {
+        world::Box box;
+        box.center = ecs::Vec3{b.center.x, wallHeight * 0.5f, b.center.z};
+        box.size = ecs::Vec3{b.size.x, wallHeight, b.size.z};
+        box.yaw = 0.0f;
+        scene.wallBoxes.push_back(box);
+    }
+
+    // Gather every road endpoint (walkable). The first is the player spawn.
+    bool haveSpawn = false;
+    ecs::Vec3 spawn{};
+    for (const world::Road& road : city.roads) {
+        if (road.centerline.size() < 2) continue;
+        if (!haveSpawn) {
+            spawn = road.centerline.front();
+            haveSpawn = true;
+            break;
+        }
+    }
+    if (haveSpawn) {
+        scene.spawns.push_back(EntitySpawn{"player", spawn, 0.0f});
+    }
+
+    // Exit: the road endpoint farthest (XZ) from the spawn, so the level spans the map.
+    if (haveSpawn) {
+        ecs::Vec3 exit = spawn;
+        float best = -1.0f;
+        for (const world::Road& road : city.roads) {
+            if (road.centerline.empty()) continue;
+            for (const ecs::Vec3& end : {road.centerline.front(), road.centerline.back()}) {
+                const float d = detail::distSqXZ(spawn, end);
+                if (d > best) {
+                    best = d;
+                    exit = end;
+                }
+            }
+        }
+        if (best > 0.0f) scene.spawns.push_back(EntitySpawn{"exit", exit, 0.0f});
+    }
+
+    // Coins on the road graph: intersections if present, else road midpoints.
+    if (opt.coinsAtIntersections && !city.intersections.empty()) {
+        for (const ecs::Vec3& node : city.intersections) {
+            scene.spawns.push_back(EntitySpawn{"coin", node, 0.0f});
+        }
+    } else if (opt.coinsAtRoadMidpoints) {
+        for (const world::Road& road : city.roads) {
+            if (road.centerline.size() < 2) continue;
+            const ecs::Vec3& a = road.centerline.front();
+            const ecs::Vec3& b = road.centerline.back();
+            scene.spawns.push_back(
+                EntitySpawn{"coin", ecs::Vec3{(a.x + b.x) * 0.5f, 0.0f, (a.z + b.z) * 0.5f}, 0.0f});
+        }
+    }
+
+    return scene;
+}
+
+/// Build a playable DungeonGame directly from an imported City.
+inline DungeonGame loadCityGame(const world::City& city, const CityGameOptions& opt = {}) {
+    return loadGame(cityToScene(city, opt));
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_city_game.cpp
+++ b/tests/test_city_game.cpp
@@ -1,0 +1,115 @@
+// Test for the GeoJSON/OSM "-> playable world" bridge - issue #313.
+//
+// Verifies that an imported City (buildings + roads + intersections) converts into a
+// playable DungeonGame: buildings become solid wall obstacles, the road network seeds
+// the player spawn / coins / exit, the spawn is clear of walls, and the resulting map
+// is actually walkable and clearable (a full headless playthrough wins). Pure std +
+// the header-only importer / game:
+//   g++ -std=c++17 -I src tests/test_city_game.cpp -o test_city_game
+
+#include "game/CityGame.h"
+#include "world/GeoJsonImporter.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// Origin = first coordinate (0,0), lat0=0 so 1 deg lon/lat = 111320 m (square).
+// Two roads sharing the node (0.0004,0) => one intersection; one building set well
+// off both road legs so the streets stay walkable.
+//   road1: (0,0)         -> (44.528,0)          along +X at z=0
+//   road2: (44.528,0)    -> (44.528,44.528)     along +Z at x=44.528
+//   building: x[11.1,22.3] z[11.1,22.3]         (clear of both legs)
+static const char* kGeoJson = R"JSON({
+  "type": "FeatureCollection",
+  "features": [
+    { "type":"Feature", "properties":{"highway":"residential"},
+      "geometry":{"type":"LineString","coordinates":[[0,0],[0.0004,0]]} },
+    { "type":"Feature", "properties":{"highway":"residential"},
+      "geometry":{"type":"LineString","coordinates":[[0.0004,0],[0.0004,0.0004]]} },
+    { "type":"Feature", "properties":{"building":"yes","height":"10"},
+      "geometry":{"type":"Polygon","coordinates":[[[0.0001,0.0001],[0.0002,0.0001],[0.0002,0.0002],[0.0001,0.0002],[0.0001,0.0001]]]} }
+  ]
+})JSON";
+
+static int countType(const game::SceneDescription& s, const char* t) {
+    int n = 0;
+    for (const auto& sp : s.spawns) if (sp.type == t) ++n;
+    return n;
+}
+
+int main() {
+    // Pass explicit options to disambiguate from the SVG importer's importString
+    // overload (both are pulled in transitively via the game headers).
+    const world::City city = world::importString(kGeoJson, world::GeoImportOptions{});
+    CHECK(city.buildings.size() == 1);
+    CHECK(city.roads.size() == 2);
+    CHECK(city.intersections.size() == 1);
+
+    const game::SceneDescription scene = game::cityToScene(city);
+
+    // Buildings became wall boxes; the road graph seeded exactly one of each spawn.
+    CHECK(scene.wallBoxes.size() == 1);
+    CHECK(countType(scene, "player") == 1);
+    CHECK(countType(scene, "exit") == 1);
+    CHECK(countType(scene, "coin") == 1); // one intersection -> one coin
+
+    game::DungeonGame gm = game::loadCityGame(city);
+    CHECK(gm.totalCoins == 1);
+    CHECK(gm.hasExit);
+    CHECK(gm.enemies.empty());
+
+    // The player spawns on a road, not inside a building.
+    CHECK(!gm.hitsWall(gm.playerPosition, gm.playerRadius));
+    // The building is solid: its center collides.
+    const ecs::Vec3 bc = city.buildings[0].center;
+    CHECK(gm.hitsWall(ecs::Vec3{bc.x, 0.0f, bc.z}, 0.4f));
+
+    // Determinism: converting the same city twice yields identical spawns.
+    const game::SceneDescription scene2 = game::cityToScene(city);
+    CHECK(scene.spawns.size() == scene2.spawns.size());
+    bool identical = scene.spawns.size() == scene2.spawns.size();
+    for (std::size_t i = 0; i < scene.spawns.size() && identical; ++i) {
+        identical = scene.spawns[i].type == scene2.spawns[i].type &&
+                    scene.spawns[i].position.x == scene2.spawns[i].position.x &&
+                    scene.spawns[i].position.z == scene2.spawns[i].position.z;
+    }
+    CHECK(identical);
+
+    // The imported map is playable and clearable: walk +X to grab the coin at the
+    // corner, then +Z to the exit; every coin collected on the exit == a win.
+    const float dt = 1.0f / 60.0f;
+    int steps = 0;
+    // Leg 1: head east until we are past the coin/corner (x ~ 44.5).
+    while (gm.playerPosition.x < 44.0f && gm.status == game::GameStatus::Playing && steps < 4000) {
+        gm.update(game::GameInput{1.0f, 0.0f}, dt);
+        ++steps;
+    }
+    CHECK(gm.coinsCollected == 1); // grabbed the intersection coin en route
+    // Leg 2: head north up the second street to the exit.
+    while (gm.status == game::GameStatus::Playing && steps < 8000) {
+        gm.update(game::GameInput{0.0f, 1.0f}, dt);
+        ++steps;
+    }
+    CHECK(gm.won());
+    CHECK(!gm.lost());
+
+    if (g_failures == 0) {
+        std::printf("test_city_game: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_city_game: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #313. The GeoJSON importer (#150) parses a map extract into a renderer-agnostic City (building footprints, road centerlines, intersections), but nothing yet turns that data into something playable. This adds the "-> playable world" layer on top of it, reusing the deterministic DungeonGame loop (#164).

## What this does

New header-only `src/game/CityGame.h`:

- `cityToScene(city, opts)` converts an imported `world::City` into a `game::SceneDescription`:
  - each building footprint becomes a solid wall-collision box (an obstacle the player slides against), reusing the same `world::Box` / DungeonGame collision,
  - the road network provides the walkable placements: the player spawns on the first road, coins drop on the road graph (intersections, else road midpoints), and the exit is the road endpoint farthest from the spawn.
- `loadCityGame(city, opts)` returns `loadGame(cityToScene(...))`, i.e. the same playable contract as a hand-drawn Doodlebound level.

Determinism: buildings/roads/intersections are visited in City order, so the same City always yields byte-identical spawns.

## Tests

`test_city_game` (headless): an imported City converts to the expected walls/spawns, the player spawn is clear of walls while building centers are solid, conversion is deterministic, and a full headless playthrough (walk the streets, grab the coin, reach the exit) wins.

## Notes

Header-only, dependency-free (std + the header-only importer / game types), registered under the `headless` CTest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_