### PR TITLE
Netplay: include the #319/#320 state in DoodleNetState equality and desync digest (#337)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,6 +633,11 @@ add_executable(test_desync
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_desync.cpp
 )
 
+# Desync equality/digest covers the #319/#320 state (keys/doors/switches/projectiles) (#337) - header-only.
+add_executable(test_desync_features
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_desync_features.cpp
+)
+
 # Renderer-agnostic drawing->scene converter (Milestone 15 / #162) - header-only.
 add_executable(test_doodle_scene
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_doodle_scene.cpp
@@ -1051,6 +1056,7 @@ set(HEADLESS_TESTS
     test_debug_console
     test_debug_text
     test_desync
+    test_desync_features
     test_determinism
     test_doodle_library
     test_doodle_rollback

--- a/src/game/DoodleRollback.h
+++ b/src/game/DoodleRollback.h
@@ -56,6 +56,35 @@ struct DoodleNetState {
                 if (a.enemies[e].position.x != b.enemies[e].position.x ||
                     a.enemies[e].position.z != b.enemies[e].position.z) return false;
             }
+            // Richer semantics (#319/#320): key/door/switch/toggle-wall/projectile state is
+            // also mutable per tick, so include it so a divergence there is detected too.
+            if (a.keys.size() != b.keys.size() || a.lockedDoors.size() != b.lockedDoors.size() ||
+                a.switches.size() != b.switches.size() ||
+                a.toggleWalls.size() != b.toggleWalls.size() ||
+                a.projectiles.size() != b.projectiles.size()) {
+                return false;
+            }
+            for (std::size_t k = 0; k < a.keys.size(); ++k) {
+                if (a.keys[k].collected != b.keys[k].collected) return false;
+            }
+            for (std::size_t d = 0; d < a.lockedDoors.size(); ++d) {
+                if (a.lockedDoors[d].open != b.lockedDoors[d].open) return false;
+            }
+            for (std::size_t s = 0; s < a.switches.size(); ++s) {
+                if (a.switches[s].wasPressed != b.switches[s].wasPressed) return false;
+            }
+            for (std::size_t w = 0; w < a.toggleWalls.size(); ++w) {
+                if (a.toggleWalls[w].solid != b.toggleWalls[w].solid) return false;
+            }
+            for (std::size_t p = 0; p < a.projectiles.size(); ++p) {
+                const Projectile& pa = a.projectiles[p];
+                const Projectile& pb = b.projectiles[p];
+                if (pa.position.x != pb.position.x || pa.position.z != pb.position.z ||
+                    pa.velocity.x != pb.velocity.x || pa.velocity.z != pb.velocity.z ||
+                    pa.life != pb.life) {
+                    return false;
+                }
+            }
         }
         return true;
     }
@@ -116,6 +145,17 @@ inline std::uint64_t stateDigest(const DoodleNetState& state) {
         for (const Enemy& e : g.enemies) {
             detail::hashFloat(h, e.position.x);
             detail::hashFloat(h, e.position.z);
+        }
+        // Richer semantics (#319/#320). Empty on a classic level, so its digest is
+        // unchanged; only levels using these features fold extra state into the hash.
+        for (const Key& k : g.keys) h.addU32(k.collected ? 1u : 0u);
+        for (const LockedDoor& d : g.lockedDoors) h.addU32(d.open ? 1u : 0u);
+        for (const Switch& s : g.switches) h.addU32(s.wasPressed ? 1u : 0u);
+        for (const ToggleWall& w : g.toggleWalls) h.addU32(w.solid ? 1u : 0u);
+        for (const Projectile& p : g.projectiles) {
+            detail::hashFloat(h, p.position.x);
+            detail::hashFloat(h, p.position.z);
+            detail::hashFloat(h, p.life);
         }
     }
     return h.digest();

--- a/tests/test_desync_features.cpp
+++ b/tests/test_desync_features.cpp
@@ -1,0 +1,94 @@
+// Test that the rollback desync check covers the #319/#320 state - issue #337.
+//
+// DoodleNetState::operator== and stateDigest previously ignored keys, locked doors,
+// switches, toggle walls, and projectiles, so a divergence in those fields would go
+// undetected. This verifies both now catch a divergence in each of them, that identical
+// states still match, and that classic-level detection is unchanged. Pure std + the
+// header-only game/net:
+//   g++ -std=c++17 -I src tests/test_desync_features.cpp -o test_desync_features
+
+#include "game/DoodleRollback.h"
+
+#include <cstdio>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static game::EntitySpawn sp(const char* t, float x, float z) {
+    return game::EntitySpawn{t, ecs::Vec3{x, 0.0f, z}, 0.0f};
+}
+
+// base != mutated by BOTH operator== and the digest.
+static void expectDivergence(const game::DoodleNetState& base, const game::DoodleNetState& mutated,
+                             const char* what) {
+    if (!(base != mutated)) {
+        std::printf("FAIL: operator== missed divergence in %s\n", what);
+        ++g_failures;
+    }
+    if (game::stateDigest(base) == game::stateDigest(mutated)) {
+        std::printf("FAIL: stateDigest missed divergence in %s\n", what);
+        ++g_failures;
+    }
+}
+
+int main() {
+    // A level exercising every new-type field, plus a ranged enemy so a projectile exists.
+    game::SceneDescription scene;
+    scene.spawns = {sp("player", 0, 0),   sp("exit", 20, 20),   sp("key@1", 1, 0),
+                    sp("lock@1", 3, 0),    sp("switch@1", 1, 2), sp("toggle@1", 5, 0),
+                    sp("enemy_ranged", 10, 10)};
+    game::DungeonGame g = game::loadGame(scene);
+    g.update(game::GameInput{}, 1.0f / 60.0f); // ranged enemy fires -> a projectile exists
+
+    game::DoodleNetState base;
+    base.games.push_back(g);
+    CHECK(base.games[0].keys.size() == 1);
+    CHECK(base.games[0].lockedDoors.size() == 1);
+    CHECK(base.games[0].switches.size() == 1);
+    CHECK(base.games[0].toggleWalls.size() == 1);
+    CHECK(!base.games[0].projectiles.empty());
+
+    // Identical states match, by both checks.
+    game::DoodleNetState same = base;
+    CHECK(base == same);
+    CHECK(game::stateDigest(base) == game::stateDigest(same));
+
+    // A divergence in each new mutable field is detected.
+    { auto m = base; m.games[0].keys[0].collected = true;            expectDivergence(base, m, "key.collected"); }
+    { auto m = base; m.games[0].lockedDoors[0].open = true;          expectDivergence(base, m, "door.open"); }
+    { auto m = base; m.games[0].switches[0].wasPressed = !m.games[0].switches[0].wasPressed;
+                                                                     expectDivergence(base, m, "switch.wasPressed"); }
+    { auto m = base; m.games[0].toggleWalls[0].solid = !m.games[0].toggleWalls[0].solid;
+                                                                     expectDivergence(base, m, "toggleWall.solid"); }
+    { auto m = base; m.games[0].projectiles[0].life -= 1.0f;         expectDivergence(base, m, "projectile.life"); }
+    { auto m = base; m.games[0].projectiles[0].position.x += 1.0f;   expectDivergence(base, m, "projectile.position"); }
+
+    // Classic levels: still detected, and identical still match (no regression).
+    {
+        game::SceneDescription cs;
+        cs.spawns = {sp("player", 0, 0), sp("coin", 2, 0), sp("exit", 4, 0)};
+        game::DoodleNetState c;
+        c.games.push_back(game::loadGame(cs));
+        game::DoodleNetState c2 = c;
+        CHECK(c == c2 && game::stateDigest(c) == game::stateDigest(c2));
+        auto m = c;
+        m.games[0].coins[0].collected = true;
+        expectDivergence(c, m, "classic coin.collected");
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_desync_features: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_desync_features: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #337. `DoodleNetState::operator==` and `stateDigest` (#291) compared and hashed only player position, coins, enemy positions, and status. The state added by #319/#320 - key collected flags, locked-door open flags, switch pressed state, toggle-wall solid state, and ranged projectiles - was neither compared nor hashed, so the desync **detector** was blind to divergence there (netplay itself stayed deterministic, since state is a pure function of inputs).

## What this does

- `operator==` now also compares keys (collected), lockedDoors (open), switches (wasPressed), toggleWalls (solid), and projectiles (position/velocity/life), including size mismatches.
- `stateDigest` folds those same fields into the hash, in the existing bit-exact float-hashing style.
- The added loops are empty on a classic level, so its equality and digest are **unchanged** (no rollback/versus regression).

## Tests

`test_desync_features` (headless): a divergence in each new field (key/door/switch/toggle-wall/projectile) is caught by **both** `==` and `stateDigest`; identical states still match; and classic-level detection is unaffected. Full 84-test headless suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_