### PR TITLE
Doodlebound: enemy behaviors (patrol, flee, ranged) via selectable AI (#320)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,6 +618,11 @@ add_executable(test_dungeon_features
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dungeon_features.cpp
 )
 
+# Selectable enemy behaviors: patrol / flee / ranged, default chase (#320) - header-only.
+add_executable(test_enemy_behaviors
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_enemy_behaviors.cpp
+)
+
 # GeoJSON/OSM map data -> playable DungeonGame world (#313) - header-only.
 add_executable(test_city_game
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_city_game.cpp
@@ -1009,6 +1014,7 @@ set(HEADLESS_TESTS
     test_ecs_benchmark
     test_ecs_query
     test_ecs_systems
+    test_enemy_behaviors
     test_entity_inspector
     test_file_watcher
     test_frame_graph

--- a/src/game/DungeonGame.h
+++ b/src/game/DungeonGame.h
@@ -2,6 +2,7 @@
 
 #include "game/DoodleScene.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <string>
@@ -44,8 +45,25 @@ struct Coin {
     bool collected{false};
 };
 
+/// Selectable enemy behavior (#320). Chase is the default and reproduces the
+/// original single chaser byte-for-byte.
+enum class EnemyBehavior { Chase, Patrol, Flee, Ranged };
+
 struct Enemy {
     ecs::Vec3 position{};
+    EnemyBehavior behavior{EnemyBehavior::Chase};
+    ecs::Vec3 home{};        ///< anchor for patrol (oscillates around it).
+    int patrolAxis{0};       ///< 0 = X, 1 = Z.
+    int patrolDir{1};        ///< current patrol direction (+1 / -1).
+    float patrolRange{3.0f}; ///< patrol amplitude around home.
+    float fireCooldown{0.0f};///< ranged: seconds until the next shot.
+};
+
+/// A projectile fired by a Ranged enemy; contact is a loss (#320).
+struct Projectile {
+    ecs::Vec3 position{};
+    ecs::Vec3 velocity{};
+    float life{0.0f};
 };
 
 // --- Optional richer drawable semantics (issue #319) -------------------------
@@ -102,6 +120,9 @@ struct DungeonGame {
     std::vector<ToggleWall> toggleWalls;
     std::vector<Hazard> hazards;
 
+    // Live ranged-enemy projectiles (#320); empty unless a Ranged enemy has fired.
+    std::vector<Projectile> projectiles;
+
     // Tunables.
     float playerSpeed{4.0f};
     float enemySpeed{2.0f};
@@ -113,6 +134,10 @@ struct DungeonGame {
     float switchRadius{0.5f};
     float hazardRadius{0.4f};
     float featureSize{1.0f}; ///< footprint of a spawned locked door / toggle wall.
+    float projectileSpeed{6.0f};      ///< ranged projectile speed.
+    float projectileRadius{0.25f};    ///< projectile hit radius.
+    float rangedFireInterval{1.0f};   ///< seconds between ranged shots.
+    float projectileLife{3.0f};       ///< projectile lifetime before it expires.
 
     // Runtime.
     GameStatus status{GameStatus::Playing};
@@ -178,20 +203,77 @@ struct DungeonGame {
             }
         }
 
-        // Enemies chase the player; contact is a loss.
+        // Enemies act by behavior (#320); direct contact is always a loss. The default
+        // Chase branch is the original chaser, so a classic enemy is byte-identical.
         for (Enemy& e : enemies) {
-            const float dx = playerPosition.x - e.position.x;
-            const float dz = playerPosition.z - e.position.z;
-            const float d = std::sqrt(dx * dx + dz * dz);
-            if (d > 1e-6f) {
-                const float step = enemySpeed * dt;
-                e.position = slideMove(e.position, (dx / d) * step, (dz / d) * step, enemyRadius);
+            switch (e.behavior) {
+                case EnemyBehavior::Chase: {
+                    const float dx = playerPosition.x - e.position.x;
+                    const float dz = playerPosition.z - e.position.z;
+                    const float d = std::sqrt(dx * dx + dz * dz);
+                    if (d > 1e-6f) {
+                        const float step = enemySpeed * dt;
+                        e.position = slideMove(e.position, (dx / d) * step, (dz / d) * step, enemyRadius);
+                    }
+                    break;
+                }
+                case EnemyBehavior::Flee: {
+                    const float dx = e.position.x - playerPosition.x;
+                    const float dz = e.position.z - playerPosition.z;
+                    const float d = std::sqrt(dx * dx + dz * dz);
+                    if (d > 1e-6f) {
+                        const float step = enemySpeed * dt;
+                        e.position = slideMove(e.position, (dx / d) * step, (dz / d) * step, enemyRadius);
+                    }
+                    break;
+                }
+                case EnemyBehavior::Patrol: {
+                    const float step = enemySpeed * dt * static_cast<float>(e.patrolDir);
+                    const float mx = e.patrolAxis == 0 ? step : 0.0f;
+                    const float mz = e.patrolAxis == 1 ? step : 0.0f;
+                    const ecs::Vec3 moved = slideMove(e.position, mx, mz, enemyRadius);
+                    const bool stuck = moved.x == e.position.x && moved.z == e.position.z;
+                    e.position = moved;
+                    const float along = e.patrolAxis == 0 ? (e.position.x - e.home.x) : (e.position.z - e.home.z);
+                    if (std::fabs(along) >= e.patrolRange || stuck) e.patrolDir = -e.patrolDir;
+                    break;
+                }
+                case EnemyBehavior::Ranged: {
+                    e.fireCooldown -= dt;
+                    if (e.fireCooldown <= 0.0f) {
+                        const float dx = playerPosition.x - e.position.x;
+                        const float dz = playerPosition.z - e.position.z;
+                        const float d = std::sqrt(dx * dx + dz * dz);
+                        if (d > 1e-6f) {
+                            projectiles.push_back(Projectile{
+                                e.position,
+                                ecs::Vec3{(dx / d) * projectileSpeed, 0.0f, (dz / d) * projectileSpeed},
+                                projectileLife});
+                        }
+                        e.fireCooldown = rangedFireInterval;
+                    }
+                    break;
+                }
             }
             if (within(playerPosition, e.position, playerRadius + enemyRadius)) {
                 status = GameStatus::Lost;
                 return;
             }
         }
+
+        // Advance projectiles; contact is a loss, and expired ones are removed (#320).
+        for (Projectile& p : projectiles) {
+            p.position.x += p.velocity.x * dt;
+            p.position.z += p.velocity.z * dt;
+            p.life -= dt;
+            if (within(playerPosition, p.position, playerRadius + projectileRadius)) {
+                status = GameStatus::Lost;
+                return;
+            }
+        }
+        projectiles.erase(std::remove_if(projectiles.begin(), projectiles.end(),
+                                         [](const Projectile& p) { return p.life <= 0.0f; }),
+                          projectiles.end());
 
         // Win: every coin collected and standing on the exit.
         if (coinsCollected >= totalCoins && hasExit &&
@@ -295,8 +377,19 @@ inline DungeonGame loadGame(const SceneDescription& scene) {
         const std::string base = detail::featureBase(s.type, id);
         if (base == "player") {
             game.playerPosition = s.position;
-        } else if (base == "enemy") {
-            game.enemies.push_back(Enemy{s.position});
+        } else if (base == "enemy" || base == "enemy_patrol" || base == "enemy_flee" ||
+                   base == "enemy_ranged") {
+            Enemy e;
+            e.position = s.position;
+            e.home = s.position;
+            if (base == "enemy_patrol") {
+                e.behavior = EnemyBehavior::Patrol;
+            } else if (base == "enemy_flee") {
+                e.behavior = EnemyBehavior::Flee;
+            } else if (base == "enemy_ranged") {
+                e.behavior = EnemyBehavior::Ranged;
+            }
+            game.enemies.push_back(e);
         } else if (base == "treasure" || base == "coin") {
             game.coins.push_back(Coin{s.position, false});
         } else if (base == "door" || base == "exit") {

--- a/tests/test_enemy_behaviors.cpp
+++ b/tests/test_enemy_behaviors.cpp
@@ -1,0 +1,110 @@
+// Test for selectable enemy behaviors - issue #320.
+//
+// Verifies each behavior is deterministic and distinct: the default "enemy" chases (and
+// is byte-identical to the original chaser); "enemy_patrol" oscillates around its home
+// without heading for the player; "enemy_flee" moves away; and "enemy_ranged" fires
+// projectiles that are a loss on contact. Pure std + the header-only game:
+//   g++ -std=c++17 -I src tests/test_enemy_behaviors.cpp -o test_enemy_behaviors
+
+#include "game/DungeonGame.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static EntitySpawn sp(const char* t, float x, float z) {
+    return EntitySpawn{t, ecs::Vec3{x, 0.0f, z}, 0.0f};
+}
+static float dist(const ecs::Vec3& a, const ecs::Vec3& b) {
+    const float dx = a.x - b.x, dz = a.z - b.z;
+    return std::sqrt(dx * dx + dz * dz);
+}
+static void drive(DungeonGame& g, float mx, float mz, int steps) {
+    const float dt = 1.0f / 60.0f;
+    for (int i = 0; i < steps && g.status == GameStatus::Playing; ++i) g.update(GameInput{mx, mz}, dt);
+}
+
+int main() {
+    // --- Default enemy chases (behavior is Chase, moves toward the player) --------
+    {
+        SceneDescription s;
+        s.spawns = {sp("player", 0, 0), sp("exit", 20, 20), sp("enemy", 5, 0)};
+        DungeonGame g = loadGame(s);
+        CHECK(g.enemies.size() == 1 && g.enemies[0].behavior == EnemyBehavior::Chase);
+        drive(g, 0.0f, 0.0f, 30); // player stands still; the chaser closes in
+        CHECK(g.enemies[0].position.x < 5.0f);
+    }
+
+    // --- Patrol oscillates around home and ignores the player --------------------
+    {
+        SceneDescription s;
+        s.spawns = {sp("player", 0, 20), sp("exit", 40, 40), sp("enemy_patrol", 5, 0)};
+        DungeonGame g = loadGame(s);
+        CHECK(g.enemies[0].behavior == EnemyBehavior::Patrol);
+        float minX = 5.0f, maxX = 5.0f, maxAbsZ = 0.0f;
+        for (int i = 0; i < 2000 && g.status == GameStatus::Playing; ++i) {
+            g.update(GameInput{}, 1.0f / 60.0f);
+            const ecs::Vec3& p = g.enemies[0].position;
+            minX = std::min(minX, p.x);
+            maxX = std::max(maxX, p.x);
+            maxAbsZ = std::max(maxAbsZ, std::fabs(p.z));
+        }
+        CHECK(minX < 4.0f && maxX > 6.0f);              // swings both ways around home
+        CHECK(minX >= 2.0f - 0.1f && maxX <= 8.0f + 0.1f); // bounded to +-patrolRange
+        CHECK(maxAbsZ < 0.1f);                          // never heads for the player (at z=20)
+    }
+
+    // --- Flee moves away from the player -----------------------------------------
+    {
+        SceneDescription s;
+        s.spawns = {sp("player", 4, 0), sp("exit", 40, 40), sp("enemy_flee", 5, 0)};
+        DungeonGame g = loadGame(s);
+        CHECK(g.enemies[0].behavior == EnemyBehavior::Flee);
+        const float before = dist(g.enemies[0].position, ecs::Vec3{4, 0, 0});
+        drive(g, 0.0f, 0.0f, 60);
+        CHECK(g.enemies[0].position.x > 5.0f);                             // fled +X, away
+        CHECK(dist(g.enemies[0].position, ecs::Vec3{4, 0, 0}) > before);   // distance grew
+    }
+
+    // --- Ranged fires projectiles that are a loss on contact ---------------------
+    auto runRanged = [](int& lostStep) {
+        SceneDescription s;
+        s.spawns = {sp("player", 0, 0), sp("exit", 40, 40), sp("enemy_ranged", 10, 0)};
+        DungeonGame g = loadGame(s);
+        g.update(GameInput{}, 1.0f / 60.0f); // first shot fires immediately (cooldown 0)
+        const bool fired = !g.projectiles.empty();
+        lostStep = -1;
+        for (int i = 1; i < 400 && g.status == GameStatus::Playing; ++i) {
+            g.update(GameInput{}, 1.0f / 60.0f);
+            if (g.lost()) { lostStep = i; break; }
+        }
+        return fired && g.lost();
+    };
+    {
+        int step1 = 0, step2 = 0;
+        CHECK(runRanged(step1));
+        CHECK(runRanged(step2));
+        CHECK(step1 > 0);
+        CHECK(step1 == step2); // deterministic: same step to the hit every run
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_enemy_behaviors: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_enemy_behaviors: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #320. The dungeon enemy was a single deterministic chaser. This gives drawn enemies variety with selectable behaviors, mirroring the engine's AISystem/AIComponent behavior set while keeping the game headless and deterministic.

## What this does

A behavior is decoded from the enemy spawn type:

- `enemy` - chase (the default), the original chaser **verbatim**.
- `enemy_patrol` - oscillates along an axis around its home, bounded by `patrolRange`, reversing at the ends or when blocked.
- `enemy_flee` - moves directly away from the player.
- `enemy_ranged` - holds position and fires a projectile at the player at a fixed cadence; projectile contact is a loss (alongside direct enemy contact). Expired projectiles are culled.

Because the default Chase branch is the original code and all new state is empty for a plain enemy, **levels with only classic enemies play byte-identically**.

## Tests

`test_enemy_behaviors` (headless): chase closes in on a still player; patrol swings bounded around home without ever heading for the player; flee increases distance; and ranged fires a projectile that lands a **deterministic loss on the same step every run**. The **full 82-test headless suite stays green** (this touches the shared `DungeonGame` core).

## Notes

Header-only, std only, no wall clock or RNG, so behaviors are seed/replay stable. Registered under the `headless` CTest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_