### PR TITLE
CV: rectify photographed drawings into playable spawns (#315)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -654,6 +654,11 @@ add_executable(test_symbol_spawns
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_symbol_spawns.cpp
 )
 
+# Photographed drawing -> rectify (de-warp) -> recognized spawns -> playable (#315) - header-only.
+add_executable(test_photo_level
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_photo_level.cpp
+)
+
 # Phase 2 CV robustness: lighting/skew/paper/wobble + corpus (Milestone 16 / #239)
 # - header-only.
 add_executable(test_cv_robust
@@ -1006,6 +1011,7 @@ set(HEADLESS_TESTS
     test_pbr_material
     test_pbr_textures
     test_perf_stats
+    test_photo_level
     test_picking
     test_quest_gen
     test_rectify

--- a/src/game/PhotoLevel.h
+++ b/src/game/PhotoLevel.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "cv/Rectify.h"        // cv::rectify (paper detect + de-warp + white balance)
+#include "game/SymbolSpawns.h" // detectSpawns / loadGame
+
+#include <utility>
+#include <vector>
+
+/**
+ * @file PhotoLevel.h
+ * @brief Photographed drawing -> rectified -> playable spawns (issue #315).
+ *
+ * A drawing is usually captured as an angled phone photo, not a clean top-down
+ * scan. Rectify (#166) already de-warps such a photo (detect the paper quad, solve
+ * the homography, warp to a square, white-balance), and SymbolSpawns (#314) turns a
+ * clean drawing into game spawns. This wires the two into the single call the mobile
+ * capture path wants: photo -> rectify -> recognize -> place, so a photographed
+ * sketch is playable end to end.
+ *
+ * Header-only, dependency-free (std + the header-only CV / game types), so the whole
+ * photo-to-playable chain is unit-testable headless and deterministic.
+ */
+namespace IKore {
+namespace game {
+
+struct PhotoLevelOptions {
+    int rectifiedSize{256};      ///< side of the square the photo is rectified to.
+    SymbolSpawnOptions spawn{};  ///< recognition + placement tunables (worldScale is in rectified px).
+};
+
+/// Rectify a photographed drawing to a clean top-down square.
+inline cv::Image rectifyPhoto(const cv::Image& photo, int rectifiedSize = 256) {
+    return cv::rectify(photo, rectifiedSize);
+}
+
+/// Rectify a photographed drawing and recognize its symbols as game spawns.
+inline std::vector<EntitySpawn> detectSpawnsFromPhoto(const cv::Image& photo,
+                                                      const PhotoLevelOptions& opt = {}) {
+    const cv::Image rectified = cv::rectify(photo, opt.rectifiedSize);
+    return detectSpawns(rectified, opt.spawn);
+}
+
+/// Convenience: a playable DungeonGame straight from a photographed drawing.
+inline DungeonGame loadPhotoGame(const cv::Image& photo, const PhotoLevelOptions& opt = {},
+                                 std::vector<world::Box> wallBoxes = {}) {
+    SceneDescription scene;
+    scene.wallBoxes = std::move(wallBoxes);
+    scene.spawns = detectSpawnsFromPhoto(photo, opt);
+    return loadGame(scene);
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_photo_level.cpp
+++ b/tests/test_photo_level.cpp
@@ -1,0 +1,116 @@
+// Test for the photographed-drawing -> playable path - issue #315.
+//
+// Proves the de-warp step (Rectify #166) lets the symbol pipeline survive a photo
+// taken at an angle: a flat drawing with four colored symbols is warped onto a
+// convex quad over a dark background (a synthetic angled photo), then
+// detectSpawnsFromPhoto rectifies and recognizes it. The four symbols must come
+// back with the right types and the right corner layout (de-warp preserves both).
+// Pure std + the header-only CV / game:
+//   g++ -std=c++17 -I src tests/test_photo_level.cpp -o test_photo_level
+
+#include "cv/Image.h"
+#include "cv/Rectify.h" // computeHomography / applyHomography for building the photo
+#include "game/PhotoLevel.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static void fillSquare(cv::Image& img, int x0, int y0, int side, int r, int g, int b) {
+    for (int y = y0; y < y0 + side; ++y)
+        for (int x = x0; x < x0 + side; ++x) {
+            img.set(x, y, 0, static_cast<std::uint8_t>(r));
+            img.set(x, y, 1, static_cast<std::uint8_t>(g));
+            img.set(x, y, 2, static_cast<std::uint8_t>(b));
+        }
+}
+
+static const game::EntitySpawn* find(const std::vector<game::EntitySpawn>& v, const char* t) {
+    for (const auto& s : v) if (s.type == t) return &s;
+    return nullptr;
+}
+
+int main() {
+    // Flat white "paper" drawing, 80x80, with four inset colored symbols so the paper
+    // corners stay white (the bright extremes the detector locks onto).
+    cv::Image flat(80, 80, 3);
+    for (int y = 0; y < 80; ++y)
+        for (int x = 0; x < 80; ++x)
+            for (int c = 0; c < 3; ++c) flat.set(x, y, c, 255);
+    fillSquare(flat, 10, 10, 16, 0, 200, 0);   // green  -> player (top-left)
+    fillSquare(flat, 54, 10, 16, 220, 220, 0); // yellow -> coin   (top-right)
+    fillSquare(flat, 10, 54, 16, 220, 0, 0);   // red    -> enemy  (bottom-left)
+    fillSquare(flat, 54, 54, 16, 0, 0, 220);   // blue   -> exit   (bottom-right)
+
+    // Synthetic angled photo: dark background, the drawing painted onto a convex quad.
+    cv::Image photo(220, 220, 3);
+    for (int y = 0; y < photo.height; ++y)
+        for (int x = 0; x < photo.width; ++x) {
+            photo.set(x, y, 0, 26);
+            photo.set(x, y, 1, 28);
+            photo.set(x, y, 2, 24);
+        }
+    const cv::Point quad[4] = {{45, 35}, {180, 60}, {165, 195}, {35, 170}};
+    const cv::Point flatCorners[4] = {{0, 0}, {80, 0}, {80, 80}, {0, 80}};
+    const cv::Mat3 photoToFlat = cv::computeHomography(quad, flatCorners);
+    for (int y = 0; y < photo.height; ++y)
+        for (int x = 0; x < photo.width; ++x) {
+            const cv::Point p = cv::applyHomography(photoToFlat, static_cast<float>(x), static_cast<float>(y));
+            if (p.x >= 0 && p.x < 80 && p.y >= 0 && p.y < 80)
+                for (int c = 0; c < 3; ++c) photo.set(x, y, c, cv::clampByte(flat.sample(p.x, p.y, c)));
+        }
+
+    game::PhotoLevelOptions opt;
+    opt.rectifiedSize = 160;
+    const std::vector<game::EntitySpawn> spawns = game::detectSpawnsFromPhoto(photo, opt);
+
+    // All four symbols survived the de-warp and were recognized.
+    CHECK(spawns.size() == 4);
+    const game::EntitySpawn* player = find(spawns, "player");
+    const game::EntitySpawn* coin = find(spawns, "coin");
+    const game::EntitySpawn* enemy = find(spawns, "enemy");
+    const game::EntitySpawn* exit = find(spawns, "exit");
+    CHECK(player && coin && enemy && exit);
+
+    // Corner layout preserved through rectification (rectified to 160, halves at 80):
+    // player top-left, coin top-right, enemy bottom-left, exit bottom-right.
+    const float mid = 80.0f;
+    if (player) CHECK(player->position.x < mid && player->position.z < mid);
+    if (coin) CHECK(coin->position.x > mid && coin->position.z < mid);
+    if (enemy) CHECK(enemy->position.x < mid && enemy->position.z > mid);
+    if (exit) CHECK(exit->position.x > mid && exit->position.z > mid);
+
+    // The photographed drawing loads into a playable game with the expected actors.
+    game::DungeonGame gm = game::loadPhotoGame(photo, opt);
+    CHECK(gm.totalCoins == 1);
+    CHECK(gm.enemies.size() == 1);
+    CHECK(gm.hasExit);
+
+    // Determinism: same photo -> identical spawns.
+    const std::vector<game::EntitySpawn> again = game::detectSpawnsFromPhoto(photo, opt);
+    bool identical = again.size() == spawns.size();
+    for (std::size_t i = 0; i < spawns.size() && identical; ++i)
+        identical = again[i].type == spawns[i].type &&
+                    again[i].position.x == spawns[i].position.x &&
+                    again[i].position.z == spawns[i].position.z;
+    CHECK(identical);
+
+    if (g_failures == 0) {
+        std::printf("test_photo_level: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_photo_level: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #315. A drawing is usually captured as an angled phone photo, not a clean top-down scan. Rectify (#166) already de-warps such a photo, and SymbolSpawns (#314) turns a clean drawing into game spawns. This wires the two into the single call the capture path wants, and adds the first test that a warped photo survives the whole pipeline to correctly-placed spawns.

## What this does

New header-only `src/game/PhotoLevel.h`:

- `rectifyPhoto(photo, size)` de-warps a photo to a clean top-down square (paper quad detect -> homography -> warp -> white balance).
- `detectSpawnsFromPhoto(photo, opts)` rectifies then recognizes + places symbols in one call.
- `loadPhotoGame(photo, opts)` returns a playable `DungeonGame` straight from a photo.

## Tests

`test_photo_level` (headless): a flat drawing with four colored symbols is warped onto a convex quad over a dark, tinted background (a synthetic angled photo). The de-warp path recovers all four symbols with the right types (player/coin/enemy/exit) and the right corner layout, loads the expected playable actors, and is deterministic.

## Notes

Builds on the existing Milestone-16 Rectify core rather than reimplementing de-warp. Header-only, dependency-free, registered under the `headless` CTest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_