### PR TITLE
Doodle: shareable spectator replays with deterministic playback (#317)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,6 +739,12 @@ add_executable(test_ghost_race
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ghost_race.cpp
 )
 
+# Shareable spectator replays: content-verified run/match codec + deterministic
+# per-tick playback (single run and versus) (#317) - header-only.
+add_executable(test_replay
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_replay.cpp
+)
+
 # Audio decode core: robust WAV/PCM parser + tone generator (#258) - header-only.
 add_executable(test_audio_decode
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_audio_decode.cpp
@@ -1021,6 +1027,7 @@ set(HEADLESS_TESTS
     test_quest_gen
     test_rectify
     test_render_pass_graph
+    test_replay
     test_rollback
     test_scene_author
     test_scene_hierarchy

--- a/src/game/Replay.h
+++ b/src/game/Replay.h
@@ -1,0 +1,235 @@
+#pragma once
+
+#include "game/GhostReplay.h" // detail codec helpers (putLE/getLE, base64, traceCodeFor), shareCodeFor
+#include "game/Versus.h"      // MatchRecord, replayVersus
+#include "game/Leaderboard.h" // RunTrace, replayRun
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/**
+ * @file Replay.h
+ * @brief Shareable spectator replays with deterministic playback (issue #317).
+ *
+ * Leaderboards (#242) and ghosts (#272) already share a single run's input trace, and
+ * versus (#293) makes a verifiable MatchRecord - but there was no compact, shareable
+ * codec for a *match*, and no player that re-simulates a run or a match exposing every
+ * player's per-tick state. This adds both, so a run or a versus match can be packaged
+ * as one self-contained string that anyone can play back deterministically.
+ *
+ *   - A Replay bundles the level, the fixed dt, one input trace per player (1 = single
+ *     run, 2 = versus), and the claimed result.
+ *   - encodeReplay/decodeReplay: a content-verified share string "DDR1:<levelCode>:
+ *     <payloadCode>:<base64url(payload)>", reusing the ghost/leaderboard share-code
+ *     helpers. The level is embedded so the replay is self-contained; decode rejects a
+ *     bad prefix, corrupt base64, a payload that does not match its hash (tamper), or a
+ *     level whose recomputed code disagrees with the embedded one.
+ *   - verifyReplay: re-simulates with replayRun / replayVersus and rejects a replay
+ *     whose traces do not reproduce its claimed result.
+ *   - ReplayPlayer: re-simulates at the fixed dt, exposing each player's DungeonGame
+ *     per tick (single run and versus).
+ *
+ * Pure std, header-only, no wall clock, deterministic.
+ */
+namespace IKore {
+namespace game {
+
+/// A self-contained, replayable record of a run (1 trace) or a match (2 traces).
+struct Replay {
+    std::string levelJson;
+    double dt{1.0 / 60.0};
+    std::vector<std::vector<GameInput>> traces; ///< one input trace per player.
+    int claimedWinner{-1};                       ///< versus: winner index; single run: 0 = claimed clear, -1 = none.
+};
+
+/// Package a single run (a leaderboard/ghost trace) as a replay; the claim is set from
+/// a deterministic re-simulation so a legit run round-trips through verifyReplay.
+inline Replay makeRunReplay(const std::string& levelJson, const RunTrace& trace) {
+    Replay r;
+    r.levelJson = levelJson;
+    r.dt = trace.dt;
+    r.traces.push_back(trace.inputs);
+    r.claimedWinner = replayRun(levelJson, trace).won ? 0 : -1;
+    return r;
+}
+
+/// Package a finished versus match (its MatchRecord) as a replay.
+inline Replay makeVersusReplay(const MatchRecord& rec) {
+    Replay r;
+    r.levelJson = rec.levelJson;
+    r.dt = rec.dt;
+    r.traces.push_back(rec.inputs0);
+    r.traces.push_back(rec.inputs1);
+    r.claimedWinner = rec.claimedWinner;
+    return r;
+}
+
+/// Re-simulate a replay and confirm it reproduces its claimed result.
+inline bool verifyReplay(const Replay& r) {
+    if (r.traces.size() >= 2) {
+        const VersusResult vr =
+            replayVersus(r.levelJson, static_cast<float>(r.dt), r.traces[0], r.traces[1]);
+        return vr.decided && vr.winner == r.claimedWinner;
+    }
+    if (r.traces.size() == 1) {
+        RunTrace t;
+        t.dt = r.dt;
+        t.inputs = r.traces[0];
+        return replayRun(r.levelJson, t).won == (r.claimedWinner == 0);
+    }
+    return false;
+}
+
+namespace detail {
+
+inline std::string serializeReplay(const Replay& r) {
+    std::string p;
+    putLE64(p, doubleBits(r.dt));
+    putLE32(p, static_cast<std::uint32_t>(r.claimedWinner)); // two's-complement, round-trips
+    putLE32(p, static_cast<std::uint32_t>(r.traces.size()));
+    putLE32(p, static_cast<std::uint32_t>(r.levelJson.size()));
+    p += r.levelJson;
+    for (const std::vector<GameInput>& tr : r.traces) {
+        putLE32(p, static_cast<std::uint32_t>(tr.size()));
+        for (const GameInput& in : tr) {
+            putLE32(p, floatBits(in.moveX));
+            putLE32(p, floatBits(in.moveZ));
+        }
+    }
+    return p;
+}
+
+/// Bounds-checked inverse of serializeReplay. Rejects any payload whose declared sizes
+/// run past the buffer, so a truncated/tampered payload cannot over-read or over-alloc.
+inline bool deserializeReplay(const std::string& p, Replay& out) {
+    std::size_t i = 0;
+    auto need = [&](std::size_t n) { return i + n <= p.size(); };
+    if (!need(8)) return false;
+    out.dt = bitsDouble(getLE64(p, i));
+    if (!need(4)) return false;
+    out.claimedWinner = static_cast<int>(getLE32(p, i));
+    if (!need(4)) return false;
+    const std::uint32_t nTraces = getLE32(p, i);
+    if (!need(4)) return false;
+    const std::uint32_t levelLen = getLE32(p, i);
+    if (!need(levelLen)) return false;
+    out.levelJson.assign(p, i, levelLen);
+    i += levelLen;
+    if (nTraces > 8) return false; // sanity cap (max supported players)
+    out.traces.clear();
+    for (std::uint32_t t = 0; t < nTraces; ++t) {
+        if (!need(4)) return false;
+        const std::uint32_t count = getLE32(p, i);
+        if (!need(static_cast<std::size_t>(count) * 8)) return false;
+        std::vector<GameInput> tr;
+        tr.reserve(count);
+        for (std::uint32_t k = 0; k < count; ++k) {
+            GameInput in;
+            in.moveX = bitsFloat(getLE32(p, i));
+            in.moveZ = bitsFloat(getLE32(p, i));
+            tr.push_back(in);
+        }
+        out.traces.push_back(std::move(tr));
+    }
+    return i == p.size(); // no trailing garbage
+}
+
+/// Content code over a replay payload (distinct namespace tag from ghost traces).
+inline std::string replayCodeFor(const std::string& payload) {
+    return "DR-" + base32Crockford(fnv1a64(payload), 13);
+}
+
+} // namespace detail
+
+/// The frozen wire prefix for a replay share string.
+inline const std::string& replaySharePrefix() {
+    static const std::string p = "DDR1:";
+    return p;
+}
+
+/// Encode a replay as a content-verified, self-contained share string.
+inline std::string encodeReplay(const Replay& r) {
+    const std::string payload = detail::serializeReplay(r);
+    return replaySharePrefix() + shareCodeFor(r.levelJson) + ":" + detail::replayCodeFor(payload) + ":" +
+           detail::base64Encode(payload);
+}
+
+/// Decode a replay share string. Returns false on a bad prefix/structure, invalid
+/// base64, a payload that does not match its content code, or an embedded level whose
+/// recomputed share code disagrees (tamper). On success @p out is byte-faithful.
+inline bool decodeReplay(const std::string& share, Replay& out) {
+    const std::string& prefix = replaySharePrefix();
+    if (share.size() <= prefix.size() || share.compare(0, prefix.size(), prefix) != 0) return false;
+    const std::size_t p1 = share.find(':', prefix.size());
+    if (p1 == std::string::npos) return false;
+    const std::size_t p2 = share.find(':', p1 + 1);
+    if (p2 == std::string::npos) return false;
+
+    const std::string levelCode = share.substr(prefix.size(), p1 - prefix.size());
+    const std::string payloadCode = share.substr(p1 + 1, p2 - (p1 + 1));
+    const std::string payloadB64 = share.substr(p2 + 1);
+
+    std::string payload;
+    if (!detail::base64Decode(payloadB64, payload)) return false;
+    if (detail::replayCodeFor(payload) != payloadCode) return false; // integrity
+    Replay r;
+    if (!detail::deserializeReplay(payload, r)) return false;
+    if (shareCodeFor(r.levelJson) != levelCode) return false; // level binding integrity
+    out = std::move(r);
+    return true;
+}
+
+/**
+ * @brief Re-simulate a replay at its fixed dt, exposing each player's game per tick.
+ *
+ * One DungeonGame per trace, loaded from the embedded level. step() advances every
+ * still-playing game by its recorded input for the current tick; a game that runs out
+ * of inputs or ends just stops advancing. Deterministic, so the per-tick state stream
+ * reproduces the original run/match exactly on any device.
+ */
+class ReplayPlayer {
+public:
+    explicit ReplayPlayer(const Replay& replay) : m_replay(replay) {
+        LevelSpec spec;
+        if (!fromLevelJson(replay.levelJson, spec) || replay.traces.empty()) return;
+        const DungeonGame base = loadGame(convert(spec));
+        m_games.assign(replay.traces.size(), base);
+        for (const std::vector<GameInput>& tr : replay.traces)
+            m_maxTicks = tr.size() > m_maxTicks ? tr.size() : m_maxTicks;
+        m_valid = true;
+    }
+
+    bool valid() const { return m_valid; }
+    int players() const { return static_cast<int>(m_games.size()); }
+    std::size_t tick() const { return m_tick; }
+    const DungeonGame& game(int player) const { return m_games[static_cast<std::size_t>(player)]; }
+
+    /// True once every tick has been played (or the replay was invalid).
+    bool finished() const { return !m_valid || m_tick >= m_maxTicks; }
+
+    /// Advance one tick: apply each player's input for this tick. Returns false at end.
+    bool step() {
+        if (finished()) return false;
+        for (std::size_t p = 0; p < m_games.size(); ++p) {
+            const std::vector<GameInput>& tr = m_replay.traces[p];
+            if (m_games[p].status == GameStatus::Playing && m_tick < tr.size())
+                m_games[p].update(tr[m_tick], static_cast<float>(m_replay.dt));
+        }
+        ++m_tick;
+        return true;
+    }
+
+    /// Run to the end.
+    void playToEnd() { while (step()) {} }
+
+private:
+    Replay m_replay;
+    std::vector<DungeonGame> m_games;
+    std::size_t m_tick{0};
+    std::size_t m_maxTicks{0};
+    bool m_valid{false};
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_replay.cpp
+++ b/tests/test_replay.cpp
@@ -1,0 +1,130 @@
+// Test for shareable spectator replays - issue #317.
+//
+// Verifies: a single run and a 2-player versus match each package into a compact,
+// content-verified share string that round-trips (encode/decode/re-sim) to the identical
+// outcome; a tampered share string is rejected on decode; a replay whose claim does not
+// re-simulate is rejected by verifyReplay; and ReplayPlayer reproduces per-tick state for
+// both single run and versus. Pure std + the header-only game:
+//   g++ -std=c++17 -I src tests/test_replay.cpp -o test_replay
+
+#include "game/Replay.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// Play +X until the game is won (or capped) to synthesize a real winning trace.
+static std::vector<game::GameInput> winTrace(const game::LevelSpec& spec, float dt) {
+    game::DungeonGame g = game::loadGame(game::convert(spec));
+    std::vector<game::GameInput> ins;
+    for (int i = 0; i < 600 && g.status == game::GameStatus::Playing; ++i) {
+        const game::GameInput in{1.0f, 0.0f};
+        g.update(in, dt);
+        ins.push_back(in);
+    }
+    return ins;
+}
+
+int main() {
+    const float dt = 1.0f / 60.0f;
+
+    // A trivial level: player at origin, exit to the +X, no coins.
+    game::LevelSpec spec;
+    spec.symbols.push_back(game::Symbol{"player", ecs::Vec3{0.0f, 0.0f, 0.0f}, 0.0f});
+    spec.symbols.push_back(game::Symbol{"exit", ecs::Vec3{3.0f, 0.0f, 0.0f}, 0.0f});
+    const std::string level = game::toLevelJson(spec);
+
+    const std::vector<game::GameInput> winner = winTrace(spec, dt);
+    CHECK(!winner.empty());
+
+    // --- Single-run replay -----------------------------------------------------
+    game::RunTrace rt;
+    rt.dt = dt;
+    rt.inputs = winner;
+    const game::Replay runReplay = game::makeRunReplay(level, rt);
+    CHECK(runReplay.traces.size() == 1);
+    CHECK(runReplay.claimedWinner == 0); // it is a winning run
+    CHECK(game::verifyReplay(runReplay));
+
+    const std::string runShare = game::encodeReplay(runReplay);
+    game::Replay runDecoded;
+    CHECK(game::decodeReplay(runShare, runDecoded));
+    CHECK(runDecoded.traces.size() == 1 && runDecoded.traces[0].size() == winner.size());
+    CHECK(runDecoded.dt == runReplay.dt && runDecoded.claimedWinner == 0);
+    CHECK(game::verifyReplay(runDecoded));
+
+    // Re-simulate anywhere -> identical outcome.
+    game::ReplayPlayer rp(runDecoded);
+    CHECK(rp.valid() && rp.players() == 1);
+    rp.playToEnd();
+    CHECK(rp.game(0).won());
+
+    // Tampered share string is rejected on decode (flip a byte in the base64 payload).
+    std::string tampered = runShare;
+    tampered[tampered.size() - 3] = (tampered[tampered.size() - 3] == 'A') ? 'B' : 'A';
+    game::Replay junk;
+    CHECK(!game::decodeReplay(tampered, junk));
+
+    // A replay whose claim does not re-simulate is rejected.
+    game::Replay lyingRun = runReplay;
+    lyingRun.claimedWinner = -1; // claims "did not clear" but it did
+    CHECK(!game::verifyReplay(lyingRun));
+
+    // --- Versus replay ---------------------------------------------------------
+    std::vector<game::GameInput> loser(winner.size(), game::GameInput{0.0f, 0.0f}); // stands still
+    game::MatchRecord rec;
+    rec.levelJson = level;
+    rec.dt = dt;
+    rec.inputs0 = winner;
+    rec.inputs1 = loser;
+    rec.claimedWinner = 0;
+    game::VersusResult vr;
+    CHECK(game::verifyMatch(rec, vr)); // sanity: player 0 wins
+
+    const game::Replay matchReplay = game::makeVersusReplay(rec);
+    CHECK(matchReplay.traces.size() == 2);
+    CHECK(game::verifyReplay(matchReplay));
+
+    const std::string matchShare = game::encodeReplay(matchReplay);
+    game::Replay matchDecoded;
+    CHECK(game::decodeReplay(matchShare, matchDecoded));
+    CHECK(matchDecoded.traces.size() == 2);
+    CHECK(matchDecoded.claimedWinner == 0);
+    CHECK(game::verifyReplay(matchDecoded));
+
+    game::ReplayPlayer mp(matchDecoded);
+    CHECK(mp.valid() && mp.players() == 2);
+    mp.playToEnd();
+    CHECK(mp.game(0).won());
+    CHECK(!mp.game(1).won());
+
+    // Tampering the claimed winner makes verification fail.
+    game::Replay lyingMatch = matchDecoded;
+    lyingMatch.claimedWinner = 1;
+    CHECK(!game::verifyReplay(lyingMatch));
+
+    // Determinism: two independent players reach the same final coins/status.
+    game::ReplayPlayer mp2(matchDecoded);
+    mp2.playToEnd();
+    CHECK(mp2.game(0).won() == mp.game(0).won());
+    CHECK(mp2.game(1).coinsCollected == mp.game(1).coinsCollected);
+
+    if (g_failures == 0) {
+        std::printf("test_replay: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_replay: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #317. Leaderboards (#242) and ghosts (#272) already share a single run's input trace, and versus (#293) makes a verifiable `MatchRecord` - but there was no compact, shareable codec for a *match*, and no player that re-simulates a run or match exposing every player's per-tick state.

## What this does

New header-only `src/game/Replay.h`:

- `Replay` bundles the level, fixed `dt`, one input trace per player (1 = single run, 2 = versus), and the claimed result. `makeRunReplay` / `makeVersusReplay` build it from a `RunTrace` / `MatchRecord`.
- `encodeReplay` / `decodeReplay`: a content-verified share string `DDR1:<levelCode>:<payloadCode>:<base64url(payload)>`, reusing the ghost/leaderboard share-code helpers. The level is embedded so the replay is self-contained; decode rejects a bad prefix, corrupt base64, a payload that does not match its hash (tamper), or a level whose recomputed code disagrees.
- `verifyReplay` re-simulates via `replayRun` / `replayVersus` and rejects a replay whose traces do not reproduce its claimed result.
- `ReplayPlayer` re-simulates at the fixed `dt`, exposing each player's `DungeonGame` per tick (single run and versus).

## Tests

`test_replay` (headless): a single run and a 2-player versus match each round-trip (encode/decode/re-sim) to the identical outcome; a tampered share string is rejected on decode; a lying claim is rejected by `verifyReplay`; and `ReplayPlayer` reproduces per-tick state deterministically for both single run and versus.

## Notes

Header-only, dependency-free, registered under the `headless` CTest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_