### PR TITLE
Rendering: draw the DungeonRuntime's entities (render list + GL pass) (#333)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,6 +663,18 @@ add_executable(test_dungeon_runtime
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dungeon_runtime.cpp
 )
 
+# Render-list builder for a live DungeonRuntime (statics + ECS actors) (#333) - header-only.
+add_executable(test_dungeon_render_data
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dungeon_render_data.cpp
+)
+
+# GL render pass that draws the DungeonRuntime draw list offscreen (#333). Links glad/glfw/
+# glm and needs a GL context, so it is a gl-labelled test (run under Xvfb + software GL).
+add_executable(test_dungeon_render_gl
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dungeon_render_gl.cpp
+)
+target_link_libraries(test_dungeon_render_gl PRIVATE glad glfw glm::glm)
+
 # Selectable enemy behaviors: patrol / flee / ranged, default chase (#320) - header-only.
 add_executable(test_enemy_behaviors
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_enemy_behaviors.cpp
@@ -1068,6 +1080,7 @@ set(HEADLESS_TESTS
     test_doodle_scene
     test_dungeon_features
     test_dungeon_game
+    test_dungeon_render_data
     test_dungeon_runtime
     test_ecs_benchmark
     test_ecs_query
@@ -1168,6 +1181,7 @@ set(GL_TESTS
     test_animation_blend
     test_animation_component
     test_audio_compressed
+    test_dungeon_render_gl
     test_event_system
     test_event_system_simple
     test_material_component

--- a/src/game/DungeonRenderData.h
+++ b/src/game/DungeonRenderData.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "core/ecs/Registry.h"
+#include "core/ecs/View.h"
+#include "core/ecs/components/Components.h"
+#include "game/DungeonGame.h" // DungeonGame, world::Box, SpawnTag (via DoodleScene)
+
+#include <string>
+#include <vector>
+
+/**
+ * @file DungeonRenderData.h
+ * @brief Build the renderer's draw list for a live DungeonRuntime (issue #333).
+ *
+ * DungeonRuntime (the engine-wiring bridge) spawns the actors as ECS Transform+SpawnTag
+ * entities; the static level features (walls, doors, switches, hazards, keys) live on the
+ * DungeonGame. This turns both into a flat, renderer-agnostic draw list - one colored,
+ * sized instance per thing to draw - so a render pass can iterate it and issue one draw per
+ * instance. Keeping this as data makes the "what to draw" logic unit-testable without a GL
+ * context (the actual GL draw consumes the list); the accompanying gl-labelled tool
+ * renders it offscreen.
+ *
+ * Collected coins disappear because their ECS entity is destroyed by the runtime; a
+ * collected key / opened door / flipped toggle-wall disappears because it is read from the
+ * game's live state. Header-only, std + the header-only ECS / game.
+ */
+namespace IKore {
+namespace game {
+
+struct RenderColor {
+    float r{0.8f}, g{0.8f}, b{0.8f};
+};
+
+struct RenderInstance {
+    ecs::Vec3 position{}; ///< world center (XZ; y is the box center for statics).
+    ecs::Vec3 size{};     ///< world size (statics use the box size; actors a marker size).
+    RenderColor color{};
+    std::string type;     ///< "wall"/"player"/"enemy"/"coin"/"exit"/"key"/... (for material choice).
+};
+
+struct RenderStyle {
+    float actorSize{0.8f};   ///< marker size for point actors/features.
+    RenderColor wall{0.50f, 0.50f, 0.55f};
+};
+
+/// A deterministic per-type color for a spawn/feature type (default material palette).
+inline RenderColor renderColorForType(const std::string& type) {
+    if (type == "player") return {0.20f, 0.80f, 0.35f};
+    if (type == "enemy" || (type.size() >= 5 && type.compare(0, 5, "enemy") == 0))
+        return {0.85f, 0.20f, 0.20f};
+    if (type == "coin" || type == "treasure") return {0.92f, 0.85f, 0.20f};
+    if (type == "exit" || type == "door") return {0.25f, 0.45f, 0.92f};
+    if (type == "key") return {0.95f, 0.80f, 0.20f};
+    if (type == "lockeddoor" || type == "lock") return {0.60f, 0.40f, 0.20f};
+    if (type == "switch") return {0.40f, 0.85f, 0.90f};
+    if (type == "toggle" || type == "togglewall") return {0.55f, 0.55f, 0.62f};
+    if (type == "hazard" || type == "spike") return {0.90f, 0.30f, 0.10f};
+    return {0.80f, 0.80f, 0.80f};
+}
+
+/**
+ * @brief Build the draw list: static level geometry/features from @p game, plus the live
+ *        actors (player/enemies/coins/exit) from their ECS Transform+SpawnTag entities in
+ *        @p reg. Only still-relevant features are emitted (a locked door that has opened, a
+ *        toggle wall that is off, a collected key, and a collected coin's destroyed entity
+ *        are all omitted).
+ */
+inline std::vector<RenderInstance> buildRenderList(ecs::Registry& reg, const DungeonGame& game,
+                                                   const RenderStyle& style = {}) {
+    std::vector<RenderInstance> out;
+    const ecs::Vec3 marker{style.actorSize, style.actorSize, style.actorSize};
+
+    // Static geometry / features from the game.
+    for (const world::Box& b : game.walls) out.push_back({b.center, b.size, style.wall, "wall"});
+    for (const LockedDoor& d : game.lockedDoors) {
+        if (!d.open) out.push_back({d.box.center, d.box.size, renderColorForType("lockeddoor"), "lockeddoor"});
+    }
+    for (const ToggleWall& w : game.toggleWalls) {
+        if (w.solid) out.push_back({w.box.center, w.box.size, renderColorForType("togglewall"), "togglewall"});
+    }
+    for (const Key& k : game.keys) {
+        if (!k.collected) out.push_back({k.position, marker, renderColorForType("key"), "key"});
+    }
+    for (const Switch& s : game.switches) {
+        out.push_back({s.position, marker, renderColorForType("switch"), "switch"});
+    }
+    for (const Hazard& h : game.hazards) {
+        out.push_back({h.position, marker, renderColorForType("hazard"), "hazard"});
+    }
+
+    // Live actors from the ECS (coins vanish when their entity is destroyed on pickup).
+    reg.view<ecs::Transform, SpawnTag>().each([&](ecs::Entity, ecs::Transform& t, SpawnTag& tag) {
+        out.push_back({t.position, marker, renderColorForType(tag.type), tag.type});
+    });
+    return out;
+}
+
+/// Count the instances of a given type in a draw list (for tests / diagnostics).
+inline int countRenderType(const std::vector<RenderInstance>& list, const std::string& type) {
+    int n = 0;
+    for (const RenderInstance& i : list) {
+        if (i.type == type) ++n;
+    }
+    return n;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_dungeon_render_data.cpp
+++ b/tests/test_dungeon_render_data.cpp
@@ -1,0 +1,108 @@
+// Test for the DungeonRuntime render-data builder - issue #333.
+//
+// Verifies buildRenderList turns a live runtime into a draw list: static level features
+// from the game (walls, locked door, toggle wall, key, switch, hazard) plus the live
+// actors from their ECS SpawnTag entities (player/enemy/coin/exit), each with the right
+// per-type color; and that collected/opened/toggled things drop out of the list. Pure std
+// + the header-only ECS / game:
+//   g++ -std=c++17 -I src tests/test_dungeon_render_data.cpp -o test_dungeon_render_data
+
+#include "game/DungeonRenderData.h"
+#include "game/DungeonRuntime.h"
+
+#include <cstdio>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond);  \
+            ++g_failures;                                          \
+        }                                                          \
+    } while (0)
+
+static EntitySpawn sp(const char* t, float x, float z) {
+    return EntitySpawn{t, ecs::Vec3{x, 0.0f, z}, 0.0f};
+}
+static bool sameColor(const RenderColor& a, const RenderColor& b) {
+    return a.r == b.r && a.g == b.g && a.b == b.b;
+}
+static const RenderInstance* find(const std::vector<RenderInstance>& v, const char* type) {
+    for (const auto& i : v) if (i.type == type) return &i;
+    return nullptr;
+}
+
+int main() {
+    SceneDescription scene;
+    world::Box w1, w2;
+    w1.center = ecs::Vec3{0.0f, 0.0f, -3.0f};
+    w1.size = ecs::Vec3{2.0f, 3.0f, 0.4f};
+    w2.center = ecs::Vec3{8.0f, 0.0f, -3.0f};
+    w2.size = ecs::Vec3{2.0f, 3.0f, 0.4f};
+    scene.wallBoxes = {w1, w2};
+    // Pickups on a straight +X path; hazard/enemy off it so a short drive is safe.
+    scene.spawns = {sp("player", 0, 0),   sp("enemy", 20, 20), sp("coin", 1, 0),
+                    sp("exit", 8, 0),      sp("key@1", 2, 0),   sp("lock@1", 4, 0),
+                    sp("switch@1", 3, 0),  sp("toggle@1", 5, 0), sp("hazard", 0, 5)};
+
+    DungeonRuntime rt(loadGame(scene));
+    ecs::Registry reg;
+    rt.spawnInto(reg);
+
+    // Initial draw list: statics from the game + actors from the ECS.
+    std::vector<RenderInstance> list = buildRenderList(reg, rt.game());
+    CHECK(countRenderType(list, "wall") == 2);
+    CHECK(countRenderType(list, "lockeddoor") == 1);
+    CHECK(countRenderType(list, "togglewall") == 1);
+    CHECK(countRenderType(list, "key") == 1);
+    CHECK(countRenderType(list, "switch") == 1);
+    CHECK(countRenderType(list, "hazard") == 1);
+    CHECK(countRenderType(list, "player") == 1);
+    CHECK(countRenderType(list, "enemy") == 1);
+    CHECK(countRenderType(list, "coin") == 1);
+    CHECK(countRenderType(list, "exit") == 1);
+    CHECK(list.size() == 11);
+
+    // Per-type colors and placement.
+    const RenderInstance* player = find(list, "player");
+    const RenderInstance* coin = find(list, "coin");
+    const RenderInstance* wall = find(list, "wall");
+    CHECK(player && sameColor(player->color, renderColorForType("player")));
+    CHECK(player && player->position.x == 0.0f);
+    CHECK(coin && sameColor(coin->color, renderColorForType("coin")));
+    CHECK(wall && sameColor(wall->color, RenderStyle{}.wall));
+
+    // Drive east: collect the coin and key, press the switch. That collects the coin
+    // (entity destroyed), collects the key (opens lock@1), and toggles toggle@1 open.
+    const float dt = 1.0f / 60.0f;
+    for (int i = 0; i < 400 && rt.game().playerPosition.x < 3.4f &&
+                    rt.game().status == GameStatus::Playing;
+         ++i) {
+        rt.update(reg, GameInput{1.0f, 0.0f}, dt);
+    }
+    CHECK(rt.game().status == GameStatus::Playing);
+
+    list = buildRenderList(reg, rt.game());
+    CHECK(countRenderType(list, "coin") == 0);       // collected -> entity destroyed
+    CHECK(countRenderType(list, "key") == 0);        // collected
+    CHECK(countRenderType(list, "lockeddoor") == 0); // opened by the matching key
+    CHECK(countRenderType(list, "togglewall") == 0); // switched off
+    CHECK(countRenderType(list, "player") == 1);
+    const RenderInstance* movedPlayer = find(list, "player");
+    CHECK(movedPlayer && movedPlayer->position.x > 1.0f); // its transform advanced
+    CHECK(countRenderType(list, "wall") == 2);           // statics unaffected
+    CHECK(countRenderType(list, "exit") == 1);
+    CHECK(countRenderType(list, "hazard") == 1);
+
+    if (g_failures == 0) {
+        std::printf("test_dungeon_render_data: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_dungeon_render_data: %d check(s) failed\n", g_failures);
+    return 1;
+}

--- a/tests/test_dungeon_render_gl.cpp
+++ b/tests/test_dungeon_render_gl.cpp
@@ -1,0 +1,183 @@
+// GL render pass for a live DungeonRuntime - issue #333.
+//
+// Proves the render list (test_dungeon_render_data, headless) actually draws: it loads a
+// level, spawns it via DungeonRuntime, builds the draw list, and renders one colored quad
+// per instance (top-down ortho) into an offscreen FBO, then reads the pixels back and
+// asserts each type's color is present. A gl-labelled test (hidden GLFW window + software
+// GL under Xvfb); it skips cleanly if no GL context is available.
+//   built as test_dungeon_render_gl (links glad/glfw/glm)
+
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "game/DungeonRenderData.h"
+#include "game/DungeonRuntime.h"
+
+using namespace IKore;
+
+namespace {
+
+constexpr int kW = 200, kH = 200;
+
+GLuint compile(GLenum type, const char* src) {
+    GLuint s = glCreateShader(type);
+    glShaderSource(s, 1, &src, nullptr);
+    glCompileShader(s);
+    GLint ok = 0;
+    glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        char log[512];
+        glGetShaderInfoLog(s, 512, nullptr, log);
+        std::fprintf(stderr, "shader compile failed: %s\n", log);
+    }
+    return s;
+}
+
+// Presence of a color (bytes) in the RGB readback, within a per-channel tolerance.
+int countColor(const std::vector<unsigned char>& rgb, int r, int g, int b, int tol) {
+    int n = 0;
+    for (std::size_t i = 0; i + 2 < rgb.size(); i += 3) {
+        if (std::abs(int(rgb[i]) - r) <= tol && std::abs(int(rgb[i + 1]) - g) <= tol &&
+            std::abs(int(rgb[i + 2]) - b) <= tol)
+            ++n;
+    }
+    return n;
+}
+
+} // namespace
+
+int main() {
+    if (!glfwInit()) { std::printf("skip: GLFW init failed (no display?)\n"); return 0; }
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+    GLFWwindow* win = glfwCreateWindow(64, 64, "dungeon-render", nullptr, nullptr);
+    if (!win) { std::printf("skip: no GL context\n"); glfwTerminate(); return 0; }
+    glfwMakeContextCurrent(win);
+    if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+        std::printf("skip: could not load GL\n");
+        glfwDestroyWindow(win);
+        glfwTerminate();
+        return 0;
+    }
+
+    // Build a small level and its live draw list.
+    game::SceneDescription scene;
+    scene.spawns = {game::EntitySpawn{"player", ecs::Vec3{2, 0, 2}, 0.0f},
+                    game::EntitySpawn{"coin", ecs::Vec3{5, 0, 5}, 0.0f},
+                    game::EntitySpawn{"exit", ecs::Vec3{8, 0, 8}, 0.0f}};
+    game::DungeonRuntime rt(game::loadGame(scene));
+    ecs::Registry reg;
+    rt.spawnInto(reg);
+    const std::vector<game::RenderInstance> list = buildRenderList(reg, rt.game());
+
+    // Ortho bounds around the instances.
+    float minX = 1e9f, maxX = -1e9f, minZ = 1e9f, maxZ = -1e9f;
+    for (const game::RenderInstance& i : list) {
+        minX = std::fmin(minX, i.position.x - i.size.x);
+        maxX = std::fmax(maxX, i.position.x + i.size.x);
+        minZ = std::fmin(minZ, i.position.z - i.size.z);
+        maxZ = std::fmax(maxZ, i.position.z + i.size.z);
+    }
+    const glm::mat4 mvp = glm::ortho(minX, maxX, minZ, maxZ, -1.0f, 1.0f);
+
+    // Offscreen target.
+    GLuint fbo = 0, tex = 0;
+    glGenFramebuffers(1, &fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kW, kH, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        std::printf("skip: FBO incomplete\n");
+        return 0;
+    }
+    glViewport(0, 0, kW, kH);
+    glClearColor(0.02f, 0.02f, 0.03f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    const char* vs = "#version 330 core\n"
+                     "layout(location=0) in vec2 aPos;\n"
+                     "uniform mat4 uMVP; uniform vec2 uCenter; uniform vec2 uHalf;\n"
+                     "void main(){ vec2 w = uCenter + aPos * uHalf * 2.0;\n"
+                     "  gl_Position = uMVP * vec4(w, 0.0, 1.0); }\n";
+    const char* fs = "#version 330 core\n"
+                     "uniform vec3 uColor; out vec4 F; void main(){ F = vec4(uColor, 1.0); }\n";
+    GLuint prog = glCreateProgram();
+    GLuint v = compile(GL_VERTEX_SHADER, vs), f = compile(GL_FRAGMENT_SHADER, fs);
+    glAttachShader(prog, v);
+    glAttachShader(prog, f);
+    glLinkProgram(prog);
+    glUseProgram(prog);
+
+    const float quad[12] = {-0.5f, -0.5f, 0.5f, -0.5f, 0.5f, 0.5f,
+                            -0.5f, -0.5f, 0.5f, 0.5f,  -0.5f, 0.5f};
+    GLuint vao = 0, vbo = 0;
+    glGenVertexArrays(1, &vao);
+    glGenBuffers(1, &vbo);
+    glBindVertexArray(vao);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(quad), quad, GL_STATIC_DRAW);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(0);
+    glUniformMatrix4fv(glGetUniformLocation(prog, "uMVP"), 1, GL_FALSE, glm::value_ptr(mvp));
+
+    // Draw walls first, then actors (so a marker is not hidden behind a wall).
+    auto draw = [&](const game::RenderInstance& i) {
+        glUniform2f(glGetUniformLocation(prog, "uCenter"), i.position.x, i.position.z);
+        glUniform2f(glGetUniformLocation(prog, "uHalf"), i.size.x * 0.5f, i.size.z * 0.5f);
+        glUniform3f(glGetUniformLocation(prog, "uColor"), i.color.r, i.color.g, i.color.b);
+        glDrawArrays(GL_TRIANGLES, 0, 6);
+    };
+    for (const game::RenderInstance& i : list) if (i.type == "wall") draw(i);
+    for (const game::RenderInstance& i : list) if (i.type != "wall") draw(i);
+    glFinish();
+
+    std::vector<unsigned char> rgba(static_cast<std::size_t>(kW) * kH * 4);
+    glReadPixels(0, 0, kW, kH, GL_RGBA, GL_UNSIGNED_BYTE, rgba.data());
+    std::vector<unsigned char> rgb(static_cast<std::size_t>(kW) * kH * 3);
+    for (std::size_t i = 0; i < static_cast<std::size_t>(kW) * kH; ++i) {
+        rgb[i * 3 + 0] = rgba[i * 4 + 0];
+        rgb[i * 3 + 1] = rgba[i * 4 + 1];
+        rgb[i * 3 + 2] = rgba[i * 4 + 2];
+    }
+
+    int failures = 0;
+    auto expectColor = [&](const char* type, const char* label) {
+        const game::RenderColor c = game::renderColorForType(type);
+        const int r = int(c.r * 255.0f + 0.5f), g = int(c.g * 255.0f + 0.5f), b = int(c.b * 255.0f + 0.5f);
+        const int n = countColor(rgb, r, g, b, 12);
+        if (n <= 0) {
+            std::fprintf(stderr, "FAIL: %s color not present in the render\n", label);
+            ++failures;
+        }
+    };
+    expectColor("player", "player");
+    expectColor("coin", "coin");
+    expectColor("exit", "exit");
+
+    glDeleteFramebuffers(1, &fbo);
+    glDeleteTextures(1, &tex);
+    glDeleteBuffers(1, &vbo);
+    glDeleteVertexArrays(1, &vao);
+    glfwDestroyWindow(win);
+    glfwTerminate();
+
+    if (failures == 0) {
+        std::printf("test_dungeon_render_gl: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_dungeon_render_gl: %d check(s) failed\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Context

Closes #333. The engine-wiring bridge (#332) spawns the dungeon actors as ECS `Transform`+`SpawnTag` entities but nothing drew them. This adds the render path.

## What this does

- **`src/game/DungeonRenderData.h`** - `buildRenderList(reg, game)` turns a live runtime into a flat, renderer-agnostic draw list: static level features from the game (walls, locked doors, toggle walls, keys, switches, hazards) plus the live actors from their ECS `SpawnTag` entities, each with a deterministic per-type color (`renderColorForType`). Only still-relevant things are emitted - a collected coin (ECS entity destroyed), a collected key, an opened door, and a switched-off toggle wall drop out - so the drawn world tracks the sim. Keeping this as data makes the "what to draw" logic unit-testable without GL.

## Tests

- `test_dungeon_render_data` (headless): the list has the expected per-type instances and colors, and collected/opened/toggled features disappear as the runtime advances.
- `test_dungeon_render_gl` (**gl-labelled**): renders the draw list to an offscreen FBO with one colored quad per instance (top-down ortho) and reads pixels back to assert each type's color is actually present - i.e. the render pass draws it. Verified locally under Xvfb + software GL; skips cleanly with no context.

Full 86-test headless suite stays green.

## Notes

The color/instance list is the seam a full material/mesh renderer plugs into (via the `DungeonRuntime` decorate hook); this proves the pass end-to-end with flat quads. Header-only core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_