### PR TITLE
Engine: wire the deterministic dungeon cores into the live ECS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -629,6 +629,11 @@ add_executable(test_dungeon_features
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dungeon_features.cpp
 )
 
+# DungeonGame -> live ECS runtime bridge (engine wiring) - header-only.
+add_executable(test_dungeon_runtime
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dungeon_runtime.cpp
+)
+
 # Selectable enemy behaviors: patrol / flee / ranged, default chase (#320) - header-only.
 add_executable(test_enemy_behaviors
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_enemy_behaviors.cpp
@@ -898,6 +903,12 @@ add_executable(sample_benchmark_export
     ${CMAKE_CURRENT_SOURCE_DIR}/samples/benchmark_export_demo.cpp
 )
 
+# Doodle cores wired into the live ECS: GeoJSON city -> playable world -> DungeonRuntime
+# spawns/steps ECS entities, validated by the solver. Header-only, no GL context.
+add_executable(sample_doodle_runtime
+    ${CMAKE_CURRENT_SOURCE_DIR}/samples/doodle_runtime_demo.cpp
+)
+
 # Render-pass dependency graph (rendering modernization step 1 / #226) - header-only.
 add_executable(test_render_pass_graph
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_render_pass_graph.cpp
@@ -1022,6 +1033,7 @@ set(HEADLESS_TESTS
     test_doodle_scene
     test_dungeon_features
     test_dungeon_game
+    test_dungeon_runtime
     test_ecs_benchmark
     test_ecs_query
     test_ecs_systems

--- a/samples/doodle_runtime_demo.cpp
+++ b/samples/doodle_runtime_demo.cpp
@@ -1,0 +1,84 @@
+// Sample: the doodle cores wired into the engine's live ECS, end to end and headless.
+//
+// Imports a small neighborhood from GeoJSON, turns it into a playable world (#313),
+// spawns its actors as ECS entities via DungeonRuntime, then drives the deterministic
+// sim toward the exit - printing the live entity transforms and the outcome. It also
+// validates the level up front with the solver (#316). No GL context required.
+//
+// Build (also wired into CMake as sample_doodle_runtime):
+//   g++ -std=c++17 -I src samples/doodle_runtime_demo.cpp -o sample_doodle_runtime
+//   ./sample_doodle_runtime
+
+#include "core/ecs/View.h"
+#include "game/CityGame.h"
+#include "game/DungeonRuntime.h"
+#include "game/Solver.h"
+
+#include <cstdio>
+
+using namespace IKore;
+
+// A tiny OSM-style neighborhood: two roads sharing a node (one intersection) plus a
+// building set off the streets.
+static const char* kNeighborhood = R"JSON({
+  "type": "FeatureCollection",
+  "features": [
+    { "type":"Feature", "properties":{"highway":"residential"},
+      "geometry":{"type":"LineString","coordinates":[[0,0],[0.0004,0]]} },
+    { "type":"Feature", "properties":{"highway":"residential"},
+      "geometry":{"type":"LineString","coordinates":[[0.0004,0],[0.0004,0.0004]]} },
+    { "type":"Feature", "properties":{"building":"yes","height":"10"},
+      "geometry":{"type":"Polygon","coordinates":[[[0.0001,0.0001],[0.0002,0.0001],[0.0002,0.0002],[0.0001,0.0002],[0.0001,0.0001]]]} }
+  ]
+})JSON";
+
+static int taggedCount(ecs::Registry& reg) {
+    int n = 0;
+    reg.view<game::SpawnTag>().each([&](ecs::Entity, game::SpawnTag&) { ++n; });
+    return n;
+}
+
+int main() {
+    const world::City city = world::importString(kNeighborhood, world::GeoImportOptions{});
+    std::printf("Imported city: %zu buildings, %zu roads, %zu intersections\n",
+                city.buildings.size(), city.roads.size(), city.intersections.size());
+
+    game::DungeonRuntime rt(game::loadCityGame(city));
+    std::printf("Playable world: %zu wall boxes, %d coin(s), exit=%s\n", rt.game().walls.size(),
+                rt.game().totalCoins, rt.game().hasExit ? "yes" : "no");
+
+    // Prove it is fair before playing it.
+    const game::SolveResult solved = game::solve(rt.game());
+    std::printf("Solver: solvable=%s par=%d reachableCoins=%d/%d\n",
+                solved.solvable ? "true" : "false", solved.par, solved.reachableCoins,
+                rt.game().totalCoins);
+
+    // Spawn the actors into the live ECS (the renderer would attach meshes via decorate).
+    ecs::Registry reg;
+    rt.spawnInto(reg);
+    std::printf("Spawned %d ECS entities (Transform + SpawnTag)\n", taggedCount(reg));
+
+    // Drive the deterministic sim along the solver's route; the entity Transforms follow.
+    const float dt = 1.0f / 60.0f;
+    int steps = 0;
+    for (const ecs::Vec3& target : solved.path) {
+        int guard = 0;
+        while (guard++ < 4000 && rt.game().status == game::GameStatus::Playing) {
+            const ecs::Vec3 p = rt.game().playerPosition;
+            const float dx = target.x - p.x, dz = target.z - p.z;
+            if (dx * dx + dz * dz < 0.0025f) break;
+            rt.update(reg, game::GameInput{dx, dz}, dt);
+            ++steps;
+        }
+        if (rt.game().status != game::GameStatus::Playing) break;
+    }
+
+    const ecs::Vec3 fp = reg.isValid(rt.playerEntity())
+                             ? reg.get<ecs::Transform>(rt.playerEntity()).position
+                             : ecs::Vec3{};
+    std::printf("After %d steps: player entity at (%.2f, %.2f), coins %d/%d, %s\n", steps, fp.x, fp.z,
+                rt.game().coinsCollected, rt.game().totalCoins,
+                rt.game().won() ? "WON" : (rt.game().lost() ? "LOST" : "still playing"));
+    std::printf("Live entities remaining: %d\n", taggedCount(reg));
+    return rt.game().won() ? 0 : 1;
+}

--- a/src/game/DungeonRuntime.h
+++ b/src/game/DungeonRuntime.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "core/ecs/Registry.h"
+#include "core/ecs/View.h"
+#include "core/ecs/components/Components.h"
+#include "game/DungeonGame.h" // DungeonGame, GameInput, SpawnTag (via DoodleScene)
+
+#include <functional>
+#include <string>
+#include <vector>
+
+/**
+ * @file DungeonRuntime.h
+ * @brief Drive the headless DungeonGame through the engine's live ECS (issue #313-#320
+ *        follow-on: wire the deterministic cores into the running engine).
+ *
+ * The DungeonGame (#164) and everything built on it - the GeoJSON city importer (#313),
+ * recognized-drawing spawns (#314/#315), keys/doors/switches/hazards (#319) and enemy
+ * behaviors (#320) - are pure headless data. This is the seam that makes them "live":
+ * spawnInto() creates one ECS entity per actor (player, enemies, coins, exit) with a
+ * Transform + SpawnTag, and update() steps the deterministic sim and writes each actor's
+ * position back onto its Transform - exactly what the renderer and the ECS systems read to
+ * draw and reason about the world. A collected coin's entity is destroyed so it stops
+ * being drawn.
+ *
+ * A caller-supplied @c decorate hook lets the live engine attach Mesh/Material/Model
+ * components per spawn (by its type string) while keeping this header renderer-agnostic
+ * and headlessly testable. Header-only, std + the header-only ECS / game.
+ */
+namespace IKore {
+namespace game {
+
+class DungeonRuntime {
+public:
+    /// Hook to attach render/engine components to a freshly-created entity, keyed by the
+    /// spawn's type ("player" / "enemy" / "coin" / "exit"). Optional; tests pass none.
+    using DecorateFn = std::function<void(ecs::Registry&, ecs::Entity, const std::string&)>;
+
+    DungeonRuntime() = default;
+    explicit DungeonRuntime(DungeonGame game) : m_game(std::move(game)) {}
+
+    DungeonGame& game() { return m_game; }
+    const DungeonGame& game() const { return m_game; }
+
+    ecs::Entity playerEntity() const { return m_player; }
+    const std::vector<ecs::Entity>& enemyEntities() const { return m_enemies; }
+    const std::vector<ecs::Entity>& coinEntities() const { return m_coins; }
+    ecs::Entity exitEntity() const { return m_exit; }
+    bool hasExitEntity() const { return m_hasExit; }
+
+    /// Create the ECS entities that mirror the game's actors. Idempotent per instance
+    /// (call once). @p decorate, if set, is invoked per new entity for the live engine
+    /// to attach meshes/materials.
+    void spawnInto(ecs::Registry& reg, const DecorateFn& decorate = {}) {
+        m_player = make(reg, m_game.playerPosition, "player", decorate);
+
+        m_enemies.clear();
+        for (const Enemy& e : m_game.enemies) {
+            m_enemies.push_back(make(reg, e.position, "enemy", decorate));
+        }
+
+        m_coins.assign(m_game.coins.size(), ecs::Entity{});
+        for (std::size_t i = 0; i < m_game.coins.size(); ++i) {
+            m_coins[i] = make(reg, m_game.coins[i].position, "coin", decorate);
+        }
+
+        if (m_game.hasExit) {
+            m_exit = make(reg, m_game.exitPosition, "exit", decorate);
+            m_hasExit = true;
+        }
+    }
+
+    /// Step the deterministic sim by @p dt with @p in, then sync every live actor's
+    /// Transform and destroy any entity for a coin collected this step.
+    void update(ecs::Registry& reg, const GameInput& in, float dt) {
+        m_game.update(in, dt);
+        syncTransforms(reg);
+    }
+
+    /// Re-sync transforms without stepping (e.g. after an external state change).
+    void syncTransforms(ecs::Registry& reg) {
+        setPosition(reg, m_player, m_game.playerPosition);
+        for (std::size_t i = 0; i < m_enemies.size() && i < m_game.enemies.size(); ++i) {
+            setPosition(reg, m_enemies[i], m_game.enemies[i].position);
+        }
+        for (std::size_t i = 0; i < m_coins.size() && i < m_game.coins.size(); ++i) {
+            if (m_game.coins[i].collected && reg.isValid(m_coins[i])) {
+                reg.destroy(m_coins[i]); // collected: stop drawing it
+            }
+        }
+    }
+
+private:
+    ecs::Entity make(ecs::Registry& reg, const ecs::Vec3& pos, const std::string& type,
+                     const DecorateFn& decorate) {
+        const ecs::Entity e = reg.create();
+        reg.add<ecs::Transform>(e, ecs::Transform{pos, ecs::Vec3{}, ecs::Vec3{1.0f, 1.0f, 1.0f}});
+        reg.add<SpawnTag>(e, SpawnTag{type});
+        if (decorate) decorate(reg, e, type);
+        return e;
+    }
+
+    static void setPosition(ecs::Registry& reg, ecs::Entity e, const ecs::Vec3& pos) {
+        if (reg.isValid(e) && reg.has<ecs::Transform>(e)) reg.get<ecs::Transform>(e).position = pos;
+    }
+
+    DungeonGame m_game;
+    ecs::Entity m_player{};
+    std::vector<ecs::Entity> m_enemies;
+    std::vector<ecs::Entity> m_coins; ///< parallel to m_game.coins (invalid once destroyed).
+    ecs::Entity m_exit{};
+    bool m_hasExit{false};
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_dungeon_runtime.cpp
+++ b/tests/test_dungeon_runtime.cpp
@@ -1,0 +1,102 @@
+// Test for the DungeonGame -> live ECS runtime bridge - engine wiring follow-on.
+//
+// Verifies the deterministic dungeon sim drives real engine ECS entities: spawnInto
+// creates one Transform+SpawnTag entity per actor, the decorate hook can attach engine
+// components, update() steps the sim and writes actor positions onto their Transforms,
+// a collected coin's entity is destroyed, and enemies track their moving positions.
+// Pure std + the header-only ECS / game:
+//   g++ -std=c++17 -I src tests/test_dungeon_runtime.cpp -o test_dungeon_runtime
+
+#include "core/ecs/View.h"
+#include "game/DungeonRuntime.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+// Stand-in for a render component the live engine would attach via the decorate hook.
+struct RenderStub {
+    int marker{0};
+};
+
+static game::EntitySpawn sp(const char* t, float x, float z) {
+    return game::EntitySpawn{t, ecs::Vec3{x, 0.0f, z}, 0.0f};
+}
+static int countTagged(ecs::Registry& reg) {
+    int n = 0;
+    reg.view<game::SpawnTag>().each([&](ecs::Entity, game::SpawnTag&) { ++n; });
+    return n;
+}
+
+int main() {
+    // Player, one coin on the path, exit past it; no enemy so a straight run wins.
+    game::SceneDescription scene;
+    scene.spawns = {sp("player", 0, 0), sp("coin", 2, 0), sp("exit", 4, 0)};
+
+    game::DungeonRuntime rt(game::loadGame(scene));
+    ecs::Registry reg;
+
+    int decorated = 0;
+    rt.spawnInto(reg, [&](ecs::Registry& r, ecs::Entity e, const std::string&) {
+        r.add<RenderStub>(e, RenderStub{1});
+        ++decorated;
+    });
+
+    // One entity per actor, each tagged and decorated.
+    CHECK(countTagged(reg) == 3); // player + coin + exit
+    CHECK(decorated == 3);
+    CHECK(reg.isValid(rt.playerEntity()) && reg.has<RenderStub>(rt.playerEntity()));
+    CHECK(rt.coinEntities().size() == 1);
+    CHECK(rt.hasExitEntity());
+
+    // Player entity's Transform starts at the spawn.
+    CHECK(reg.get<ecs::Transform>(rt.playerEntity()).position.x == 0.0f);
+
+    // Drive east: the Transform tracks the sim, the coin gets collected and destroyed.
+    const float dt = 1.0f / 60.0f;
+    bool coinGone = false;
+    for (int i = 0; i < 400 && rt.game().status == game::GameStatus::Playing; ++i) {
+        rt.update(reg, game::GameInput{1.0f, 0.0f}, dt);
+        // Transform mirrors the deterministic sim every step.
+        CHECK(reg.get<ecs::Transform>(rt.playerEntity()).position.x == rt.game().playerPosition.x);
+        if (rt.game().coinsCollected == 1 && !reg.isValid(rt.coinEntities()[0])) coinGone = true;
+    }
+    CHECK(rt.game().coinsCollected == 1);
+    CHECK(coinGone);                              // collected coin's entity was destroyed
+    CHECK(!reg.isValid(rt.coinEntities()[0]));
+    CHECK(countTagged(reg) == 2);                // player + exit remain
+    CHECK(rt.game().won());
+
+    // Enemy entities track their moving positions.
+    {
+        game::SceneDescription es;
+        es.spawns = {sp("player", 0, 0), sp("enemy", 5, 0), sp("exit", 20, 20)};
+        game::DungeonRuntime ert(game::loadGame(es));
+        ecs::Registry ereg;
+        ert.spawnInto(ereg);
+        CHECK(ert.enemyEntities().size() == 1);
+        const float ex0 = ereg.get<ecs::Transform>(ert.enemyEntities()[0]).position.x;
+        for (int i = 0; i < 30; ++i) ert.update(ereg, game::GameInput{0.0f, 0.0f}, dt);
+        const float ex1 = ereg.get<ecs::Transform>(ert.enemyEntities()[0]).position.x;
+        CHECK(ex1 < ex0); // the chaser moved toward the player, and its Transform followed
+        CHECK(ex1 == ert.game().enemies[0].position.x);
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_dungeon_runtime: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_dungeon_runtime: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

The `DungeonGame` and everything built on it — the GeoJSON city importer (#313), recognized-drawing spawns (#314/#315), keys/doors/switches/hazards (#319), enemy behaviors (#320) — were pure headless data with no path into the running engine. This adds the seam that makes them live.

## What this does

New header-only `src/game/DungeonRuntime.h`:

- `spawnInto(registry, decorate?)` creates one ECS entity per actor (player / enemies / coins / exit) with a `Transform` + `SpawnTag` — exactly what the renderer and ECS systems consume for placement.
- `update(registry, input, dt)` steps the deterministic sim and writes each actor's position onto its `Transform`; a coin collected this step has its entity destroyed so it stops being drawn.
- A caller-supplied `decorate` hook lets the live engine attach `Mesh`/`Material`/`Model` per spawn (keyed by type) while keeping this header renderer-agnostic and headless-testable.

Because every core produces a `DungeonGame` via `loadGame`, this one bridge covers all of them.

## Tests & demo

- `test_dungeon_runtime` (headless): spawn creates the expected tagged entities, the decorate hook attaches components, `Transform`s track the sim every step, a collected coin's entity is destroyed, and enemies follow their moving positions.
- `sample_doodle_runtime`: a runnable end-to-end demo — imports a GeoJSON city (#313), validates it with the solver (#316), spawns it into an ECS registry, and drives it to a win.

Full 83-test headless suite stays green.

## Notes

Header-only, deterministic, registered under the `headless` CTest label. The GL draw itself is then just the renderer consuming these `Transform`s (its existing job); this PR provides the spatial truth it reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_