### PR TITLE
Doodlebound: multi-room levels from the Topology graph (#344)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -690,6 +690,11 @@ add_executable(test_solver
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_solver.cpp
 )
 
+# Multi-room levels from a cv::Topology room/doorway graph (#344) - header-only.
+add_executable(test_multi_room
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_multi_room.cpp
+)
+
 # Headless tower-defense mode on the room topology: doorway-graph pathing, tower
 # damage, lives, win/lose, determinism (#271) - header-only.
 add_executable(test_tower_defense
@@ -1114,6 +1119,7 @@ set(HEADLESS_TESTS
     test_level_share
     test_log_system
     test_menu_system
+    test_multi_room
     test_navmesh
     test_normal_mapping
     test_particle_emit

--- a/src/game/MultiRoom.h
+++ b/src/game/MultiRoom.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "cv/Topology.h"      // cv::Topology, cv::Room, cv::Doorway
+#include "game/DoodleScene.h" // SceneDescription, EntitySpawn, world::Box, detail::appendBox
+#include "game/DungeonGame.h" // DungeonGame, loadGame
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+/**
+ * @file MultiRoom.h
+ * @brief Turn a room-topology graph into a multi-room playable level (issue #344).
+ *
+ * DungeonGame (#164) plays a single connected space, but cv/Topology (#168) already
+ * segments a drawing's walls into rooms, doorways, and a connectivity graph. This
+ * bridges the two: it rebuilds the walls from the topology's cell grid (one wall box
+ * per wall cell), leaves each doorway cell open as a passage, and places the player,
+ * the exit, and one coin objective across distinct rooms - so a level spans several
+ * connected chambers instead of one.
+ *
+ * Because the passages are exactly the topology's doorways, a level is clearable iff
+ * the rooms are connected through them, which the Solver (#316) verifies over the
+ * same DungeonGame collision rules. Each grid cell maps to a @c cellWorld-sized world
+ * square (default 2 units, comfortably wider than the player diameter) so a one-cell
+ * doorway is a clean passage.
+ *
+ * Header-only, deterministic, dependency-free (std + the header-only CV / game types).
+ */
+namespace IKore {
+namespace game {
+
+struct MultiRoomOptions {
+    float cellWorld{2.0f};  ///< world units per topology cell (>= player diameter for clean doorways).
+    float wallHeight{3.0f}; ///< extruded wall height.
+};
+
+struct MultiRoomResult {
+    SceneDescription scene; ///< walls (boxes + mesh) + player/exit/coin spawns across rooms.
+    int roomCount{0};       ///< interior (non-outside) rooms placed.
+    int doorwayCount{0};    ///< doorways left open as passages.
+    int coinCount{0};       ///< coin objectives placed (one per middle room).
+};
+
+/**
+ * @brief Build a multi-room scene from a topology graph.
+ *
+ * Every wall cell becomes a unit wall box; every doorway cell is left open so the two
+ * rooms it separates connect. The player is placed in the lowest-id interior room, the
+ * exit in the highest-id interior room, and one coin in each room in between - all at a
+ * deterministic walkable anchor cell (the first open cell of the room in scan order),
+ * so the player, exit, and objectives span distinct connected rooms.
+ */
+inline MultiRoomResult buildMultiRoom(const cv::Topology& topo, const MultiRoomOptions& opt = {}) {
+    MultiRoomResult out;
+    const float s = opt.cellWorld > 1e-4f ? opt.cellWorld : 2.0f;
+    const float h = opt.wallHeight > 1e-4f ? opt.wallHeight : 3.0f;
+    const int W = topo.width, H = topo.height;
+    if (W <= 0 || H <= 0) return out;
+
+    // Doorway cells stay open (passages); mark them so they are not walled over.
+    std::vector<char> isDoor(static_cast<std::size_t>(W) * H, 0);
+    for (const cv::Doorway& d : topo.doorways) {
+        if (d.x >= 0 && d.y >= 0 && d.x < W && d.y < H)
+            isDoor[static_cast<std::size_t>(d.y) * W + d.x] = 1;
+    }
+    out.doorwayCount = static_cast<int>(topo.doorways.size());
+
+    // Walls: every non-room cell that is not a passable doorway becomes a unit wall box.
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            if (topo.labelAt(x, y) != -1) continue;                     // room floor
+            if (isDoor[static_cast<std::size_t>(y) * W + x]) continue;  // passage
+            const ecs::Vec3 c{x * s, h * 0.5f, y * s};
+            world::Box b;
+            b.center = c;
+            b.size = ecs::Vec3{s, h, s};
+            b.yaw = 0.0f;
+            out.scene.wallBoxes.push_back(b);
+            detail::appendBox(out.scene.wallMesh, c, s, h, s, 0.0f);
+        }
+    }
+
+    // Interior rooms in id order + a deterministic walkable anchor cell for each.
+    std::vector<int> interior;
+    for (const cv::Room& r : topo.rooms)
+        if (!r.isOutside) interior.push_back(r.id);
+    std::sort(interior.begin(), interior.end());
+    out.roomCount = static_cast<int>(interior.size());
+
+    std::vector<ecs::Vec3> anchor(topo.rooms.size(), ecs::Vec3{});
+    std::vector<char> haveAnchor(topo.rooms.size(), 0);
+    for (int y = 0; y < H; ++y) {
+        for (int x = 0; x < W; ++x) {
+            const int id = topo.labelAt(x, y);
+            if (id < 0 || haveAnchor[static_cast<std::size_t>(id)]) continue;
+            anchor[static_cast<std::size_t>(id)] = ecs::Vec3{x * s, 0.0f, y * s};
+            haveAnchor[static_cast<std::size_t>(id)] = 1;
+        }
+    }
+
+    // Spawns across rooms: player first, exit last, one coin per middle room.
+    if (!interior.empty()) {
+        out.scene.spawns.push_back(EntitySpawn{"player", anchor[static_cast<std::size_t>(interior.front())], 0.0f});
+        if (interior.size() >= 2)
+            out.scene.spawns.push_back(EntitySpawn{"exit", anchor[static_cast<std::size_t>(interior.back())], 0.0f});
+        for (std::size_t i = 1; i + 1 < interior.size(); ++i) {
+            out.scene.spawns.push_back(EntitySpawn{"coin", anchor[static_cast<std::size_t>(interior[i])], 0.0f});
+            ++out.coinCount;
+        }
+    }
+    return out;
+}
+
+/// Convenience: a playable multi-room DungeonGame straight from a topology graph.
+inline DungeonGame buildMultiRoomGame(const cv::Topology& topo, const MultiRoomOptions& opt = {}) {
+    return loadGame(buildMultiRoom(topo, opt).scene);
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_multi_room.cpp
+++ b/tests/test_multi_room.cpp
@@ -1,0 +1,125 @@
+// Multi-room levels from a topology graph - issue #344.
+//
+// Builds a 3-room floor plan (two doorways in series: left <-> middle <-> right),
+// derives the room/doorway graph with cv::buildTopologyFromGrid (#168), turns it into a
+// multi-room DungeonGame with buildMultiRoom (#344), and proves it is one playable level
+// clearable across rooms: the Solver (#316) validates cross-room clearability, and driving
+// the solver's route as inputs wins the actual game (player -> coin in the middle -> exit
+// in the far room, through both doorways). Pure std + the header-only CV / game:
+//   g++ -std=c++17 -I src tests/test_multi_room.cpp -o test_multi_room
+
+#include "cv/Topology.h"
+#include "game/MultiRoom.h"
+#include "game/Solver.h"
+
+#include <cstdio>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+// Drive the game along the solver's cell route; returns true if it wins.
+static bool drivePath(DungeonGame& g, const std::vector<ecs::Vec3>& path) {
+    const float dt = 1.0f / 60.0f;
+    for (const ecs::Vec3& wp : path) {
+        for (int guard = 0; guard < 4000 && g.status == GameStatus::Playing; ++guard) {
+            const float dx = wp.x - g.playerPosition.x;
+            const float dz = wp.z - g.playerPosition.z;
+            if (dx * dx + dz * dz < 0.0025f) break;
+            g.update(GameInput{dx, dz}, dt);
+        }
+    }
+    return g.won();
+}
+
+int main() {
+    // A 13x5 grid: three 3-wide rooms separated by vertical walls, each with a
+    // one-cell doorway at row 2. '#' wall, '.' floor, 'D' doorway (a 1-wide gap).
+    //   #############
+    //   #...#...#...#
+    //   #...D...D...#
+    //   #...#...#...#
+    //   #############
+    const int W = 13, H = 5;
+    cv::Mask walls(W, H);
+    for (int x = 0; x < W; ++x) { walls.set(x, 0, 1); walls.set(x, H - 1, 1); }
+    for (int y = 0; y < H; ++y) {
+        walls.set(0, y, 1);
+        walls.set(W - 1, y, 1);
+        walls.set(4, y, 1);  // divider between left and middle
+        walls.set(8, y, 1);  // divider between middle and right
+    }
+    walls.set(4, 2, 0);  // doorway left <-> middle
+    walls.set(8, 2, 0);  // doorway middle <-> right
+
+    // 1. Topology: three interior rooms, two doorways, all connected in a chain.
+    const cv::Topology topo = cv::buildTopologyFromGrid(walls);
+    CHECK(topo.interiorRoomCount() == 3);
+    CHECK(topo.doorways.size() == 2);
+    CHECK(topo.reachable(0, 2)); // far rooms reachable through the middle
+
+    // 2. Multi-room scene: walls rebuilt, doorways left open, spawns across rooms.
+    const MultiRoomResult mr = buildMultiRoom(topo);
+    CHECK(mr.roomCount == 3);
+    CHECK(mr.doorwayCount == 2);
+    CHECK(mr.coinCount == 1); // one middle room between player and exit
+    CHECK(!mr.scene.wallBoxes.empty());
+
+    int players = 0, exits = 0, coins = 0;
+    for (const EntitySpawn& sp : mr.scene.spawns) {
+        if (sp.type == "player") ++players;
+        else if (sp.type == "exit") ++exits;
+        else if (sp.type == "coin") ++coins;
+    }
+    CHECK(players == 1);
+    CHECK(exits == 1);
+    CHECK(coins == 1);
+
+    // Player and exit must sit in different rooms (far apart along +X).
+    const DungeonGame game = loadGame(mr.scene);
+    CHECK(game.hasExit);
+    CHECK(game.exitPosition.x - game.playerPosition.x > 4.0f);
+
+    // 3. Solver proves cross-room clearability.
+    const SolveResult res = solve(game);
+    CHECK(res.solvable);
+    CHECK(res.exitReachable);
+    CHECK(res.totalCoins == 1);
+    CHECK(res.reachableCoins == 1);
+    CHECK(res.unreachableObjectives == 0);
+    CHECK(res.par > 0);
+    CHECK(!res.path.empty());
+
+    // 4. The solver route, driven as inputs, actually clears the level across rooms.
+    DungeonGame play = game;
+    CHECK(drivePath(play, res.path));
+    CHECK(play.won());
+
+    // A disconnected room graph must not be clearable: seal the middle<->right doorway.
+    {
+        cv::Mask sealed = walls;
+        sealed.set(8, 2, 1); // wall the second doorway shut
+        const cv::Topology t2 = cv::buildTopologyFromGrid(sealed);
+        const MultiRoomResult mr2 = buildMultiRoom(t2);
+        const SolveResult r2 = solve(loadGame(mr2.scene));
+        CHECK(!r2.solvable);          // exit now in an unreachable room
+        CHECK(!r2.exitReachable);
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_multi_room: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_multi_room: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #344. Bridges `cv::Topology` (#168) to `DungeonGame` (#164) so a level spans several connected rooms instead of one.

`buildMultiRoom(topo)` (new header `src/game/MultiRoom.h`):
- rebuilds the walls from the topology's cell grid (one unit wall box per wall cell),
- leaves each doorway cell open as a passage,
- places the player in the lowest-id interior room, the exit in the highest-id room, and one coin in each room in between, at a deterministic walkable anchor cell.

Because the passages are exactly the topology's doorways, a level is clearable iff the rooms are connected through them, which the `Solver` (#316) verifies over the same collision rules. Each grid cell maps to a `cellWorld`-sized square (default 2 units, wider than the player diameter) so a one-cell doorway is a clean passage. A convenience `buildMultiRoomGame(topo)` returns a ready `DungeonGame`.

## Testing

`test_multi_room` (headless) builds a 3-room floor plan (left <-> middle <-> right, two doorways in series) and asserts:
- the topology has 3 interior rooms, 2 doorways, and the far rooms are reachable through the middle;
- the multi-room scene rebuilds walls, keeps both doorways open, and places one player / one exit / one coin across distinct rooms (exit far from the player);
- the `Solver` proves cross-room clearability (solvable, exit reachable, coin reachable, `par > 0`);
- driving the solver route as inputs actually wins the level end to end;
- sealing one doorway makes the level unsolvable (exit stranded in a disconnected room).

Built and run via CTest under the `headless` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_