### PR TITLE
Sim: deterministic solvability validator and auto-solver for levels (#316)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,6 +618,11 @@ add_executable(test_city_game
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_city_game.cpp
 )
 
+# Deterministic solvability validator + auto-solver over DungeonGame rules (#316) - header-only.
+add_executable(test_solver
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_solver.cpp
+)
+
 # Headless tower-defense mode on the room topology: doorway-graph pathing, tower
 # damage, lives, win/lose, determinism (#271) - header-only.
 add_executable(test_tower_defense
@@ -1026,6 +1031,7 @@ set(HEADLESS_TESTS
     test_simulation
     test_skinned_shadow
     test_skinning
+    test_solver
     test_ssao_kernel
     test_svg_floorplan
     test_symbol_recognizer

--- a/src/game/Solver.h
+++ b/src/game/Solver.h
@@ -1,0 +1,250 @@
+#pragma once
+
+#include "game/DungeonGame.h"  // DungeonGame, GameInput, loadGame, SceneDescription
+#include "game/LevelFormat.h"  // fromLevelJson (validateLevelJson)
+
+#include <algorithm>
+#include <cstdint>
+#include <queue>
+#include <string>
+#include <vector>
+
+/**
+ * @file Solver.h
+ * @brief Deterministic solvability validator + auto-solver for levels (issue #316).
+ *
+ * Weekly challenges (#273) and seed-shared levels can be unfair (an unreachable exit
+ * or coin). Because DungeonGame (#164) is fully deterministic, a search can prove a
+ * level is clearable and report the optimal clear length (par), gating challenges and
+ * leaderboards.
+ *
+ * The solver discretizes the walkable XZ space into a grid and runs a breadth-first
+ * search over (cell, collected-coin bitmask), so it finds the shortest route that
+ * collects every coin and reaches the exit. Crucially it reuses DungeonGame's own
+ * rules: a cell is walkable iff game.hitsWall(center, playerRadius) is false (the same
+ * collision), and a coin/exit is "reached" from a cell iff the center is within the
+ * same pickup radius the game uses. So the solver and the game agree - the returned
+ * path, driven as inputs, wins the actual game (exercised by the test).
+ *
+ * The chase enemy is ignored by default (static solvability); optionally it can be
+ * treated as a fixed hazard at its start (enemiesAsHazard). Header-only, std-only,
+ * deterministic.
+ */
+namespace IKore {
+namespace game {
+
+struct SolveOptions {
+    float cellSize{0.5f};       ///< grid resolution in world units.
+    int padCells{2};            ///< walkable margin added around the content AABB.
+    bool enemiesAsHazard{false}; ///< block cells near an enemy's start position.
+    int maxCoinsExact{16};      ///< above this, skip the exact bitmask search (report reachability only).
+};
+
+struct SolveResult {
+    bool solvable{false};         ///< every coin collectible and the exit reachable after collecting them.
+    int par{-1};                  ///< minimal number of grid steps to clear; -1 if unsolvable/unknown.
+    int totalCoins{0};
+    int reachableCoins{0};        ///< coins collectible from some cell reachable from the start.
+    bool exitReachable{false};    ///< exit reachable from the start (ignoring coin gating).
+    int unreachableObjectives{0}; ///< unreachable coins + (exit unreachable ? 1 : 0).
+    std::vector<ecs::Vec3> path;  ///< cell centers from start to the winning cell (auto-solver output).
+};
+
+namespace detail {
+
+struct SolverGrid {
+    float minX{0.0f}, minZ{0.0f}, cellSize{0.5f};
+    int nx{0}, nz{0};
+
+    int index(int gx, int gz) const {
+        if (gx < 0 || gz < 0 || gx >= nx || gz >= nz) return -1;
+        return gz * nx + gx;
+    }
+    int cellOf(float x, float z) const {
+        const int gx = static_cast<int>(std::floor((x - minX) / cellSize));
+        const int gz = static_cast<int>(std::floor((z - minZ) / cellSize));
+        return index(gx, gz);
+    }
+    ecs::Vec3 center(int idx) const {
+        const int gx = idx % nx, gz = idx / nx;
+        return ecs::Vec3{minX + (gx + 0.5f) * cellSize, 0.0f, minZ + (gz + 0.5f) * cellSize};
+    }
+};
+
+inline SolverGrid buildGrid(const DungeonGame& g, const SolveOptions& opt) {
+    float minX = g.playerPosition.x, maxX = g.playerPosition.x;
+    float minZ = g.playerPosition.z, maxZ = g.playerPosition.z;
+    auto grow = [&](const ecs::Vec3& p, float ext) {
+        minX = std::min(minX, p.x - ext);
+        maxX = std::max(maxX, p.x + ext);
+        minZ = std::min(minZ, p.z - ext);
+        maxZ = std::max(maxZ, p.z + ext);
+    };
+    for (const world::Box& b : g.walls) grow(b.center, 0.5f * std::max(std::fabs(b.size.x), std::fabs(b.size.z)));
+    for (const Coin& c : g.coins) grow(c.position, 0.0f);
+    for (const Enemy& e : g.enemies) grow(e.position, 0.0f);
+    if (g.hasExit) grow(g.exitPosition, 0.0f);
+
+    SolverGrid grid;
+    grid.cellSize = opt.cellSize > 1e-4f ? opt.cellSize : 0.5f;
+    grid.minX = minX - opt.padCells * grid.cellSize;
+    grid.minZ = minZ - opt.padCells * grid.cellSize;
+    grid.nx = static_cast<int>(std::ceil((maxX - minX) / grid.cellSize)) + 2 * opt.padCells + 1;
+    grid.nz = static_cast<int>(std::ceil((maxZ - minZ) / grid.cellSize)) + 2 * opt.padCells + 1;
+    grid.nx = std::max(grid.nx, 1);
+    grid.nz = std::max(grid.nz, 1);
+    return grid;
+}
+
+} // namespace detail
+
+/**
+ * @brief Prove a level clearable and return the optimal clear route.
+ *
+ * BFS over (cell, coin bitmask): the start cell seeds whatever coins are collectible
+ * there; each move ORs in the neighbor's collectible coins; the goal is "all coins
+ * collected and standing on a cell that reaches the exit". par is the number of grid
+ * steps of that shortest route.
+ */
+inline SolveResult solve(const DungeonGame& game, const SolveOptions& opt = {}) {
+    SolveResult res;
+    res.totalCoins = static_cast<int>(game.coins.size());
+
+    const detail::SolverGrid grid = detail::buildGrid(game, opt);
+    const int cellCount = grid.nx * grid.nz;
+    if (cellCount <= 0) return res;
+
+    // Walkable mask (same collision as the game), plus optional enemy-hazard blocking.
+    std::vector<char> walkable(static_cast<std::size_t>(cellCount), 0);
+    for (int i = 0; i < cellCount; ++i) {
+        const ecs::Vec3 c = grid.center(i);
+        bool ok = !game.hitsWall(c, game.playerRadius);
+        if (ok && opt.enemiesAsHazard) {
+            for (const Enemy& e : game.enemies) {
+                const float dx = c.x - e.position.x, dz = c.z - e.position.z;
+                const float r = game.playerRadius + game.enemyRadius;
+                if (dx * dx + dz * dz <= r * r) { ok = false; break; }
+            }
+        }
+        walkable[static_cast<std::size_t>(i)] = ok ? 1 : 0;
+    }
+
+    // Per-cell collectible-coin bitmask and exit reachability.
+    const int nCoins = res.totalCoins;
+    std::vector<std::uint32_t> coinsAt(static_cast<std::size_t>(cellCount), 0);
+    std::vector<char> exitAt(static_cast<std::size_t>(cellCount), 0);
+    for (int i = 0; i < cellCount; ++i) {
+        if (!walkable[static_cast<std::size_t>(i)]) continue;
+        const ecs::Vec3 c = grid.center(i);
+        for (int k = 0; k < nCoins; ++k) {
+            const Coin& coin = game.coins[static_cast<std::size_t>(k)];
+            const float dx = c.x - coin.position.x, dz = c.z - coin.position.z;
+            const float r = game.playerRadius + game.coinRadius;
+            if (dx * dx + dz * dz <= r * r) coinsAt[static_cast<std::size_t>(i)] |= (1u << k);
+        }
+        if (game.hasExit) {
+            const float dx = c.x - game.exitPosition.x, dz = c.z - game.exitPosition.z;
+            const float r = game.playerRadius + game.exitRadius;
+            if (dx * dx + dz * dz <= r * r) exitAt[static_cast<std::size_t>(i)] = 1;
+        }
+    }
+
+    const int start = grid.cellOf(game.playerPosition.x, game.playerPosition.z);
+    if (start < 0 || !walkable[static_cast<std::size_t>(start)]) return res; // player boxed in
+
+    // Plain reachability flood (for reporting reachable coins / exit, ignoring gating).
+    {
+        std::vector<char> seen(static_cast<std::size_t>(cellCount), 0);
+        std::queue<int> q;
+        q.push(start);
+        seen[static_cast<std::size_t>(start)] = 1;
+        std::uint32_t reachMask = 0;
+        bool exitSeen = false;
+        const int dxs[4] = {1, -1, 0, 0}, dzs[4] = {0, 0, 1, -1};
+        while (!q.empty()) {
+            const int cur = q.front();
+            q.pop();
+            reachMask |= coinsAt[static_cast<std::size_t>(cur)];
+            if (exitAt[static_cast<std::size_t>(cur)]) exitSeen = true;
+            const int gx = cur % grid.nx, gz = cur / grid.nx;
+            for (int d = 0; d < 4; ++d) {
+                const int nb = grid.index(gx + dxs[d], gz + dzs[d]);
+                if (nb < 0 || seen[static_cast<std::size_t>(nb)] || !walkable[static_cast<std::size_t>(nb)]) continue;
+                seen[static_cast<std::size_t>(nb)] = 1;
+                q.push(nb);
+            }
+        }
+        for (int k = 0; k < nCoins; ++k)
+            if (reachMask & (1u << k)) ++res.reachableCoins;
+        res.exitReachable = exitSeen;
+        res.unreachableObjectives = (nCoins - res.reachableCoins) + (exitSeen ? 0 : 1);
+    }
+
+    if (nCoins > opt.maxCoinsExact) return res; // too many coins for the exact bitmask search
+
+    // BFS over (cell, mask). State id = cell * 2^nCoins + mask.
+    const std::uint32_t full = nCoins >= 32 ? 0xFFFFFFFFu : ((1u << nCoins) - 1u);
+    const std::size_t maskCount = static_cast<std::size_t>(full) + 1;
+    const std::size_t stateCount = static_cast<std::size_t>(cellCount) * maskCount;
+    std::vector<int> dist(stateCount, -1);
+    std::vector<int> parent(stateCount, -1);
+
+    auto stateId = [&](int cell, std::uint32_t mask) {
+        return static_cast<std::size_t>(cell) * maskCount + mask;
+    };
+
+    const std::uint32_t startMask = coinsAt[static_cast<std::size_t>(start)];
+    const std::size_t s0 = stateId(start, startMask);
+    dist[s0] = 0;
+    std::queue<std::size_t> q;
+    q.push(s0);
+    std::size_t goalState = static_cast<std::size_t>(-1);
+    const int dxs[4] = {1, -1, 0, 0}, dzs[4] = {0, 0, 1, -1};
+    while (!q.empty()) {
+        const std::size_t cur = q.front();
+        q.pop();
+        const int cell = static_cast<int>(cur / maskCount);
+        const std::uint32_t mask = static_cast<std::uint32_t>(cur % maskCount);
+        if (mask == full && exitAt[static_cast<std::size_t>(cell)]) { goalState = cur; break; }
+        const int gx = cell % grid.nx, gz = cell / grid.nx;
+        for (int d = 0; d < 4; ++d) {
+            const int nb = grid.index(gx + dxs[d], gz + dzs[d]);
+            if (nb < 0 || !walkable[static_cast<std::size_t>(nb)]) continue;
+            const std::uint32_t nmask = mask | coinsAt[static_cast<std::size_t>(nb)];
+            const std::size_t ns = stateId(nb, nmask);
+            if (dist[ns] >= 0) continue;
+            dist[ns] = dist[cur] + 1;
+            parent[ns] = static_cast<int>(cur);
+            q.push(ns);
+        }
+    }
+
+    if (goalState == static_cast<std::size_t>(-1)) return res; // unsolvable
+    res.solvable = true;
+    res.par = dist[goalState];
+
+    // Reconstruct the winning route (cell centers, start -> goal).
+    std::vector<int> cells;
+    for (int s = static_cast<int>(goalState); s >= 0; s = parent[static_cast<std::size_t>(s)]) {
+        cells.push_back(static_cast<int>(static_cast<std::size_t>(s) / maskCount));
+        if (parent[static_cast<std::size_t>(s)] < 0) break;
+    }
+    std::reverse(cells.begin(), cells.end());
+    for (int c : cells) res.path.push_back(grid.center(c));
+    return res;
+}
+
+/// Validate an already-converted scene.
+inline SolveResult validateLevel(const SceneDescription& scene, const SolveOptions& opt = {}) {
+    return solve(loadGame(scene), opt);
+}
+
+/// Validate a level from its "doodle-level" JSON (convenience for gating).
+inline SolveResult validateLevelJson(const std::string& json, const SolveOptions& opt = {}) {
+    LevelSpec spec;
+    if (!fromLevelJson(json, spec)) return SolveResult{};
+    return solve(loadGame(convert(spec)), opt);
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_solver.cpp
+++ b/tests/test_solver.cpp
@@ -1,0 +1,135 @@
+// Test for the deterministic solvability validator + auto-solver - issue #316.
+//
+// Verifies: a solvable level is proven clearable with the hand-verified optimal par;
+// the returned auto-solver route, driven as real inputs, actually wins the DungeonGame
+// (solver and game agree); an unsolvable level (a coin trapped in a wall) is rejected
+// with the right unreachable-objective report; and the JSON gating entry point works.
+// Pure std + the header-only game:
+//   g++ -std=c++17 -I src tests/test_solver.cpp -o test_solver
+
+#include "game/Solver.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// Drive a copy of the game along the solver's route as real inputs; return whether
+// it wins (proving the abstract route is a genuine, rule-legal clear).
+static bool drivesToWin(game::DungeonGame g, const std::vector<ecs::Vec3>& path) {
+    const float dt = 1.0f / 60.0f;
+    for (const ecs::Vec3& target : path) {
+        int steps = 0;
+        while (steps < 4000 && g.status == game::GameStatus::Playing) {
+            const float dx = target.x - g.playerPosition.x;
+            const float dz = target.z - g.playerPosition.z;
+            if (dx * dx + dz * dz < 0.0025f) break; // within 0.05
+            g.update(game::GameInput{dx, dz}, dt);
+            ++steps;
+        }
+        if (g.status != game::GameStatus::Playing) break;
+    }
+    return g.won();
+}
+
+static game::EntitySpawn spawn(const char* t, float x, float z) {
+    return game::EntitySpawn{t, ecs::Vec3{x, 0.0f, z}, 0.0f};
+}
+
+int main() {
+    // --- Fixture 1: open row, hand-verifiable par ------------------------------
+    // cellSize 1.0. Player at x=0.5, exit at x=5.5, same row, no coins/walls. With
+    // padCells=2 the start cell is gx=2 and the nearest exit cell is gx=6 -> par 4.
+    {
+        game::SceneDescription scene;
+        scene.spawns.push_back(spawn("player", 0.5f, 0.5f));
+        scene.spawns.push_back(spawn("exit", 5.5f, 0.5f));
+        game::SolveOptions opt;
+        opt.cellSize = 1.0f;
+        const game::SolveResult r = game::solve(game::loadGame(scene), opt);
+        CHECK(r.solvable);
+        CHECK(r.exitReachable);
+        CHECK(r.totalCoins == 0);
+        CHECK(r.par == 4);
+        CHECK(r.path.size() == 5); // par + 1 cells
+        CHECK(drivesToWin(game::loadGame(scene), r.path));
+    }
+
+    // --- Fixture 2: coins + a wall, solver route must actually win --------------
+    {
+        game::SceneDescription scene;
+        scene.spawns.push_back(spawn("player", 0.0f, 0.0f));
+        scene.spawns.push_back(spawn("coin", 3.0f, 0.0f));
+        scene.spawns.push_back(spawn("coin", 3.0f, 4.0f));
+        scene.spawns.push_back(spawn("exit", 0.0f, 4.0f));
+        // A wall segment between the two coins so the route is not a straight line.
+        world::Box wall;
+        wall.center = ecs::Vec3{1.5f, 1.5f, 2.0f};
+        wall.size = ecs::Vec3{3.0f, 3.0f, 0.4f};
+        wall.yaw = 0.0f;
+        scene.wallBoxes.push_back(wall);
+
+        const game::SolveResult r = game::solve(game::loadGame(scene));
+        CHECK(r.solvable);
+        CHECK(r.totalCoins == 2);
+        CHECK(r.reachableCoins == 2);
+        CHECK(r.exitReachable);
+        CHECK(r.par > 0);
+        CHECK(!r.path.empty());
+        CHECK(drivesToWin(game::loadGame(scene), r.path)); // route collects both coins and exits
+    }
+
+    // --- Fixture 3: unsolvable, a coin trapped inside a wall -------------------
+    {
+        game::SceneDescription scene;
+        scene.spawns.push_back(spawn("player", 0.0f, 0.0f));
+        scene.spawns.push_back(spawn("exit", 2.0f, 0.0f));
+        scene.spawns.push_back(spawn("coin", 8.0f, 8.0f)); // sealed inside the wall below
+        world::Box block;
+        block.center = ecs::Vec3{8.0f, 1.5f, 8.0f};
+        block.size = ecs::Vec3{3.0f, 3.0f, 3.0f}; // fully covers the coin's pickup radius
+        block.yaw = 0.0f;
+        scene.wallBoxes.push_back(block);
+
+        const game::SolveResult r = game::solve(game::loadGame(scene));
+        CHECK(!r.solvable);
+        CHECK(r.par == -1);
+        CHECK(r.totalCoins == 1);
+        CHECK(r.reachableCoins == 0);   // the trapped coin is collectible from nowhere
+        CHECK(r.exitReachable);         // the exit itself is fine
+        CHECK(r.unreachableObjectives == 1);
+        CHECK(r.path.empty());
+    }
+
+    // --- JSON gating entry point ----------------------------------------------
+    {
+        game::LevelSpec spec;
+        game::Wall w;
+        w.polyline = {ecs::Vec3{-1.0f, 0.0f, -1.0f}, ecs::Vec3{6.0f, 0.0f, -1.0f}};
+        spec.walls.push_back(w);
+        spec.symbols.push_back(game::Symbol{"player", ecs::Vec3{0.5f, 0.0f, 0.5f}, 0.0f});
+        spec.symbols.push_back(game::Symbol{"exit", ecs::Vec3{5.5f, 0.0f, 0.5f}, 0.0f});
+        const std::string json = game::toLevelJson(spec);
+        const game::SolveResult r = game::validateLevelJson(json);
+        CHECK(r.solvable);
+        CHECK(r.exitReachable);
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_solver: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_solver: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #316. Weekly challenges (#273) and seed-shared levels can be unfair (an unreachable exit or coin). Because DungeonGame (#164) is fully deterministic, a search can prove a level clearable and report the optimal clear length, gating challenges and leaderboards.

## What this does

New header-only `src/game/Solver.h`:

- `solve(game, opts)` discretizes the walkable XZ space into a grid and runs BFS over `(cell, collected-coin bitmask)`, finding the shortest route that collects every coin and reaches the exit. It reuses DungeonGame's own rules: a cell is walkable iff `hitsWall(center, playerRadius)` is false (same collision), and a coin/exit is reached iff the center is within the same pickup radius the game uses. So the returned route is a genuine, rule-legal clear.
- `SolveResult` reports `solvable`, `par` (grid steps of the optimal route), `reachableCoins`, `exitReachable`, `unreachableObjectives`, and the auto-solver `path`.
- The chase enemy is ignored by default (static solvability), or optionally treated as a fixed hazard at its start (`enemiesAsHazard`).
- `validateLevel(scene)` / `validateLevelJson(json)` expose the result for gating.

## Tests

`test_solver` (headless): a solvable open-row fixture gives the hand-verified `par == 4`; the returned route, **driven as real DungeonGame inputs, wins the actual game** (solver and game agree), including a coins+wall fixture; an unsolvable level (a coin sealed inside a wall) is rejected with `reachableCoins == 0` and `unreachableObjectives == 1`; and the JSON gating entry point works.

## Notes

Header-only, std-only, deterministic. Registered under the `headless` CTest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_