### PR TITLE
Doodlebound: keys, locked doors, switches, and hazards (#319)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,6 +613,11 @@ add_executable(test_dungeon_game
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dungeon_game.cpp
 )
 
+# Keys, locked doors, switches, and hazards over the dungeon loop (#319) - header-only.
+add_executable(test_dungeon_features
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dungeon_features.cpp
+)
+
 # GeoJSON/OSM map data -> playable DungeonGame world (#313) - header-only.
 add_executable(test_city_game
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_city_game.cpp
@@ -999,6 +1004,7 @@ set(HEADLESS_TESTS
     test_doodle_library
     test_doodle_rollback
     test_doodle_scene
+    test_dungeon_features
     test_dungeon_game
     test_ecs_benchmark
     test_ecs_query

--- a/src/game/DungeonGame.h
+++ b/src/game/DungeonGame.h
@@ -3,6 +3,7 @@
 #include "game/DoodleScene.h"
 
 #include <cmath>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
@@ -47,6 +48,43 @@ struct Enemy {
     ecs::Vec3 position{};
 };
 
+// --- Optional richer drawable semantics (issue #319) -------------------------
+// All of these are absent from a classic level, so a level with none of them
+// plays byte-identically to the original move/collect/avoid/exit loop.
+
+/// A collectible key; collecting it opens every LockedDoor with the same @c id.
+struct Key {
+    ecs::Vec3 position{};
+    int id{0};
+    bool collected{false};
+};
+
+/// A door that blocks movement until a key of the same @c id is collected.
+struct LockedDoor {
+    world::Box box;
+    int id{0};
+    bool open{false};
+};
+
+/// A momentary switch; entering it toggles every ToggleWall with the same @c id.
+struct Switch {
+    ecs::Vec3 position{};
+    int id{0};
+    bool wasPressed{false};
+};
+
+/// A wall that a Switch flips between solid (blocks) and open.
+struct ToggleWall {
+    world::Box box;
+    int id{0};
+    bool solid{true};
+};
+
+/// A static hazard; touching it is a loss.
+struct Hazard {
+    ecs::Vec3 position{};
+};
+
 /// A self-contained, headless dungeon game built from a converted scene.
 struct DungeonGame {
     // Geometry + actors (populated by loadGame).
@@ -57,6 +95,13 @@ struct DungeonGame {
     ecs::Vec3 exitPosition{};
     bool hasExit{false};
 
+    // Optional richer semantics (#319); empty on a classic level.
+    std::vector<Key> keys;
+    std::vector<LockedDoor> lockedDoors;
+    std::vector<Switch> switches;
+    std::vector<ToggleWall> toggleWalls;
+    std::vector<Hazard> hazards;
+
     // Tunables.
     float playerSpeed{4.0f};
     float enemySpeed{2.0f};
@@ -64,6 +109,10 @@ struct DungeonGame {
     float enemyRadius{0.4f};
     float coinRadius{0.4f};
     float exitRadius{0.6f};
+    float keyRadius{0.4f};
+    float switchRadius{0.5f};
+    float hazardRadius{0.4f};
+    float featureSize{1.0f}; ///< footprint of a spawned locked door / toggle wall.
 
     // Runtime.
     GameStatus status{GameStatus::Playing};
@@ -100,6 +149,35 @@ struct DungeonGame {
             }
         }
 
+        // Key pickup opens every locked door of the same id (#319).
+        for (Key& k : keys) {
+            if (!k.collected && within(playerPosition, k.position, playerRadius + keyRadius)) {
+                k.collected = true;
+                for (LockedDoor& d : lockedDoors) {
+                    if (d.id == k.id) d.open = true;
+                }
+            }
+        }
+
+        // A switch toggles its linked walls once per press (rising edge) (#319).
+        for (Switch& sw : switches) {
+            const bool pressed = within(playerPosition, sw.position, playerRadius + switchRadius);
+            if (pressed && !sw.wasPressed) {
+                for (ToggleWall& w : toggleWalls) {
+                    if (w.id == sw.id) w.solid = !w.solid;
+                }
+            }
+            sw.wasPressed = pressed;
+        }
+
+        // Hazard contact is a loss (#319).
+        for (const Hazard& h : hazards) {
+            if (within(playerPosition, h.position, playerRadius + hazardRadius)) {
+                status = GameStatus::Lost;
+                return;
+            }
+        }
+
         // Enemies chase the player; contact is a loss.
         for (Enemy& e : enemies) {
             const float dx = playerPosition.x - e.position.x;
@@ -130,6 +208,19 @@ struct DungeonGame {
         return false;
     }
 
+    /// True if movement is blocked here: a static wall, a still-locked door, or a solid
+    /// toggle wall (#319). Equals hitsWall() on a classic level (no doors/toggle walls).
+    bool blocked(const ecs::Vec3& pos, float radius) const {
+        if (hitsWall(pos, radius)) return true;
+        for (const LockedDoor& d : lockedDoors) {
+            if (!d.open && circleHitsBox(pos, radius, d.box)) return true;
+        }
+        for (const ToggleWall& w : toggleWalls) {
+            if (w.solid && circleHitsBox(pos, radius, w.box)) return true;
+        }
+        return false;
+    }
+
 private:
     static bool within(const ecs::Vec3& a, const ecs::Vec3& b, float radius) {
         const float dx = a.x - b.x, dz = a.z - b.z;
@@ -155,33 +246,74 @@ private:
     /// Move from @p from by (dx,dz), sliding along whichever axis stays clear.
     ecs::Vec3 slideMove(const ecs::Vec3& from, float dx, float dz, float radius) const {
         const ecs::Vec3 full{from.x + dx, from.y, from.z + dz};
-        if (!hitsWall(full, radius)) return full;
+        if (!blocked(full, radius)) return full;
         const ecs::Vec3 xOnly{from.x + dx, from.y, from.z};
-        if (!hitsWall(xOnly, radius)) return xOnly;
+        if (!blocked(xOnly, radius)) return xOnly;
         const ecs::Vec3 zOnly{from.x, from.y, from.z + dz};
-        if (!hitsWall(zOnly, radius)) return zOnly;
+        if (!blocked(zOnly, radius)) return zOnly;
         return from; // fully blocked this step
     }
 };
 
+namespace detail {
+
+/// Split a spawn type into its base name and optional "@id" link group (#319). A plain
+/// type with no "@" yields id 0, so classic spawns ("player", "coin", ...) are unchanged.
+inline std::string featureBase(const std::string& type, int& id) {
+    const std::size_t at = type.find('@');
+    if (at == std::string::npos) {
+        id = 0;
+        return type;
+    }
+    id = std::atoi(type.c_str() + at + 1);
+    return type.substr(0, at);
+}
+
+/// A square footprint box for a spawned locked door / toggle wall (collision is XZ-only).
+inline world::Box featureBox(const ecs::Vec3& pos, float yaw, float size) {
+    world::Box b;
+    b.center = ecs::Vec3{pos.x, size * 0.5f, pos.z};
+    b.size = ecs::Vec3{size, size, size};
+    b.yaw = yaw;
+    return b;
+}
+
+} // namespace detail
+
 /**
- * @brief Build a playable game from a converted scene: walls become collision
- *        geometry; "player"/"enemy"/"treasure"(or "coin")/"door"(or "exit")
- *        spawns become the player, enemies, coins, and exit.
+ * @brief Build a playable game from a converted scene: walls become collision geometry;
+ *        "player"/"enemy"/"treasure"(or "coin")/"door"(or "exit") spawns become the
+ *        player, enemies, coins, and exit. Optionally (#319) "key"/"lock"/"switch"/
+ *        "toggle"/"hazard" spawns (each with an optional "@id" link) add richer rules; a
+ *        scene with none of these produces exactly the classic game.
  */
 inline DungeonGame loadGame(const SceneDescription& scene) {
     DungeonGame game;
     game.walls = scene.wallBoxes;
     for (const EntitySpawn& s : scene.spawns) {
-        if (s.type == "player") {
+        int id = 0;
+        const std::string base = detail::featureBase(s.type, id);
+        if (base == "player") {
             game.playerPosition = s.position;
-        } else if (s.type == "enemy") {
+        } else if (base == "enemy") {
             game.enemies.push_back(Enemy{s.position});
-        } else if (s.type == "treasure" || s.type == "coin") {
+        } else if (base == "treasure" || base == "coin") {
             game.coins.push_back(Coin{s.position, false});
-        } else if (s.type == "door" || s.type == "exit") {
+        } else if (base == "door" || base == "exit") {
             game.exitPosition = s.position;
             game.hasExit = true;
+        } else if (base == "key") {
+            game.keys.push_back(Key{s.position, id, false});
+        } else if (base == "lock" || base == "lockeddoor") {
+            game.lockedDoors.push_back(
+                LockedDoor{detail::featureBox(s.position, s.yaw, game.featureSize), id, false});
+        } else if (base == "switch") {
+            game.switches.push_back(Switch{s.position, id, false});
+        } else if (base == "toggle" || base == "togglewall") {
+            game.toggleWalls.push_back(
+                ToggleWall{detail::featureBox(s.position, s.yaw, game.featureSize), id, true});
+        } else if (base == "hazard" || base == "spike") {
+            game.hazards.push_back(Hazard{s.position});
         }
     }
     game.totalCoins = static_cast<int>(game.coins.size());

--- a/tests/test_dungeon_features.cpp
+++ b/tests/test_dungeon_features.cpp
@@ -1,0 +1,135 @@
+// Test for keys, locked doors, switches, and hazards - issue #319.
+//
+// Verifies each new rule on fixture corridors: a locked door blocks until its key is
+// collected; a solid toggle wall blocks until its switch is pressed; a hazard is a loss on
+// contact; and a level with none of the new types plays exactly as the classic game. Pure
+// std + the header-only game:
+//   g++ -std=c++17 -I src tests/test_dungeon_features.cpp -o test_dungeon_features
+
+#include "game/DungeonGame.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static EntitySpawn sp(const char* t, float x, float z) {
+    return EntitySpawn{t, ecs::Vec3{x, 0.0f, z}, 0.0f};
+}
+
+// Two long walls forming a 1-wide corridor along +X at z=0, x in [-2, 8].
+static std::vector<world::Box> corridor() {
+    world::Box top, bot;
+    top.center = ecs::Vec3{3.0f, 0.0f, 1.0f};
+    top.size = ecs::Vec3{10.0f, 1.0f, 0.4f};
+    bot.center = ecs::Vec3{3.0f, 0.0f, -1.0f};
+    bot.size = ecs::Vec3{10.0f, 1.0f, 0.4f};
+    return {top, bot};
+}
+
+static void drive(DungeonGame& g, float mx, float mz, int steps) {
+    const float dt = 1.0f / 60.0f;
+    for (int i = 0; i < steps && g.status == GameStatus::Playing; ++i) g.update(GameInput{mx, mz}, dt);
+}
+
+int main() {
+    // --- Locked door blocks without its key --------------------------------------
+    {
+        SceneDescription s;
+        s.wallBoxes = corridor();
+        s.spawns = {sp("player", 0, 0), sp("exit", 6, 0), sp("lock@1", 3, 0)};
+        DungeonGame g = loadGame(s);
+        CHECK(g.lockedDoors.size() == 1 && !g.lockedDoors[0].open);
+        CHECK(g.blocked(ecs::Vec3{3, 0, 0}, 0.4f));   // the door blocks
+        CHECK(!g.hitsWall(ecs::Vec3{3, 0, 0}, 0.4f)); // but it is not a static wall
+        drive(g, 1.0f, 0.0f, 600);
+        CHECK(!g.won());                 // cannot pass the locked door
+        CHECK(g.playerPosition.x < 2.5f); // stuck in front of it
+    }
+
+    // --- Key opens its door, level clears ----------------------------------------
+    {
+        SceneDescription s;
+        s.wallBoxes = corridor();
+        s.spawns = {sp("player", 0, 0), sp("exit", 6, 0), sp("lock@1", 3, 0), sp("key@1", 1, 0)};
+        DungeonGame g = loadGame(s);
+        drive(g, 1.0f, 0.0f, 600);
+        CHECK(g.keys.size() == 1 && g.keys[0].collected); // grabbed en route
+        CHECK(g.lockedDoors[0].open);                      // which opened the door
+        CHECK(g.won());
+    }
+
+    // --- Non-matching key does not open the door ---------------------------------
+    {
+        SceneDescription s;
+        s.wallBoxes = corridor();
+        s.spawns = {sp("player", 0, 0), sp("exit", 6, 0), sp("lock@1", 3, 0), sp("key@2", 1, 0)};
+        DungeonGame g = loadGame(s);
+        drive(g, 1.0f, 0.0f, 600);
+        CHECK(g.keys[0].collected);       // key@2 is picked up
+        CHECK(!g.lockedDoors[0].open);    // but it does not open door@1
+        CHECK(!g.won());
+    }
+
+    // --- Solid toggle wall blocks; its switch opens it ---------------------------
+    {
+        SceneDescription blockOnly;
+        blockOnly.wallBoxes = corridor();
+        blockOnly.spawns = {sp("player", 0, 0), sp("exit", 6, 0), sp("toggle@1", 3, 0)};
+        DungeonGame gb = loadGame(blockOnly);
+        CHECK(gb.toggleWalls.size() == 1 && gb.toggleWalls[0].solid);
+        drive(gb, 1.0f, 0.0f, 600);
+        CHECK(!gb.won());
+
+        SceneDescription withSwitch;
+        withSwitch.wallBoxes = corridor();
+        withSwitch.spawns = {sp("player", 0, 0), sp("exit", 6, 0), sp("toggle@1", 3, 0), sp("switch@1", 1, 0)};
+        DungeonGame gs = loadGame(withSwitch);
+        drive(gs, 1.0f, 0.0f, 600);
+        CHECK(!gs.toggleWalls[0].solid); // the switch toggled it open (once, on the rising edge)
+        CHECK(gs.won());
+    }
+
+    // --- Hazard contact is a loss ------------------------------------------------
+    {
+        SceneDescription s;
+        s.spawns = {sp("player", 0, 0), sp("exit", 6, 0), sp("hazard", 3, 0)};
+        DungeonGame g = loadGame(s);
+        CHECK(g.hazards.size() == 1);
+        drive(g, 1.0f, 0.0f, 600);
+        CHECK(g.lost());
+        CHECK(!g.won());
+    }
+
+    // --- Byte-identical: a classic level with no new types plays as before -------
+    {
+        SceneDescription s;
+        s.spawns = {sp("player", 0, 0), sp("coin", 2, 0), sp("exit", 4, 0)};
+        DungeonGame g = loadGame(s);
+        CHECK(g.keys.empty() && g.lockedDoors.empty() && g.switches.empty());
+        CHECK(g.toggleWalls.empty() && g.hazards.empty());
+        CHECK(g.blocked(ecs::Vec3{0, 0, 0}, 0.4f) == g.hitsWall(ecs::Vec3{0, 0, 0}, 0.4f));
+        drive(g, 1.0f, 0.0f, 600);
+        CHECK(g.coinsCollected == 1);
+        CHECK(g.won());
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_dungeon_features: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_dungeon_features: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #319. DungeonGame (#164) is move / collect-coins / avoid-enemy / reach-exit. This deepens the loop with four small deterministic rules, each a drawable semantic decoded from the scene.

## What this does

New spawn types (each with an optional `@id` link group), decoded by `loadGame`:

- `key@id` - collectible; collecting it opens every `lock@id` (locked door).
- `lock@id` / `lockeddoor@id` - blocks movement until a key of the same id is collected.
- `switch@id` - toggles every `toggle@id` once per press (rising edge).
- `toggle@id` / `togglewall@id` - a wall that a switch flips between solid and open.
- `hazard` / `spike` - touching it is a loss.

Movement now routes through `blocked()` (static walls + still-locked doors + solid toggle walls), which equals `hitsWall()` when none of the new types are present. `loadGame` adds these entities only for the new type strings, so **a classic level plays byte-identically**.

## Tests

`test_dungeon_features` (headless): a locked door blocks until its matching key is collected (a non-matching key does not open it); a solid toggle wall blocks until its switch is pressed; a hazard is a loss on contact; and a level with no new types clears exactly as before. The **full 81-test headless suite stays green** (this touches the shared `DungeonGame` core).

## Notes

Header-only, std only, deterministic. Registered under the `headless` CTest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_