### PR TITLE
Doodlebound: campaign structure and persistent progress (#347)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -695,6 +695,11 @@ add_executable(test_multi_room
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_multi_room.cpp
 )
 
+# Ordered campaign with unlocks + persistent progress via the Settings store (#347) - header-only.
+add_executable(test_campaign
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_campaign.cpp
+)
+
 # Headless tower-defense mode on the room topology: doorway-graph pathing, tower
 # damage, lives, win/lose, determinism (#271) - header-only.
 add_executable(test_tower_defense
@@ -1081,6 +1086,7 @@ set(HEADLESS_TESTS
     test_audio_decode
     test_audio_streaming
     test_benchmark
+    test_campaign
     test_city_game
     test_crowd
     test_cv_robust

--- a/src/game/Campaign.h
+++ b/src/game/Campaign.h
@@ -1,0 +1,180 @@
+#pragma once
+
+#include "core/Settings.h" // Settings key/value store (#58)
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+/**
+ * @file Campaign.h
+ * @brief Ordered campaign with unlocks and persistent progress (issue #347).
+ *
+ * Turns one-off levels into a structured single-player campaign: ordered worlds, each an
+ * ordered set of levels, with unlock rules and a per-level best (stars + time). Levels
+ * unlock sequentially within a world (clear one to reveal the next); a world unlocks once
+ * enough levels of the previous world are cleared (its @c requiredToAdvance, or all levels
+ * when 0). Progress persists through the Settings store (#58): save() writes each level's
+ * best into a Settings object and load() restores it, so serialize()/loadFromFile() round
+ * trips it across sessions.
+ *
+ * Star values are supplied by the caller (e.g. the star rating in #346), so this core has
+ * no dependency on how stars are computed. Header-only, std only, deterministic.
+ */
+namespace IKore {
+namespace game {
+
+struct CampaignLevel {
+    std::string id;        ///< stable key for persistence (auto-filled "w{w}l{l}" if empty).
+    std::string name;      ///< display name.
+    std::string levelJson; ///< optional level content (may be empty for structure-only).
+};
+
+struct CampaignWorld {
+    std::string name;
+    std::vector<CampaignLevel> levels;
+    int requiredToAdvance{0}; ///< clears in THIS world needed to unlock the next (0 => all).
+};
+
+/// A level's map state for the world-map UI.
+enum class LevelState { Locked, Unlocked, Completed };
+
+/// Best result recorded for one level.
+struct LevelProgress {
+    bool completed{false};
+    int bestStars{0};      ///< 0 = none earned yet.
+    double bestTime{-1.0}; ///< < 0 = no cleared time yet.
+};
+
+class Campaign {
+public:
+    Campaign() = default;
+    explicit Campaign(std::vector<CampaignWorld> worlds) : m_worlds(std::move(worlds)) {
+        // Give every level a stable id and a progress slot in a deterministic order.
+        for (std::size_t w = 0; w < m_worlds.size(); ++w) {
+            for (std::size_t l = 0; l < m_worlds[w].levels.size(); ++l) {
+                CampaignLevel& lv = m_worlds[w].levels[l];
+                if (lv.id.empty())
+                    lv.id = "w" + std::to_string(w) + "l" + std::to_string(l);
+                m_progress.push_back(LevelProgress{});
+                m_index.push_back(lv.id);
+            }
+        }
+    }
+
+    // --- Structure -----------------------------------------------------------------
+    std::size_t worldCount() const { return m_worlds.size(); }
+    std::size_t levelCount(std::size_t world) const {
+        return world < m_worlds.size() ? m_worlds[world].levels.size() : 0;
+    }
+    const CampaignWorld& world(std::size_t w) const { return m_worlds.at(w); }
+    const CampaignLevel& level(std::size_t w, std::size_t l) const { return m_worlds.at(w).levels.at(l); }
+
+    // --- Recording -----------------------------------------------------------------
+    /// Record a clear: marks the level completed and keeps the best stars (max) and time
+    /// (min). Out-of-range indices are ignored.
+    void recordClear(std::size_t world, std::size_t level, int stars, double time) {
+        const int idx = flat(world, level);
+        if (idx < 0) return;
+        LevelProgress& p = m_progress[static_cast<std::size_t>(idx)];
+        p.completed = true;
+        if (stars > p.bestStars) p.bestStars = stars;
+        if (time >= 0.0 && (p.bestTime < 0.0 || time < p.bestTime)) p.bestTime = time;
+    }
+
+    // --- Queries -------------------------------------------------------------------
+    LevelProgress progressOf(std::size_t world, std::size_t level) const {
+        const int idx = flat(world, level);
+        return idx < 0 ? LevelProgress{} : m_progress[static_cast<std::size_t>(idx)];
+    }
+    bool levelCompleted(std::size_t world, std::size_t level) const {
+        return progressOf(world, level).completed;
+    }
+    /// Number of completed levels in a world.
+    int worldClears(std::size_t world) const {
+        int n = 0;
+        for (std::size_t l = 0; l < levelCount(world); ++l)
+            if (levelCompleted(world, l)) ++n;
+        return n;
+    }
+    /// A world is unlocked if it is the first, or the previous world has enough clears.
+    bool worldUnlocked(std::size_t world) const {
+        if (world >= m_worlds.size()) return false;
+        if (world == 0) return true;
+        if (!worldUnlocked(world - 1)) return false;
+        const CampaignWorld& prev = m_worlds[world - 1];
+        const int need = prev.requiredToAdvance > 0 ? prev.requiredToAdvance
+                                                     : static_cast<int>(prev.levels.size());
+        return worldClears(world - 1) >= need;
+    }
+    /// A level is unlocked if its world is unlocked and it is the first level or the
+    /// previous level in the world is completed.
+    bool levelUnlocked(std::size_t world, std::size_t level) const {
+        if (level >= levelCount(world) || !worldUnlocked(world)) return false;
+        if (level == 0) return true;
+        return levelCompleted(world, level - 1);
+    }
+    LevelState stateOf(std::size_t world, std::size_t level) const {
+        if (levelCompleted(world, level)) return LevelState::Completed;
+        if (levelUnlocked(world, level)) return LevelState::Unlocked;
+        return LevelState::Locked;
+    }
+    /// Total stars earned across the campaign.
+    int totalStars() const {
+        int n = 0;
+        for (const LevelProgress& p : m_progress) n += p.bestStars;
+        return n;
+    }
+
+    // --- Persistence via the Settings store (#58) ----------------------------------
+    /// Write every level's best into @p s under "campaign.<id>.*" keys.
+    void save(Settings& s) const {
+        for (std::size_t i = 0; i < m_index.size(); ++i) {
+            const std::string& id = m_index[i];
+            const LevelProgress& p = m_progress[i];
+            s.setBool(key(id, "done"), p.completed);
+            s.setInt(key(id, "stars"), p.bestStars);
+            s.setFloat(key(id, "time"), static_cast<float>(p.bestTime));
+        }
+    }
+    /// Restore every level's best from @p s (missing keys leave a fresh, empty progress).
+    void load(const Settings& s) {
+        for (std::size_t i = 0; i < m_index.size(); ++i) {
+            const std::string& id = m_index[i];
+            LevelProgress p;
+            p.completed = s.getBool(key(id, "done"), false);
+            p.bestStars = s.getInt(key(id, "stars"), 0);
+            p.bestTime = static_cast<double>(s.getFloat(key(id, "time"), -1.0f));
+            m_progress[i] = p;
+        }
+    }
+    /// Convenience: progress as the Settings text form (for a full save-file round trip).
+    std::string serializeProgress() const {
+        Settings s;
+        save(s);
+        return s.serialize();
+    }
+    void loadProgress(const std::string& text) {
+        Settings s;
+        s.load(text);
+        load(s);
+    }
+
+private:
+    int flat(std::size_t world, std::size_t level) const {
+        if (world >= m_worlds.size() || level >= m_worlds[world].levels.size()) return -1;
+        int idx = 0;
+        for (std::size_t w = 0; w < world; ++w) idx += static_cast<int>(m_worlds[w].levels.size());
+        return idx + static_cast<int>(level);
+    }
+    static std::string key(const std::string& id, const char* field) {
+        return "campaign." + id + "." + field;
+    }
+
+    std::vector<CampaignWorld> m_worlds;
+    std::vector<LevelProgress> m_progress; ///< flat, parallel to m_index (deterministic order).
+    std::vector<std::string> m_index;      ///< flat level ids, world-major.
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_campaign.cpp
+++ b/tests/test_campaign.cpp
@@ -1,0 +1,115 @@
+// Campaign structure and persistent progress - issue #347.
+//
+// Builds an ordered two-world campaign, checks the unlock rules (a level unlocks when the
+// previous in its world is cleared; a world unlocks once its predecessor has enough clears),
+// records per-level bests (max stars, min time), and round-trips progress through the
+// Settings store (#58) so it survives across sessions. Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_campaign.cpp -o test_campaign
+
+#include "game/Campaign.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+// World 0 "Grasslands": 3 levels, clear 2 to advance. World 1 "Caverns": 2 levels.
+static Campaign makeCampaign() {
+    CampaignWorld w0;
+    w0.name = "Grasslands";
+    w0.requiredToAdvance = 2;
+    w0.levels = {CampaignLevel{"", "L1", ""}, CampaignLevel{"", "L2", ""}, CampaignLevel{"", "L3", ""}};
+    CampaignWorld w1;
+    w1.name = "Caverns";
+    w1.requiredToAdvance = 0; // 0 => all levels
+    w1.levels = {CampaignLevel{"", "C1", ""}, CampaignLevel{"", "C2", ""}};
+    return Campaign(std::vector<CampaignWorld>{w0, w1});
+}
+
+int main() {
+    Campaign camp = makeCampaign();
+    CHECK(camp.worldCount() == 2);
+    CHECK(camp.levelCount(0) == 3);
+    CHECK(camp.levelCount(1) == 2);
+
+    // 1. Initial gating: only world 0's first level is playable.
+    CHECK(camp.worldUnlocked(0));
+    CHECK(!camp.worldUnlocked(1));
+    CHECK(camp.stateOf(0, 0) == LevelState::Unlocked);
+    CHECK(camp.stateOf(0, 1) == LevelState::Locked);
+    CHECK(camp.stateOf(0, 2) == LevelState::Locked);
+    CHECK(camp.stateOf(1, 0) == LevelState::Locked);
+
+    // 2. Clearing a level unlocks the next in its world; the world stays locked until N.
+    camp.recordClear(0, 0, /*stars=*/3, /*time=*/10.0);
+    CHECK(camp.stateOf(0, 0) == LevelState::Completed);
+    CHECK(camp.stateOf(0, 1) == LevelState::Unlocked);
+    CHECK(camp.stateOf(0, 2) == LevelState::Locked);
+    CHECK(!camp.worldUnlocked(1)); // only 1 clear < 2 required
+
+    // 3. Second clear reaches the world's requiredToAdvance -> next world unlocks.
+    camp.recordClear(0, 1, 2, 12.0);
+    CHECK(camp.worldClears(0) == 2);
+    CHECK(camp.worldUnlocked(1));
+    CHECK(camp.stateOf(1, 0) == LevelState::Unlocked);
+    CHECK(camp.stateOf(1, 1) == LevelState::Locked); // its prev not cleared yet
+    CHECK(camp.stateOf(0, 2) == LevelState::Unlocked);
+
+    // 4. Best-of tracking: max stars, min time; a worse run never regresses the best.
+    camp.recordClear(0, 0, 1, 8.0);
+    camp.recordClear(0, 0, 2, 20.0);
+    const LevelProgress p00 = camp.progressOf(0, 0);
+    CHECK(p00.bestStars == 3);
+    CHECK(std::fabs(p00.bestTime - 8.0) < 1e-6);
+    CHECK(camp.totalStars() == 5); // (0,0)=3 + (0,1)=2
+
+    // 5. Progress persists across sessions via the Settings store round trip.
+    const std::string saved = camp.serializeProgress();
+    CHECK(!saved.empty());
+    CHECK(camp.serializeProgress() == saved); // deterministic
+
+    Campaign restored = makeCampaign();
+    // A fresh campaign starts locked...
+    CHECK(restored.stateOf(0, 1) == LevelState::Locked);
+    CHECK(!restored.worldUnlocked(1));
+    // ...and restoring the saved progress reproduces the unlocked/completed world map.
+    restored.loadProgress(saved);
+    CHECK(restored.stateOf(0, 0) == LevelState::Completed);
+    CHECK(restored.stateOf(0, 1) == LevelState::Completed);
+    CHECK(restored.worldUnlocked(1));
+    CHECK(restored.stateOf(1, 0) == LevelState::Unlocked);
+    CHECK(restored.stateOf(1, 1) == LevelState::Locked);
+    const LevelProgress r00 = restored.progressOf(0, 0);
+    CHECK(r00.bestStars == 3);
+    CHECK(std::fabs(r00.bestTime - 8.0) < 1e-6);
+    CHECK(restored.totalStars() == 5);
+
+    // 6. The Settings object form is usable directly (save/load via Settings, #58).
+    Settings s;
+    camp.save(s);
+    Settings s2;
+    s2.load(s.serialize());
+    Campaign restored2 = makeCampaign();
+    restored2.load(s2);
+    CHECK(restored2.progressOf(0, 1).bestStars == 2);
+    CHECK(restored2.stateOf(1, 0) == LevelState::Unlocked);
+
+    if (g_failures == 0) {
+        std::printf("test_campaign: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_campaign: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #347. Turns one-off levels into a structured single-player campaign with unlocks and progress that persists via the Settings store (#58).

New header `src/game/Campaign.h`:
- **Structure**: ordered `CampaignWorld`s, each an ordered set of `CampaignLevel`s. Every level gets a stable id (auto-filled `w{w}l{l}` if empty).
- **Unlocks**: a level unlocks when the previous level in its world is completed; a world unlocks once the previous world has enough clears (its `requiredToAdvance`, or all its levels when 0). `stateOf` returns `Locked` / `Unlocked` / `Completed` for a world-map UI.
- **Bests**: `recordClear(world, level, stars, time)` marks completion and keeps the best stars (max) and time (min). Star values are supplied by the caller (e.g. #346), so this core does not depend on how stars are computed.
- **Persistence (#58)**: `save(Settings&)` / `load(const Settings&)` write and restore each level's best under `campaign.<id>.*` keys; `serializeProgress()` / `loadProgress()` do the same through the Settings text form, so progress round-trips across sessions.

## Testing

`test_campaign` (headless):
- initial gating: only world 0's first level is playable;
- clearing a level unlocks the next in its world; the world stays locked until its `requiredToAdvance` is met, then the next world (and its first level) unlock;
- best-of tracking keeps max stars / min time and never regresses on a worse run; `totalStars` sums correctly;
- progress persists: a fresh campaign is locked, and loading saved progress reproduces the completed/unlocked world map and bests (deterministic serialization), both through the text form and directly through a `Settings` object.

Built and run via CTest under the `headless` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_