### PR TITLE
Doodlebound: par-based star ratings (#346)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,6 +804,11 @@ add_executable(test_leaderboard
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_leaderboard.cpp
 )
 
+# Par-based 1-3 star ratings on leaderboard + weekly submissions (#346) - header-only.
+add_executable(test_star_rating
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_star_rating.cpp
+)
+
 # Solver-backed fairness gate for leaderboard/weekly-challenge submissions (#334) - header-only.
 add_executable(test_fairness_gate
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_fairness_gate.cpp
@@ -1147,6 +1152,7 @@ set(HEADLESS_TESTS
     test_solver
     test_spectator_ui
     test_ssao_kernel
+    test_star_rating
     test_svg_floorplan
     test_symbol_recognizer
     test_symbol_spawns

--- a/src/game/Leaderboard.h
+++ b/src/game/Leaderboard.h
@@ -5,6 +5,7 @@
 #include "game/Fairness.h"     // checkLevelFairness (opt-in solvability gate, #334)
 #include "game/LevelFormat.h"  // fromLevelJson, LevelSpec
 #include "game/LevelShare.h"   // shareCodeFor
+#include "game/StarRating.h"   // StarConfig, starsForClear (#346)
 
 #include <algorithm>
 #include <cmath>
@@ -80,6 +81,7 @@ struct ScoreEntry {
     double clearTime{0.0};
     int steps{0};
     std::int64_t submittedAt{0};
+    int stars{0}; ///< 1-3 stars of this best run vs par, 0 if par unknown (#346).
 };
 
 /// Result of a submission attempt.
@@ -88,6 +90,7 @@ struct SubmitResult {
     bool improved{false};  ///< it was the player's first or a new personal best.
     double clearTime{0.0};
     int rank{0};           ///< 1-based rank after this submission (0 if not accepted).
+    int stars{0};          ///< 1-3 stars earned by this run vs par, 0 if par unknown (#346).
     std::string reason;    ///< why an unaccepted run was rejected.
 };
 
@@ -128,6 +131,10 @@ public:
     bool hasLevel(const std::string& code) const { return m_levels.count(code) > 0; }
     double fixedDt() const { return m_fixedDt; }
 
+    /// Tune the star-rating thresholds/constants applied at submit time (#346).
+    void setStarConfig(const StarConfig& cfg) { m_starCfg = cfg; }
+    const StarConfig& starConfig() const { return m_starCfg; }
+
     /**
      * @brief Submit a run for @p player on level @p code.
      *
@@ -164,18 +171,23 @@ public:
 
         res.accepted = true;
         res.clearTime = rr.clearTime;
+        // Star rating vs the recorded solver par (#346). Par is only known when fairness is
+        // enforced; without it stars stay 0 (rankings are unchanged either way).
+        const int par = parFor(code);
+        res.stars = par > 0 ? starsForClear(rr.clearTime, par, m_starCfg) : 0;
         std::vector<ScoreEntry>& board = m_scores[code];
         ScoreEntry* existing = nullptr;
         for (ScoreEntry& e : board) {
             if (e.player == player) { existing = &e; break; }
         }
         if (existing == nullptr) {
-            board.push_back(ScoreEntry{player, rr.clearTime, rr.steps, submittedAt});
+            board.push_back(ScoreEntry{player, rr.clearTime, rr.steps, submittedAt, res.stars});
             res.improved = true;
         } else if (rr.clearTime < existing->clearTime) {
             existing->clearTime = rr.clearTime;
             existing->steps = rr.steps;
             existing->submittedAt = submittedAt;
+            existing->stars = res.stars;
             res.improved = true;
         }
         // Keep the winning trace so a rank's ghost can be fetched later (issue #272).
@@ -248,6 +260,7 @@ private:
 
     static const std::size_t kMaxInputs = 1000000;
     double m_fixedDt;
+    StarConfig m_starCfg{}; ///< star-rating tunables applied at submit time (#346).
     bool m_enforceFairness{false};
     std::string m_lastRegisterReason;
     std::unordered_map<std::string, int> m_par; ///< solver par per fair level (when enforced).

--- a/src/game/StarRating.h
+++ b/src/game/StarRating.h
@@ -1,0 +1,50 @@
+#pragma once
+
+/**
+ * @file StarRating.h
+ * @brief Deterministic 1-3 star ratings from a run's clear time versus solver par (#346).
+ *
+ * The Solver (#316) reports the optimal clear length "par" as a count of grid steps. A run
+ * earns stars by how close its clear time comes to that optimum: a near-par run gets 3
+ * stars, progressively slower runs get 2 then 1. To compare a wall-time clear against a
+ * grid-step par, par is first turned into an ideal traversal time - the time to walk the
+ * optimal path at full speed: parTime = par * cellSize / playerSpeed - using the solver's
+ * cell size (#316 default 0.5) and the game's player speed (DungeonGame default 4.0). The
+ * ratio clearTime / parTime then drives the star thresholds.
+ *
+ * Header-only, std-free, deterministic: same inputs always yield the same stars.
+ */
+namespace IKore {
+namespace game {
+
+/// Tunable star thresholds and the par-time conversion constants.
+struct StarConfig {
+    double three{1.20};      ///< clearTime <= parTime * three  -> 3 stars (near-optimal).
+    double two{2.00};        ///< clearTime <= parTime * two    -> 2 stars; slower -> 1.
+    double cellSize{0.5};    ///< solver grid cell size used to compute par (SolveOptions default).
+    double playerSpeed{4.0}; ///< player speed used to convert path length to time (DungeonGame default).
+};
+
+/// Ideal traversal time for an integer solver @p par (grid steps); 0 if par is unknown.
+inline double parTime(int par, const StarConfig& cfg = {}) {
+    if (par <= 0 || cfg.playerSpeed <= 0.0) return 0.0;
+    return (static_cast<double>(par) * cfg.cellSize) / cfg.playerSpeed;
+}
+
+/**
+ * @brief Stars (1-3) earned by a cleared run.
+ * @param clearTime the run's clear time (seconds), e.g. RunResult::clearTime.
+ * @param par       the solver par (grid steps) for the level.
+ * @return 3 for a near-par run, 2 then 1 as it slows; 0 when par or clearTime is undefined.
+ */
+inline int starsForClear(double clearTime, int par, const StarConfig& cfg = {}) {
+    const double pt = parTime(par, cfg);
+    if (pt <= 0.0 || clearTime <= 0.0) return 0;
+    const double ratio = clearTime / pt;
+    if (ratio <= cfg.three) return 3;
+    if (ratio <= cfg.two) return 2;
+    return 1;
+}
+
+} // namespace game
+} // namespace IKore

--- a/src/game/WeeklyChallenge.h
+++ b/src/game/WeeklyChallenge.h
@@ -56,10 +56,12 @@ public:
      * @param epoch          Timestamp of week 0's start (the rotation anchor).
      * @param fixedDt        Fixed timestep the per-week boards verify against (#242).
      */
+    /// @param enforceFairness when true, per-week boards enforce solvability and record par,
+    ///        so submissions are star-rated (#346). Off by default (behavior unchanged).
     explicit WeeklyChallenge(std::int64_t secondsPerWeek = kSecondsPerWeek, std::int64_t epoch = 0,
-                             double fixedDt = 1.0 / 60.0)
+                             double fixedDt = 1.0 / 60.0, bool enforceFairness = false)
         : m_secondsPerWeek(secondsPerWeek > 0 ? secondsPerWeek : kSecondsPerWeek),
-          m_epoch(epoch), m_fixedDt(fixedDt) {}
+          m_epoch(epoch), m_fixedDt(fixedDt), m_enforceFairness(enforceFairness) {}
 
     /// Week index for @p now (floored; can be negative before the epoch).
     int weekIndexAt(std::int64_t now) const {
@@ -141,7 +143,8 @@ public:
             res.reason = "no featured level";
             return res;
         }
-        Leaderboard& board = m_boards.emplace(info.weekIndex, Leaderboard(m_fixedDt)).first->second;
+        Leaderboard& board =
+            m_boards.emplace(info.weekIndex, Leaderboard(m_fixedDt, m_enforceFairness)).first->second;
         const std::string code = board.registerLevel(info.level.levelJson); // idempotent (content code)
         m_weekCode[info.weekIndex] = code;
         return board.submit(code, player, trace, submittedAt, claimedTime);
@@ -174,6 +177,7 @@ private:
     std::int64_t m_secondsPerWeek;
     std::int64_t m_epoch;
     double m_fixedDt;
+    bool m_enforceFairness{false};                   ///< per-week boards record par + rate stars (#346).
     std::unordered_map<int, Leaderboard> m_boards;   ///< per-week competition boards.
     std::unordered_map<int, std::string> m_weekCode; ///< week index -> featured level code.
 };

--- a/tests/test_star_rating.cpp
+++ b/tests/test_star_rating.cpp
@@ -1,0 +1,163 @@
+// Par-based star ratings - issue #346.
+//
+// The Solver reports optimal par (#316); this awards 1-3 stars from a run's clear time
+// versus par and surfaces them on the leaderboard (#242) and the weekly challenge (#273).
+// Checks: the pure star function maps time/par to 3 -> 2 -> 1 with tunable thresholds and
+// is deterministic; a verified leaderboard submission carries stars (when par is known via
+// enforced fairness) and a faster run never scores fewer stars than a slower one; and a
+// weekly submission is star-rated when the challenge opts into fairness. Pure std +
+// header-only:
+//   g++ -std=c++17 -I src tests/test_star_rating.cpp -o test_star_rating
+
+#include "doodle/Doodle.h"
+#include "game/StarRating.h"
+#include "game/WeeklyChallenge.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static std::string makeLevelJson() {
+    doodle::LevelSpec s;
+    s.walls.push_back(doodle::Wall{{{10, 0, 10}, {40, 0, 10}, {40, 0, 40}, {10, 0, 40}, {10, 0, 10}}});
+    s.symbols.push_back(doodle::Symbol{"player", doodle::Vec3{15, 0, 15}, 0.0f});
+    s.symbols.push_back(doodle::Symbol{"coin", doodle::Vec3{25, 0, 25}, 0.0f});
+    s.symbols.push_back(doodle::Symbol{"exit", doodle::Vec3{34, 0, 34}, 0.0f});
+    return doodle::saveLevel(s);
+}
+
+// A greedy client toward the nearest uncollected coin then the exit (a real clearing run).
+static RunTrace playGreedy(const std::string& json, double dt, int maxSteps) {
+    RunTrace tr;
+    tr.dt = dt;
+    LevelSpec spec;
+    doodle::loadLevel(json, spec);
+    DungeonGame g = loadGame(convert(spec));
+    for (int step = 0; step < maxSteps && g.status == GameStatus::Playing; ++step) {
+        ecs::Vec3 target = g.exitPosition;
+        double best = 1e30;
+        for (const Coin& c : g.coins) {
+            if (c.collected) continue;
+            const double d = std::hypot(c.position.x - g.playerPosition.x, c.position.z - g.playerPosition.z);
+            if (d < best) { best = d; target = c.position; }
+        }
+        const GameInput in{target.x - g.playerPosition.x, target.z - g.playerPosition.z};
+        tr.inputs.push_back(in);
+        g.update(in, static_cast<float>(dt));
+    }
+    return tr;
+}
+
+static RunTrace padded(const RunTrace& base, int idleFrames) {
+    RunTrace tr;
+    tr.dt = base.dt;
+    for (int i = 0; i < idleFrames; ++i) tr.inputs.push_back(GameInput{0.0f, 0.0f});
+    for (const GameInput& in : base.inputs) tr.inputs.push_back(in);
+    return tr;
+}
+
+int main() {
+    // 1. Pure star function: par-time -> 3 stars, progressively slower -> 2 then 1.
+    {
+        const int par = 100;
+        const double pt = parTime(par);          // 100 * 0.5 / 4.0
+        CHECK(std::fabs(pt - 12.5) < 1e-9);
+        CHECK(starsForClear(pt, par) == 3);       // exactly par -> 3
+        CHECK(starsForClear(pt * 1.20, par) == 3); // at the 3-star threshold
+        CHECK(starsForClear(pt * 1.30, par) == 2);
+        CHECK(starsForClear(pt * 2.00, par) == 2); // at the 2-star threshold
+        CHECK(starsForClear(pt * 2.50, par) == 1);
+        CHECK(starsForClear(pt * 8.00, par) == 1);
+        // Monotonic: never more stars for a slower time.
+        CHECK(starsForClear(pt, par) >= starsForClear(pt * 1.5, par));
+        CHECK(starsForClear(pt * 1.5, par) >= starsForClear(pt * 3.0, par));
+        // Undefined inputs -> 0 stars.
+        CHECK(starsForClear(pt, 0) == 0);
+        CHECK(starsForClear(0.0, par) == 0);
+        CHECK(parTime(0) == 0.0);
+        // Tunable thresholds.
+        StarConfig strict;
+        strict.three = 1.05;
+        CHECK(starsForClear(pt * 1.10, par, strict) == 2); // now outside 3-star band
+    }
+
+    // 2. Leaderboard: a verified run is star-rated against the recorded par, and a slower
+    //    run never earns more stars than a faster one.
+    {
+        Leaderboard lb(1.0 / 60.0, /*enforceFairness=*/true);
+        const std::string json = makeLevelJson();
+        const std::string code = lb.registerLevel(json);
+        CHECK(!code.empty());
+        CHECK(lb.parFor(code) > 0);
+
+        const RunTrace fast = playGreedy(json, lb.fixedDt(), 5000);
+        const RunTrace slow = padded(fast, 120);
+
+        const SubmitResult a = lb.submit(code, "alice", fast, 1);
+        const SubmitResult b = lb.submit(code, "bob", slow, 2);
+        CHECK(a.accepted && b.accepted);
+        CHECK(a.stars >= 1 && a.stars <= 3);
+        CHECK(b.stars >= 1 && b.stars <= 3);
+        // Stars are exactly what the star function gives for the verified time + par.
+        CHECK(a.stars == starsForClear(a.clearTime, lb.parFor(code)));
+        CHECK(b.stars == starsForClear(b.clearTime, lb.parFor(code)));
+        CHECK(b.stars <= a.stars); // slower run: no more stars
+        // The stored best entry carries the run's stars.
+        const std::vector<ScoreEntry> board = lb.top(code);
+        CHECK(!board.empty());
+        CHECK(board[0].player == "alice");
+        CHECK(board[0].stars == a.stars);
+    }
+
+    // 3. Without enforced fairness the par is unknown, so stars stay 0 (rankings unchanged).
+    {
+        Leaderboard lb(1.0 / 60.0); // fairness off
+        const std::string json = makeLevelJson();
+        const std::string code = lb.registerLevel(json);
+        const RunTrace fast = playGreedy(json, lb.fixedDt(), 5000);
+        const SubmitResult r = lb.submit(code, "alice", fast, 1);
+        CHECK(r.accepted);
+        CHECK(r.stars == 0);
+        CHECK(lb.parFor(code) == -1);
+    }
+
+    // 4. Weekly challenge: opt-in fairness makes submissions star-rated; default does not.
+    {
+        LevelCatalog cat;
+        cat.publish("ann", "Aaa", makeLevelJson(), /*publishedAt=*/100);
+
+        WeeklyChallenge rated(kSecondsPerWeek, 0, 1.0 / 60.0, /*enforceFairness=*/true);
+        const WeeklyChallengeInfo info = rated.current(cat, 10);
+        CHECK(info.valid);
+        const RunTrace win = playGreedy(info.level.levelJson, rated.fixedDt(), 5000);
+        const SubmitResult r = rated.submit(cat, 10, "alice", win, 1);
+        CHECK(r.accepted);
+        CHECK(r.stars >= 1 && r.stars <= 3);
+
+        WeeklyChallenge plain(kSecondsPerWeek, 0, 1.0 / 60.0); // default: no rating
+        const SubmitResult r2 = plain.submit(cat, 10, "bob", win, 2);
+        CHECK(r2.accepted);
+        CHECK(r2.stars == 0);
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_star_rating: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_star_rating: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #346. Awards 1-3 stars from a run's clear time versus the solver's optimal par (#316), surfaced on the leaderboard (#242) and weekly challenge (#273).

**`StarRating.h` (new, pure)**
- `parTime(par)` turns a grid-step par into an ideal traversal time (`par * cellSize / playerSpeed`) so a wall-time clear can be compared against a step-count par.
- `starsForClear(clearTime, par, cfg)` maps the `clearTime / parTime` ratio to stars with tunable thresholds: `<= 1.20x` par -> 3, `<= 2.00x` -> 2, slower -> 1; returns 0 when par/time is undefined. Deterministic.

**`Leaderboard`**
- `SubmitResult.stars` and the stored `ScoreEntry.stars` now carry the run's rating, computed at submit time against the recorded par. Par is known only when fairness is enforced (#334); without it stars stay 0 and rankings are completely unchanged. `setStarConfig` tunes the thresholds.

**`WeeklyChallenge`**
- New opt-in `enforceFairness` constructor flag makes per-week boards record par, so weekly submissions are star-rated too. Default off preserves existing behavior.

## Testing

`test_star_rating` (headless):
- pure function: exactly par -> 3 stars, `1.20x`/`2.00x` boundaries, progressively slower -> 2 then 1, monotonic (a slower time never scores more), undefined inputs -> 0, and tunable thresholds shift the bands;
- leaderboard: a replay-verified run is star-rated exactly as `starsForClear(clearTime, par)`, a slower player never outscores a faster one, and the stored entry carries the stars; without enforced fairness, stars are 0;
- weekly: an opt-in-fairness challenge star-rates a verified submission (1-3), the default challenge does not (0).

Regression-checked `test_leaderboard`, `test_weekly_challenge`, `test_fairness_gate` locally. Built and run via CTest under the `headless` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_