### PR TITLE
UI: FFA standings HUD and a spectator replay scrubber (#335)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -811,6 +811,11 @@ add_executable(test_versus_ffa
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_versus_ffa.cpp
 )
 
+# FFA standings HUD + spectator replay scrubber over the HUD framework (#335) - header-only.
+add_executable(test_spectator_ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_spectator_ui.cpp
+)
+
 # Audio decode core: robust WAV/PCM parser + tone generator (#258) - header-only.
 add_executable(test_audio_decode
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_audio_decode.cpp
@@ -1116,6 +1121,7 @@ set(HEADLESS_TESTS
     test_skinned_shadow
     test_skinning
     test_solver
+    test_spectator_ui
     test_ssao_kernel
     test_svg_floorplan
     test_symbol_recognizer

--- a/src/game/SpectatorUi.h
+++ b/src/game/SpectatorUi.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include "game/Replay.h"    // Replay, ReplayPlayer
+#include "game/VersusFFA.h" // VersusFFA, VersusStanding
+#include "ui/HudFramework.h" // Hud, hudList
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+/**
+ * @file SpectatorUi.h
+ * @brief FFA standings HUD and a spectator replay scrubber (issue #335).
+ *
+ * N-player FFA (#318) exposes per-tick standings and shareable replays (#317) expose a
+ * ReplayPlayer, but neither was surfaced for the UI. This adds both on top of the
+ * header-only HUD framework (#55), so the widget/scrubber state is decoupled from GL and
+ * unit-testable headless:
+ *   - ffaStandingsLines / buildFfaHud: a live standings list widget bound to
+ *     VersusFFA::standings(), refreshed per tick.
+ *   - ReplayScrubber: play/pause and seek-to-tick over a Replay. Because playback is
+ *     deterministic, seeking re-simulates from the start to the target tick, exposing each
+ *     player's game at that tick.
+ *
+ * Header-only, std only.
+ */
+namespace IKore {
+namespace game {
+
+// --- FFA standings HUD -------------------------------------------------------
+
+/// One standings line, e.g. "1. P0  coins 2  WON".
+inline std::string formatStanding(int rank, const VersusStanding& s) {
+    std::string line = std::to_string(rank) + ". P" + std::to_string(s.player) + "  coins " +
+                       std::to_string(s.coinsCollected);
+    if (s.won) {
+        line += "  WON";
+    } else if (s.lost) {
+        line += "  OUT";
+    }
+    return line;
+}
+
+/// The live standings as ranked display lines (best first).
+inline std::vector<std::string> ffaStandingsLines(const VersusFFA& match) {
+    std::vector<std::string> lines;
+    const std::vector<VersusStanding> standings = match.standings();
+    lines.reserve(standings.size());
+    for (std::size_t i = 0; i < standings.size(); ++i) {
+        lines.push_back(formatStanding(static_cast<int>(i) + 1, standings[i]));
+    }
+    return lines;
+}
+
+/// Build a HUD with a top-right standings list bound to the live match. The returned Hud
+/// captures @p match by reference, so it must not outlive the match.
+inline Hud buildFfaHud(const VersusFFA& match) {
+    Hud hud;
+    const float rows = static_cast<float>(match.players() > 0 ? match.players() : 1);
+    hud.add(hudList("ffa_standings", HudAnchor::TopRight, HudVec2{8.0f, 8.0f},
+                    HudVec2{220.0f, 18.0f * rows}, [&match]() { return ffaStandingsLines(match); }));
+    return hud;
+}
+
+// --- Spectator replay scrubber ----------------------------------------------
+
+/**
+ * @brief Play/pause and seek over a Replay (#317), exposing each player's game at the
+ *        current tick. Seeking re-simulates deterministically from the start to the target
+ *        tick, so any tick is reproducible.
+ */
+class ReplayScrubber {
+public:
+    explicit ReplayScrubber(Replay replay) : m_replay(std::move(replay)), m_player(m_replay) {
+        for (const std::vector<GameInput>& tr : m_replay.traces) {
+            m_length = std::max(m_length, tr.size());
+        }
+        m_valid = m_player.valid();
+    }
+
+    bool valid() const { return m_valid; }
+    int players() const { return m_player.players(); }
+    std::size_t tick() const { return m_tick; }
+    std::size_t length() const { return m_length; } ///< total number of ticks.
+    bool playing() const { return m_playing; }
+    bool atEnd() const { return m_tick >= m_length; }
+
+    void play() { m_playing = true; }
+    void pause() { m_playing = false; }
+    void togglePlay() { m_playing = !m_playing; }
+
+    /// Jump to @p tick (clamped to [0, length]), re-simulating from the start.
+    void seek(std::size_t tick) {
+        if (tick > m_length) tick = m_length;
+        m_player = ReplayPlayer(m_replay); // fresh, deterministic re-sim
+        for (std::size_t i = 0; i < tick; ++i) m_player.step();
+        m_tick = tick;
+    }
+
+    /// Advance one tick if playing (and not at the end). Returns whether it advanced.
+    bool advance() {
+        if (!m_playing || m_tick >= m_length) return false;
+        seek(m_tick + 1);
+        return true;
+    }
+
+    /// The player's game state at the current tick.
+    const DungeonGame& game(int player) const { return m_player.game(player); }
+
+private:
+    Replay m_replay;
+    std::size_t m_length{0};
+    std::size_t m_tick{0};
+    bool m_playing{false};
+    bool m_valid{false};
+    ReplayPlayer m_player;
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_spectator_ui.cpp
+++ b/tests/test_spectator_ui.cpp
@@ -1,0 +1,143 @@
+// Test for the FFA standings HUD and the spectator replay scrubber - issue #335.
+//
+// Verifies the standings HUD lists all N players ranked by live progress (bound into the
+// HUD framework), and that ReplayScrubber seeks to any tick deterministically (re-sim from
+// the start), reproduces per-player state, and honors play/pause - for both a single run
+// and a versus match. Pure std + the header-only game / ui:
+//   g++ -std=c++17 -I src tests/test_spectator_ui.cpp -o test_spectator_ui
+
+#include "game/LevelFormat.h" // toLevelJson
+#include "game/SpectatorUi.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static const float kDt = 1.0f / 60.0f;
+
+static std::string makeLevelJson() {
+    LevelSpec s;
+    s.walls.push_back(Wall{{{0, 0, 0}, {40, 0, 0}, {40, 0, 40}, {0, 0, 40}, {0, 0, 0}}});
+    s.symbols.push_back(Symbol{"player", ecs::Vec3{5, 0, 5}, 0.0f});
+    s.symbols.push_back(Symbol{"coin", ecs::Vec3{9, 0, 9}, 0.0f});
+    s.symbols.push_back(Symbol{"exit", ecs::Vec3{14, 0, 14}, 0.0f});
+    return toLevelJson(s);
+}
+
+static std::vector<GameInput> winTrace(const std::string& json) {
+    LevelSpec spec;
+    fromLevelJson(json, spec);
+    DungeonGame g = loadGame(convert(spec));
+    std::vector<GameInput> ins;
+    for (int i = 0; i < 800 && g.status == GameStatus::Playing; ++i) {
+        const GameInput in{1.0f, 1.0f};
+        g.update(in, kDt);
+        ins.push_back(in);
+    }
+    return ins;
+}
+
+static bool contains(const std::string& s, const std::string& sub) {
+    return s.find(sub) != std::string::npos;
+}
+
+int main() {
+    const std::string json = makeLevelJson();
+
+    // --- FFA standings HUD ------------------------------------------------------
+    {
+        VersusFFA match(json, /*local=*/0, /*players=*/3, kDt);
+        CHECK(match.valid());
+        for (int f = 0; f < 120; ++f) {
+            match.advance(GameInput{1.0f, 1.0f});         // player 0 rushes
+            match.addRemoteInput(1, f, GameInput{});      // players 1 and 2 idle
+            match.addRemoteInput(2, f, GameInput{});
+        }
+        const std::vector<std::string> lines = ffaStandingsLines(match);
+        CHECK(lines.size() == 3);
+        CHECK(contains(lines[0], "P0"));                  // the rusher leads the standings
+        CHECK(match.standings().front().player == 0);
+
+        Hud hud = buildFfaHud(match);
+        CHECK(hud.count() == 1);
+        const std::vector<std::string> hudLines = hud.elements()[0].list();
+        CHECK(hudLines.size() == 3);
+        CHECK(contains(hudLines[0], "P0"));
+    }
+
+    // --- Replay scrubber: single run -------------------------------------------
+    {
+        RunTrace t;
+        t.dt = kDt;
+        t.inputs = winTrace(json);
+        const Replay replay = makeRunReplay(json, t);
+        ReplayScrubber sc(replay);
+        CHECK(sc.valid());
+        CHECK(sc.players() == 1);
+        CHECK(sc.length() > 0);
+
+        sc.seek(0);
+        CHECK(sc.game(0).coinsCollected == 0);
+        const float startX = sc.game(0).playerPosition.x;
+
+        const std::size_t mid = sc.length() / 2;
+        sc.seek(mid);
+        const float midX = sc.game(0).playerPosition.x;
+        CHECK(midX > startX);                              // advanced by the mid tick
+
+        sc.seek(sc.length());
+        CHECK(sc.game(0).won());                           // the run clears by the end
+
+        // Determinism: seeking back and forth reproduces the exact mid state.
+        sc.seek(0);
+        sc.seek(mid);
+        CHECK(sc.game(0).playerPosition.x == midX);
+
+        // Play/pause.
+        sc.seek(0);
+        sc.pause();
+        CHECK(!sc.advance());                              // paused: no advance
+        sc.play();
+        CHECK(sc.advance());                               // playing: advances
+        CHECK(sc.tick() == 1);
+    }
+
+    // --- Replay scrubber: versus match -----------------------------------------
+    {
+        std::vector<GameInput> winner = winTrace(json);
+        std::vector<GameInput> loser(winner.size(), GameInput{}); // idle
+        MatchRecord rec;
+        rec.levelJson = json;
+        rec.dt = kDt;
+        rec.inputs0 = winner;
+        rec.inputs1 = loser;
+        rec.claimedWinner = 0;
+        const Replay replay = makeVersusReplay(rec);
+
+        ReplayScrubber sc(replay);
+        CHECK(sc.players() == 2);
+        sc.seek(sc.length());
+        CHECK(sc.game(0).won());
+        CHECK(!sc.game(1).won());
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_spectator_ui: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_spectator_ui: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #335. N-player FFA (#318) exposes per-tick standings and shareable replays (#317) expose a `ReplayPlayer`, but neither was surfaced for the UI. This adds both on the header-only HUD framework (#55), so the widget/scrubber state is decoupled from GL and unit-testable headless.

## What this does

New header-only `src/game/SpectatorUi.h`:

- **FFA standings HUD** - `ffaStandingsLines(match)` formats `VersusFFA::standings()` into ranked display lines (best first), and `buildFfaHud(match)` binds them into a `hudList` element, refreshed per tick.
- **`ReplayScrubber`** - play/pause and `seek(tick)` over a `Replay`. Because playback is deterministic, seeking re-simulates from the start to the target tick and exposes each player's `DungeonGame` at that tick (any tick reproducible).

## Tests

`test_spectator_ui` (headless): the standings list ranks the leader (the rushing player) first and binds correctly into the HUD framework; the scrubber seeks to any tick deterministically (identical state on re-seek), advances the player state by the mid tick, reaches the win at the end, and honors play/pause - for both a single run and a versus match.

## Notes

Header-only, deterministic; the GL draw is the renderer's existing job (it walks the HUD elements). Registered under the `headless` CTest label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_