### PR TITLE
Doodlebound: pushable blocks (Sokoban) with solver support (#345)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,6 +680,11 @@ add_executable(test_enemy_behaviors
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_enemy_behaviors.cpp
 )
 
+# Pushable blocks (Sokoban) + block-aware solver over DungeonGame rules (#345) - header-only.
+add_executable(test_pushable_blocks
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_pushable_blocks.cpp
+)
+
 # GeoJSON/OSM map data -> playable DungeonGame world (#313) - header-only.
 add_executable(test_city_game
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_city_game.cpp
@@ -1124,6 +1129,7 @@ set(HEADLESS_TESTS
     test_perf_stats
     test_photo_level
     test_picking
+    test_pushable_blocks
     test_quest_gen
     test_rectify
     test_render_pass_graph

--- a/src/game/DungeonGame.h
+++ b/src/game/DungeonGame.h
@@ -103,6 +103,14 @@ struct Hazard {
     ecs::Vec3 position{};
 };
 
+/// A pushable block (Sokoban, #345). Solid like a wall, but when the player presses into
+/// it and the cell one @c blockGrid step ahead is clear, the block slides one cell over.
+/// A block can be shoved to seal or unseal a passage, so a level can require the correct
+/// pushes to clear (and a wrong push can strand an objective).
+struct Block {
+    ecs::Vec3 position{}; ///< center; moves in whole @c blockGrid steps.
+};
+
 /// A self-contained, headless dungeon game built from a converted scene.
 struct DungeonGame {
     // Geometry + actors (populated by loadGame).
@@ -120,6 +128,9 @@ struct DungeonGame {
     std::vector<ToggleWall> toggleWalls;
     std::vector<Hazard> hazards;
 
+    // Pushable blocks (#345); empty on a classic level, which then plays byte-identically.
+    std::vector<Block> blocks;
+
     // Live ranged-enemy projectiles (#320); empty unless a Ranged enemy has fired.
     std::vector<Projectile> projectiles;
 
@@ -134,6 +145,7 @@ struct DungeonGame {
     float switchRadius{0.5f};
     float hazardRadius{0.4f};
     float featureSize{1.0f}; ///< footprint of a spawned locked door / toggle wall.
+    float blockGrid{1.0f};   ///< pushable-block footprint and per-push step (#345).
     float projectileSpeed{6.0f};      ///< ranged projectile speed.
     float projectileRadius{0.25f};    ///< projectile hit radius.
     float rangedFireInterval{1.0f};   ///< seconds between ranged shots.
@@ -158,8 +170,12 @@ struct DungeonGame {
     void update(const GameInput& in, float dt) {
         if (status != GameStatus::Playing) return;
 
-        // Player movement with wall collision (axis slide).
+        // Pushable blocks (#345): a block directly ahead slides one grid cell if the cell
+        // beyond it is clear. Runs before the move so the vacated cell is then walkable.
         const float len = std::sqrt(in.moveX * in.moveX + in.moveZ * in.moveZ);
+        if (!blocks.empty() && len > 1e-6f) tryPushBlocks(in);
+
+        // Player movement with wall collision (axis slide).
         if (len > 1e-6f) {
             const float step = playerSpeed * dt;
             playerPosition =
@@ -300,6 +316,9 @@ struct DungeonGame {
         for (const ToggleWall& w : toggleWalls) {
             if (w.solid && circleHitsBox(pos, radius, w.box)) return true;
         }
+        for (const Block& b : blocks) {
+            if (circleHitsBox(pos, radius, blockBox(b))) return true;
+        }
         return false;
     }
 
@@ -334,6 +353,55 @@ private:
         const ecs::Vec3 zOnly{from.x, from.y, from.z + dz};
         if (!blocked(zOnly, radius)) return zOnly;
         return from; // fully blocked this step
+    }
+
+    /// The oriented (axis-aligned) footprint box of a pushable block (#345).
+    world::Box blockBox(const Block& b) const {
+        world::Box bb;
+        bb.center = ecs::Vec3{b.position.x, blockGrid * 0.5f, b.position.z};
+        bb.size = ecs::Vec3{blockGrid, blockGrid, blockGrid};
+        bb.yaw = 0.0f;
+        return bb;
+    }
+
+    /// True if a block could occupy cell center @p c: clear of walls, still-closed doors,
+    /// solid toggle walls, and every other block.
+    bool blockTargetClear(const ecs::Vec3& c, const Block* exclude) const {
+        const float r = blockGrid * 0.5f - 1e-3f; // footprint that must fit in the cell
+        if (hitsWall(c, r)) return false;
+        for (const LockedDoor& d : lockedDoors)
+            if (!d.open && circleHitsBox(c, r, d.box)) return false;
+        for (const ToggleWall& w : toggleWalls)
+            if (w.solid && circleHitsBox(c, r, w.box)) return false;
+        for (const Block& o : blocks) {
+            if (&o == exclude) continue;
+            if (std::fabs(c.x - o.position.x) < blockGrid - 1e-3f &&
+                std::fabs(c.z - o.position.z) < blockGrid - 1e-3f)
+                return false;
+        }
+        return true;
+    }
+
+    /// Push the block directly ahead of the player one grid cell, if the cell beyond is
+    /// clear. The push direction is the dominant input axis (tie-break: X), so a diagonal
+    /// press resolves to a single deterministic push.
+    void tryPushBlocks(const GameInput& in) {
+        float dx = 0.0f, dz = 0.0f;
+        if (std::fabs(in.moveX) >= std::fabs(in.moveZ))
+            dx = in.moveX > 0.0f ? 1.0f : (in.moveX < 0.0f ? -1.0f : 0.0f);
+        else
+            dz = in.moveZ > 0.0f ? 1.0f : (in.moveZ < 0.0f ? -1.0f : 0.0f);
+        if (dx == 0.0f && dz == 0.0f) return;
+
+        const float reach = playerRadius + blockGrid * 0.5f + 0.05f;
+        const ecs::Vec3 probe{playerPosition.x + dx * reach, playerPosition.y, playerPosition.z + dz * reach};
+        const float half = blockGrid * 0.5f;
+        for (Block& b : blocks) {
+            if (std::fabs(probe.x - b.position.x) > half || std::fabs(probe.z - b.position.z) > half) continue;
+            const ecs::Vec3 target{b.position.x + dx * blockGrid, b.position.y, b.position.z + dz * blockGrid};
+            if (blockTargetClear(target, &b)) b.position = target;
+            return; // only the block directly ahead of the player
+        }
     }
 };
 
@@ -407,6 +475,8 @@ inline DungeonGame loadGame(const SceneDescription& scene) {
                 ToggleWall{detail::featureBox(s.position, s.yaw, game.featureSize), id, true});
         } else if (base == "hazard" || base == "spike") {
             game.hazards.push_back(Hazard{s.position});
+        } else if (base == "block") {
+            game.blocks.push_back(Block{s.position});
         }
     }
     game.totalCoins = static_cast<int>(game.coins.size());

--- a/src/game/Solver.h
+++ b/src/game/Solver.h
@@ -5,8 +5,10 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <map>
 #include <queue>
 #include <string>
+#include <utility>
 #include <vector>
 
 /**
@@ -83,6 +85,7 @@ inline SolverGrid buildGrid(const DungeonGame& g, const SolveOptions& opt) {
     for (const world::Box& b : g.walls) grow(b.center, 0.5f * std::max(std::fabs(b.size.x), std::fabs(b.size.z)));
     for (const Coin& c : g.coins) grow(c.position, 0.0f);
     for (const Enemy& e : g.enemies) grow(e.position, 0.0f);
+    for (const Block& b : g.blocks) grow(b.position, 0.5f * g.blockGrid);
     if (g.hasExit) grow(g.exitPosition, 0.0f);
 
     SolverGrid grid;
@@ -99,6 +102,195 @@ inline SolverGrid buildGrid(const DungeonGame& g, const SolveOptions& opt) {
 } // namespace detail
 
 /**
+ * @brief Block-aware solver (Sokoban): BFS over (player cell, coin mask, block cells).
+ *
+ * Used automatically by solve() when the level has pushable blocks (#345). A step moves the
+ * player to an adjacent walkable cell; if that cell holds a block and the cell one step
+ * beyond is walkable and block-free, the block is pushed there instead (still one player
+ * step, so @c par stays comparable to the block-free solver). Static walls, still-closed
+ * doors, and solid toggle walls are impassable, evaluated at the start state - so a level
+ * mixing blocks with keys/doors is treated conservatively (doors assumed closed).
+ *
+ * The grid step is @c blockGrid so one push equals one cell. The state space is
+ * cells * 2^coins * (block placements); a bounded backstop stops a pathological search.
+ */
+inline SolveResult solveWithBlocks(const DungeonGame& game, const SolveOptions& opt) {
+    SolveResult res;
+    res.totalCoins = static_cast<int>(game.coins.size());
+    const int nCoins = res.totalCoins;
+
+    SolveOptions bopt = opt;
+    bopt.cellSize = game.blockGrid > 1e-4f ? game.blockGrid : 1.0f; // one push == one cell
+    const detail::SolverGrid grid = detail::buildGrid(game, bopt);
+    const int cellCount = grid.nx * grid.nz;
+    if (cellCount <= 0) return res;
+    const int nx = grid.nx;
+
+    // Static walkability WITHOUT the blocks (blocks are dynamic state): a block-free copy so
+    // blocked() still accounts for walls, closed doors, and solid toggle walls.
+    DungeonGame stat = game;
+    stat.blocks.clear();
+    std::vector<char> walkable(static_cast<std::size_t>(cellCount), 0);
+    std::vector<std::uint32_t> coinsAt(static_cast<std::size_t>(cellCount), 0);
+    std::vector<char> exitAt(static_cast<std::size_t>(cellCount), 0);
+    for (int i = 0; i < cellCount; ++i) {
+        const ecs::Vec3 c = grid.center(i);
+        if (stat.blocked(c, game.playerRadius)) continue;
+        walkable[static_cast<std::size_t>(i)] = 1;
+        for (int k = 0; k < nCoins; ++k) {
+            const Coin& coin = game.coins[static_cast<std::size_t>(k)];
+            const float dx = c.x - coin.position.x, dz = c.z - coin.position.z;
+            const float r = game.playerRadius + game.coinRadius;
+            if (dx * dx + dz * dz <= r * r) coinsAt[static_cast<std::size_t>(i)] |= (1u << k);
+        }
+        if (game.hasExit) {
+            const float dx = c.x - game.exitPosition.x, dz = c.z - game.exitPosition.z;
+            const float r = game.playerRadius + game.exitRadius;
+            if (dx * dx + dz * dz <= r * r) exitAt[static_cast<std::size_t>(i)] = 1;
+        }
+    }
+
+    const int start = grid.cellOf(game.playerPosition.x, game.playerPosition.z);
+    if (start < 0 || !walkable[static_cast<std::size_t>(start)]) return res; // player boxed in
+
+    std::vector<int> startBlocks;
+    for (const Block& b : game.blocks) {
+        const int bc = grid.cellOf(b.position.x, b.position.z);
+        if (bc < 0) return res; // block off the grid: cannot model
+        startBlocks.push_back(bc);
+    }
+    std::sort(startBlocks.begin(), startBlocks.end());
+
+    if (nCoins > opt.maxCoinsExact) return res; // too many coins for the exact mask search
+    const std::uint32_t full = nCoins >= 32 ? 0xFFFFFFFFu : ((1u << nCoins) - 1u);
+
+    const int dxs[4] = {1, -1, 0, 0}, dzs[4] = {0, 0, 1, -1};
+    const std::size_t kStateCap = 4000000; // bounded-search backstop
+
+    auto blockIndexAt = [](const std::vector<int>& bl, int cell) -> int {
+        for (std::size_t i = 0; i < bl.size(); ++i)
+            if (bl[i] == cell) return static_cast<int>(i);
+        return -1;
+    };
+    // State key = [cell, mask, sorted block cells...].
+    auto encode = [&](int cell, std::uint32_t mask, const std::vector<int>& bl) {
+        std::vector<int> key;
+        key.reserve(bl.size() + 2);
+        key.push_back(cell);
+        key.push_back(static_cast<int>(mask));
+        for (int c : bl) key.push_back(c);
+        return key;
+    };
+
+    // Gated BFS: shortest player-step route that collects every coin and stands on the exit.
+    std::map<std::vector<int>, int> dist;
+    std::map<std::vector<int>, std::vector<int>> parent;
+    const std::vector<int> startKey = encode(start, coinsAt[static_cast<std::size_t>(start)], startBlocks);
+    dist[startKey] = 0;
+    std::queue<std::vector<int>> q;
+    q.push(startKey);
+    std::vector<int> goalKey;
+    bool found = false;
+    while (!q.empty()) {
+        const std::vector<int> cur = q.front();
+        q.pop();
+        const int cell = cur[0];
+        const std::uint32_t mask = static_cast<std::uint32_t>(cur[1]);
+        if (mask == full && exitAt[static_cast<std::size_t>(cell)]) { goalKey = cur; found = true; break; }
+        const int d0 = dist[cur];
+        const std::vector<int> bl(cur.begin() + 2, cur.end());
+        const int gx = cell % nx, gz = cell / nx;
+        for (int d = 0; d < 4; ++d) {
+            const int nb = grid.index(gx + dxs[d], gz + dzs[d]);
+            if (nb < 0 || !walkable[static_cast<std::size_t>(nb)]) continue;
+            std::vector<int> nbl = bl;
+            const int bidx = blockIndexAt(bl, nb);
+            if (bidx >= 0) { // pushing a block
+                const int beyond = grid.index(gx + 2 * dxs[d], gz + 2 * dzs[d]);
+                if (beyond < 0 || !walkable[static_cast<std::size_t>(beyond)]) continue;
+                if (blockIndexAt(bl, beyond) >= 0) continue;
+                nbl[static_cast<std::size_t>(bidx)] = beyond;
+                std::sort(nbl.begin(), nbl.end());
+            }
+            const std::uint32_t nmask = mask | coinsAt[static_cast<std::size_t>(nb)];
+            const std::vector<int> nkey = encode(nb, nmask, nbl);
+            if (dist.find(nkey) != dist.end()) continue;
+            dist[nkey] = d0 + 1;
+            parent[nkey] = cur;
+            q.push(nkey);
+        }
+        if (dist.size() > kStateCap) break;
+    }
+
+    if (found) {
+        res.solvable = true;
+        res.par = dist[goalKey];
+        res.reachableCoins = nCoins;
+        res.exitReachable = true;
+        res.unreachableObjectives = 0;
+        std::vector<int> cells;
+        std::vector<int> s = goalKey;
+        while (true) {
+            cells.push_back(s[0]);
+            const auto it = parent.find(s);
+            if (it == parent.end()) break;
+            s = it->second;
+        }
+        std::reverse(cells.begin(), cells.end());
+        for (int c : cells) res.path.push_back(grid.center(c));
+        return res;
+    }
+
+    // Unsolvable: report what the player could still reach (ignoring coin gating) by
+    // exploring (player cell, block cells) states.
+    std::map<std::vector<int>, char> seen;
+    auto rkey = [&](int cell, const std::vector<int>& bl) {
+        std::vector<int> k;
+        k.reserve(bl.size() + 1);
+        k.push_back(cell);
+        for (int c : bl) k.push_back(c);
+        return k;
+    };
+    std::queue<std::pair<int, std::vector<int>>> rq;
+    rq.push({start, startBlocks});
+    seen[rkey(start, startBlocks)] = 1;
+    std::uint32_t reachMask = coinsAt[static_cast<std::size_t>(start)];
+    bool exitSeen = exitAt[static_cast<std::size_t>(start)] != 0;
+    while (!rq.empty()) {
+        const std::pair<int, std::vector<int>> curp = rq.front();
+        rq.pop();
+        const int cell = curp.first;
+        const std::vector<int>& bl = curp.second;
+        const int gx = cell % nx, gz = cell / nx;
+        for (int d = 0; d < 4; ++d) {
+            const int nb = grid.index(gx + dxs[d], gz + dzs[d]);
+            if (nb < 0 || !walkable[static_cast<std::size_t>(nb)]) continue;
+            std::vector<int> nbl = bl;
+            const int bidx = blockIndexAt(bl, nb);
+            if (bidx >= 0) {
+                const int beyond = grid.index(gx + 2 * dxs[d], gz + 2 * dzs[d]);
+                if (beyond < 0 || !walkable[static_cast<std::size_t>(beyond)]) continue;
+                if (blockIndexAt(bl, beyond) >= 0) continue;
+                nbl[static_cast<std::size_t>(bidx)] = beyond;
+                std::sort(nbl.begin(), nbl.end());
+            }
+            const std::vector<int> k = rkey(nb, nbl);
+            if (seen.find(k) != seen.end()) continue;
+            seen[k] = 1;
+            reachMask |= coinsAt[static_cast<std::size_t>(nb)];
+            if (exitAt[static_cast<std::size_t>(nb)]) exitSeen = true;
+            rq.push({nb, nbl});
+        }
+        if (seen.size() > kStateCap) break;
+    }
+    for (int k = 0; k < nCoins; ++k)
+        if (reachMask & (1u << k)) ++res.reachableCoins;
+    res.exitReachable = exitSeen;
+    res.unreachableObjectives = (nCoins - res.reachableCoins) + (exitSeen ? 0 : 1);
+    return res;
+}
+
+/**
  * @brief Prove a level clearable and return the optimal clear route.
  *
  * BFS over (cell, coin bitmask): the start cell seeds whatever coins are collectible
@@ -109,6 +301,10 @@ inline SolverGrid buildGrid(const DungeonGame& g, const SolveOptions& opt) {
 inline SolveResult solve(const DungeonGame& game, const SolveOptions& opt = {}) {
     SolveResult res;
     res.totalCoins = static_cast<int>(game.coins.size());
+
+    // Pushable-block levels need the Sokoban-aware search (#345); classic levels take the
+    // original fast path below unchanged.
+    if (!game.blocks.empty()) return solveWithBlocks(game, opt);
 
     const detail::SolverGrid grid = detail::buildGrid(game, opt);
     const int cellCount = grid.nx * grid.nz;

--- a/tests/test_pushable_blocks.cpp
+++ b/tests/test_pushable_blocks.cpp
@@ -1,0 +1,163 @@
+// Pushable blocks (Sokoban) with solver support - issue #345.
+//
+// Two halves: the game mechanic (a block ahead of the player slides one grid cell when the
+// cell beyond is clear, and does not move when it is walled), and the block-aware Solver
+// (BFS over player + block positions) classifying solvable / unsolvable and par correctly.
+// A pinch puzzle is clearable only by pushing the block down through the choke twice; the
+// same puzzle with no escape below the choke is unsolvable. Classic (block-free) levels are
+// unaffected. Pure std + the header-only game / solver:
+//   g++ -std=c++17 -I src tests/test_pushable_blocks.cpp -o test_pushable_blocks
+
+#include "game/DungeonGame.h"
+#include "game/Solver.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+// World units per cell (== blockGrid). Wide enough that the exit pickup radius covers only
+// its own cell, so the solver's par is an exact cell count.
+static const float S = 2.0f;
+
+// Build a DungeonGame from an ASCII grid: '#' wall, '.' floor, 'P' player, 'B' block,
+// 'E' exit, 'C' coin. Cell (x,y) maps to world (x*S, 0, y*S); walls are S-sized boxes.
+static DungeonGame buildGame(const std::vector<std::string>& rows) {
+    SceneDescription scene;
+    for (int y = 0; y < static_cast<int>(rows.size()); ++y) {
+        for (int x = 0; x < static_cast<int>(rows[y].size()); ++x) {
+            const char ch = rows[y][x];
+            const ecs::Vec3 p{x * S, 0.0f, y * S};
+            if (ch == '#') {
+                world::Box b;
+                b.center = ecs::Vec3{p.x, S * 0.5f, p.z};
+                b.size = ecs::Vec3{S, S, S};
+                b.yaw = 0.0f;
+                scene.wallBoxes.push_back(b);
+            } else if (ch == 'P') {
+                scene.spawns.push_back(EntitySpawn{"player", p, 0.0f});
+            } else if (ch == 'B') {
+                scene.spawns.push_back(EntitySpawn{"block", p, 0.0f});
+            } else if (ch == 'E') {
+                scene.spawns.push_back(EntitySpawn{"exit", p, 0.0f});
+            } else if (ch == 'C') {
+                scene.spawns.push_back(EntitySpawn{"coin", p, 0.0f});
+            }
+        }
+    }
+    DungeonGame g = loadGame(scene);
+    g.blockGrid = S;
+    return g;
+}
+
+static void hold(DungeonGame& g, float mx, float mz, int frames) {
+    const float dt = 1.0f / 60.0f;
+    for (int i = 0; i < frames && g.status == GameStatus::Playing; ++i)
+        g.update(GameInput{mx, mz}, dt);
+}
+
+static bool drivePath(DungeonGame& g, const std::vector<ecs::Vec3>& path) {
+    const float dt = 1.0f / 60.0f;
+    for (const ecs::Vec3& wp : path) {
+        for (int i = 0; i < 4000 && g.status == GameStatus::Playing; ++i) {
+            const float dx = wp.x - g.playerPosition.x, dz = wp.z - g.playerPosition.z;
+            if (dx * dx + dz * dz < 0.0025f) break;
+            g.update(GameInput{dx, dz}, dt);
+        }
+    }
+    return g.won();
+}
+
+int main() {
+    // 1. Mechanic: the player pushes a block along a clear corridor and stays behind it.
+    {
+        DungeonGame g = buildGame({"########",
+                                   "#P.B...#",
+                                   "########"});
+        CHECK(g.blocks.size() == 1);
+        const float x0 = g.blocks[0].position.x;
+        hold(g, 1.0f, 0.0f, 400);
+        CHECK(g.blocks[0].position.x > x0 + S - 0.01f);   // pushed at least one cell
+        CHECK(g.playerPosition.x < g.blocks[0].position.x); // player stays behind the block
+    }
+
+    // 2. Mechanic: a block against a wall cannot be pushed, and blocks the player.
+    {
+        DungeonGame g = buildGame({"######",
+                                   "#PB#.#",
+                                   "######"});
+        const float bx0 = g.blocks[0].position.x;
+        hold(g, 1.0f, 0.0f, 400);
+        CHECK(g.blocks[0].position.x == bx0);              // wall behind it: no move
+        CHECK(g.playerPosition.x < g.blocks[0].position.x); // player cannot pass through it
+    }
+
+    // 3. Solver: a pinch puzzle solvable only by pushing the block down through the choke.
+    //    Push (down, down), then walk around to the exit: par = 4 player steps.
+    {
+        DungeonGame g = buildGame({"#####",
+                                   "#.P.#",
+                                   "##B##",
+                                   "#...#",
+                                   "#E..#",
+                                   "#####"});
+        const SolveResult r = solve(g);
+        CHECK(r.solvable);
+        CHECK(r.exitReachable);
+        CHECK(r.par == 4);
+        CHECK(r.path.size() == static_cast<std::size_t>(r.par) + 1);
+        // Deterministic: same result on a second run.
+        const SolveResult r2 = solve(g);
+        CHECK(r2.solvable && r2.par == r.par);
+    }
+
+    // 4. Solver: the same choke with no room below is unsolvable - the only push seals the
+    //    single passage into the exit room.
+    {
+        DungeonGame g = buildGame({"#####",
+                                   "#.P.#",
+                                   "##B##",
+                                   "#E..#",
+                                   "#####"});
+        const SolveResult r = solve(g);
+        CHECK(!r.solvable);
+        CHECK(r.par == -1);
+        CHECK(!r.exitReachable);
+    }
+
+    // 5. Classic (no blocks) is unaffected: the block-free solver path still classifies and
+    //    the game still drives to a win along the returned route.
+    {
+        DungeonGame g = buildGame({"######",
+                                   "#P.CE#",
+                                   "######"});
+        CHECK(g.blocks.empty());
+        const SolveResult r = solve(g);
+        CHECK(r.solvable);
+        CHECK(r.totalCoins == 1);
+        CHECK(r.reachableCoins == 1);
+        CHECK(r.exitReachable);
+        CHECK(r.par > 0);
+        DungeonGame play = g;
+        CHECK(drivePath(play, r.path));
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_pushable_blocks: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_pushable_blocks: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #345. Adds pushable blocks and extends the `Solver` (#316) so block puzzles stay provably clearable.

**Game (`DungeonGame.h`)**
- New `"block"` spawn: a solid, pushable box (`std::vector<Block> blocks`, footprint/step `blockGrid`).
- When the player presses into a block and the cell one `blockGrid` step ahead is clear (no wall, still-closed door, solid toggle wall, or other block), the block slides one cell. The push direction is the dominant input axis, so a diagonal press resolves to one deterministic push.
- Blocks are solid in `blocked()`, so they obstruct the player (and enemies) and a wrongly-pushed block can seal a passage.

**Solver (`Solver.h`)**
- When a level has blocks, `solve()` dispatches to a new Sokoban-aware `solveWithBlocks`: BFS over `(player cell, coin mask, sorted block cells)`. A push is one player step, so `par` stays comparable to the block-free solver. Static walls, closed doors, and solid toggle walls are impassable (evaluated at the start state; block+door levels are handled conservatively). The grid step is `blockGrid` so one push equals one cell, with a bounded-search backstop.
- Block-free levels take the original fast path unchanged and play byte-identically.

## Testing

`test_pushable_blocks` (headless):
- mechanic: the player pushes a block along a clear corridor and stays behind it; a block against a wall does not move and blocks the player;
- solver: a pinch puzzle solvable only by pushing the block down through the choke twice reports `solvable` with `par == 4` (and `path.size() == par + 1`, deterministic across runs);
- solver: the same choke with no room below is `unsolvable` (`par == -1`, exit unreachable) because the only push seals the passage;
- classic (block-free) levels are unaffected: the original solver path still classifies and the game drives to a win.

Regression-checked `test_solver`, `test_dungeon_game`, `test_dungeon_features`, `test_enemy_behaviors` locally. Built and run via CTest under the `headless` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_