### PR TITLE
CV: recognize hand-drawn symbols and place them as game spawns (#314)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,6 +649,11 @@ add_executable(test_symbols
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_symbols.cpp
 )
 
+# Recognized drawing symbols -> game spawns -> playable DungeonGame (#314) - header-only.
+add_executable(test_symbol_spawns
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_symbol_spawns.cpp
+)
+
 # Phase 2 CV robustness: lighting/skew/paper/wobble + corpus (Milestone 16 / #239)
 # - header-only.
 add_executable(test_cv_robust
@@ -1018,6 +1023,7 @@ set(HEADLESS_TESTS
     test_ssao_kernel
     test_svg_floorplan
     test_symbol_recognizer
+    test_symbol_spawns
     test_symbols
     test_timeline
     test_tmx_importer

--- a/src/game/SymbolSpawns.h
+++ b/src/game/SymbolSpawns.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "cv/Symbols.h"       // cv::Image, cv::SymbolInstance, detectSymbols
+#include "game/DungeonGame.h" // SceneDescription, EntitySpawn, DungeonGame, loadGame
+
+#include <string>
+#include <vector>
+
+/**
+ * @file SymbolSpawns.h
+ * @brief Recognize hand-drawn symbols and place them as game spawns (issue #314).
+ *
+ * The Tier-1 recognizer (#169) already classifies a colored blob into the game
+ * vocabulary ("player"/"enemy"/"coin"/"exit"), and LevelReview (#170) can fold CV
+ * outputs into an editable LevelSpec. This closes the remaining gap: a single call
+ * that turns a (rectified) drawing image straight into the DungeonGame spawn list,
+ * so a photographed/drawn sketch is playable without the intermediate review model.
+ *
+ * The recognizer's object strings are exactly loadGame()'s spawn vocabulary, so:
+ *   Image -> detectSymbols -> placeSpawns -> SceneDescription -> loadGame
+ * is a complete drawing-to-playable path. Symbol centroids (image pixels, y down)
+ * are scaled into world XZ by @c worldScale, matching assembleLevel()'s convention
+ * so symbol placement agrees with the wall placement in the same pipeline.
+ *
+ * Header-only, dependency-free (std + the header-only CV / game types), so the whole
+ * chain is unit-testable headless and deterministic.
+ */
+namespace IKore {
+namespace game {
+
+struct SymbolSpawnOptions {
+    float worldScale{1.0f};         ///< image pixels -> world units (matches assembleLevel).
+    cv::SymbolOptions detect{};     ///< blob detection + recognition tunables.
+    bool dropUnknown{false};        ///< skip blobs the recognizer could not name.
+};
+
+/// Map already-detected symbol instances (image-space centroids) to entity spawns.
+inline std::vector<EntitySpawn> placeSpawns(const std::vector<cv::SymbolInstance>& symbols,
+                                            const SymbolSpawnOptions& opt = {}) {
+    std::vector<EntitySpawn> spawns;
+    spawns.reserve(symbols.size());
+    for (const cv::SymbolInstance& s : symbols) {
+        if (s.result.object.empty()) continue;
+        if (opt.dropUnknown && s.result.color == cv::ColorClass::Unknown) continue;
+        spawns.push_back(EntitySpawn{s.result.object,
+                                     ecs::Vec3{s.cx * opt.worldScale, 0.0f, s.cy * opt.worldScale},
+                                     0.0f});
+    }
+    return spawns;
+}
+
+/// Detect + recognize + place every symbol in @p img in one step.
+inline std::vector<EntitySpawn> detectSpawns(const cv::Image& img,
+                                             const SymbolSpawnOptions& opt = {}) {
+    return placeSpawns(cv::detectSymbols(img, opt.detect), opt);
+}
+
+/**
+ * @brief Build a SceneDescription from recognized symbols (optionally over existing
+ *        wall geometry). The spawns come straight from the drawing's symbols.
+ */
+inline SceneDescription symbolsToScene(const cv::Image& img, const SymbolSpawnOptions& opt = {},
+                                       std::vector<world::Box> wallBoxes = {}) {
+    SceneDescription scene;
+    scene.wallBoxes = std::move(wallBoxes);
+    scene.spawns = detectSpawns(img, opt);
+    return scene;
+}
+
+/// Convenience: a playable DungeonGame straight from a recognized drawing.
+inline DungeonGame loadSymbolGame(const cv::Image& img, const SymbolSpawnOptions& opt = {},
+                                  std::vector<world::Box> wallBoxes = {}) {
+    return loadGame(symbolsToScene(img, opt, std::move(wallBoxes)));
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_symbol_spawns.cpp
+++ b/tests/test_symbol_spawns.cpp
@@ -1,0 +1,104 @@
+// Test for the drawing-symbols -> game-spawns bridge - issue #314.
+//
+// Exercises the full chain that had no single test: a (rectified) RGB drawing with
+// colored symbol blobs -> detectSymbols (recognize) -> placeSpawns (world XZ) ->
+// loadGame (playable). Asserts each color is recognized as the right game object,
+// lands at the right world cell, and yields the expected playable actors. Pure std +
+// the header-only CV / game:
+//   g++ -std=c++17 -I src tests/test_symbol_spawns.cpp -o test_symbol_spawns
+
+#include "cv/Image.h"
+#include "game/SymbolSpawns.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 1.0f) { return std::fabs(a - b) <= eps; }
+
+// Fill a solid side x side square whose top-left corner is (x0, y0). Its centroid
+// is (x0 + (side-1)/2, y0 + (side-1)/2).
+static void fillSquare(cv::Image& img, int x0, int y0, int side, int r, int g, int b) {
+    for (int y = y0; y < y0 + side; ++y) {
+        for (int x = x0; x < x0 + side; ++x) {
+            img.set(x, y, 0, static_cast<std::uint8_t>(r));
+            img.set(x, y, 1, static_cast<std::uint8_t>(g));
+            img.set(x, y, 2, static_cast<std::uint8_t>(b));
+        }
+    }
+}
+
+static const game::EntitySpawn* find(const std::vector<game::EntitySpawn>& v, const char* type) {
+    for (const auto& s : v) if (s.type == type) return &s;
+    return nullptr;
+}
+
+int main() {
+    // Black background (uncolored); four saturated symbol squares, side 10, so each
+    // centroid is at corner + 4.5.
+    cv::Image img(80, 80, 3);
+    fillSquare(img, 15, 15, 10, 0, 200, 0);   // green  -> player, centroid (19.5, 19.5)
+    fillSquare(img, 55, 15, 10, 220, 0, 0);   // red    -> enemy,  centroid (59.5, 19.5)
+    fillSquare(img, 15, 55, 10, 220, 220, 0); // yellow -> coin,   centroid (19.5, 59.5)
+    fillSquare(img, 55, 55, 10, 0, 0, 220);   // blue   -> exit,   centroid (59.5, 59.5)
+
+    game::SymbolSpawnOptions opt; // worldScale 1.0
+    const std::vector<game::EntitySpawn> spawns = game::detectSpawns(img, opt);
+
+    // Every symbol recognized and placed.
+    CHECK(spawns.size() == 4);
+    const game::EntitySpawn* player = find(spawns, "player");
+    const game::EntitySpawn* enemy = find(spawns, "enemy");
+    const game::EntitySpawn* coin = find(spawns, "coin");
+    const game::EntitySpawn* exit = find(spawns, "exit");
+    CHECK(player && enemy && coin && exit);
+
+    // Colors mapped to the right game objects at the right world cells.
+    if (player) CHECK(approx(player->position.x, 19.5f) && approx(player->position.z, 19.5f));
+    if (enemy) CHECK(approx(enemy->position.x, 59.5f) && approx(enemy->position.z, 19.5f));
+    if (coin) CHECK(approx(coin->position.x, 19.5f) && approx(coin->position.z, 59.5f));
+    if (exit) CHECK(approx(exit->position.x, 59.5f) && approx(exit->position.z, 59.5f));
+
+    // The recognized drawing loads into a playable game with the expected actors.
+    game::DungeonGame gm = game::loadSymbolGame(img, opt);
+    CHECK(gm.totalCoins == 1);
+    CHECK(gm.enemies.size() == 1);
+    CHECK(gm.hasExit);
+    if (player) CHECK(approx(gm.playerPosition.x, 19.5f) && approx(gm.playerPosition.z, 19.5f));
+
+    // worldScale actually scales placement.
+    game::SymbolSpawnOptions half;
+    half.worldScale = 0.5f;
+    const std::vector<game::EntitySpawn> scaled = game::detectSpawns(img, half);
+    const game::EntitySpawn* p2 = find(scaled, "player");
+    CHECK(p2 && approx(p2->position.x, 9.75f) && approx(p2->position.z, 9.75f));
+
+    // Determinism: same image -> identical spawns.
+    const std::vector<game::EntitySpawn> again = game::detectSpawns(img, opt);
+    bool identical = again.size() == spawns.size();
+    for (std::size_t i = 0; i < spawns.size() && identical; ++i) {
+        identical = again[i].type == spawns[i].type &&
+                    again[i].position.x == spawns[i].position.x &&
+                    again[i].position.z == spawns[i].position.z;
+    }
+    CHECK(identical);
+
+    if (g_failures == 0) {
+        std::printf("test_symbol_spawns: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_symbol_spawns: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #314. The Tier-1 symbol recognizer (#169) already classifies a colored blob into the game vocabulary ("player"/"enemy"/"coin"/"exit"), and LevelReview (#170) can fold CV outputs into an editable `LevelSpec`. The remaining gap: nothing turned a (rectified) drawing image *straight* into DungeonGame spawns, and no single test covered the whole recognize -> place -> playable chain.

## What this does

New header-only `src/game/SymbolSpawns.h`:

- `placeSpawns(symbols, opts)` maps already-detected `cv::SymbolInstance` centroids (image pixels) into `EntitySpawn`s in the world XZ plane, using the same `worldScale` convention as `assembleLevel()` so symbol placement agrees with wall placement in the same pipeline.
- `detectSpawns(img, opts)` runs `detectSymbols` + `placeSpawns` in one call.
- `symbolsToScene()` / `loadSymbolGame()` produce a `SceneDescription` / playable `DungeonGame` directly from a drawing (optionally over existing wall geometry).

The recognizer's object strings are exactly `loadGame()`'s spawn vocabulary, so `Image -> detectSymbols -> placeSpawns -> loadGame` is now a complete drawing-to-playable path.

## Tests

`test_symbol_spawns` (headless) builds a synthetic RGB drawing with four saturated symbol squares and asserts the full chain: green->player, red->enemy, yellow->coin, blue->exit, each at the right world cell; `worldScale` scales placement; the recognized drawing loads into a playable game with the expected actors; deterministic.

## Notes

Builds on the existing Milestone-16 CV cores rather than reimplementing recognition. Header-only, dependency-free, registered under the `headless` CTest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_