### PR TITLE
Doodlebound: tutorial and onboarding levels (#349)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -705,6 +705,11 @@ add_executable(test_campaign
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_campaign.cpp
 )
 
+# Authored tutorial/onboarding levels wired as the campaign's first world (#349) - header-only.
+add_executable(test_tutorial
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tutorial.cpp
+)
+
 # Headless tower-defense mode on the room topology: doorway-graph pathing, tower
 # damage, lives, win/lose, determinism (#271) - header-only.
 add_executable(test_tower_defense
@@ -1177,6 +1182,7 @@ set(HEADLESS_TESTS
     test_topology
     test_tour_camera
     test_tower_defense
+    test_tutorial
     test_ui_scaling
     test_vectorize
     test_versus

--- a/src/game/Tutorial.h
+++ b/src/game/Tutorial.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "game/Campaign.h"    // CampaignWorld, CampaignLevel
+#include "game/DoodleScene.h" // LevelSpec, Wall, Symbol
+#include "game/LevelFormat.h" // toLevelJson
+
+#include <string>
+#include <vector>
+
+/**
+ * @file Tutorial.h
+ * @brief Authored onboarding levels that teach each mechanic in order (issue #349).
+ *
+ * A short, fixed sequence of hand-authored LevelSpecs that introduce the core verbs one at
+ * a time - move to the exit, collect coins, use a key on a locked door (#319), trip a
+ * switch to open a wall (#319), then avoid a hazard (#320) - each with ordered on-screen
+ * hint prompts. tutorialWorld() packages them as a CampaignWorld so they can be wired as
+ * the campaign's first world (#347): completing them unlocks the rest of the campaign.
+ *
+ * Every level is clearable with the classic move/collect/exit rules the Solver (#316)
+ * checks, and the mechanic-specific levels are additionally playable end to end (grab the
+ * key, then pass the door; trip the switch, then pass the wall; walk around the hazard).
+ * Header-only, deterministic, std only.
+ */
+namespace IKore {
+namespace game {
+
+/// One onboarding level: its name, the level content, and ordered hint prompts.
+struct TutorialLevel {
+    std::string name;
+    LevelSpec spec;
+    std::vector<std::string> hints;
+};
+
+namespace detail {
+
+/// A closed rectangular room outline (walls) from (x0,z0) to (x1,z1).
+inline Wall roomOutline(float x0, float z0, float x1, float z1) {
+    Wall w;
+    w.polyline = {ecs::Vec3{x0, 0.0f, z0}, ecs::Vec3{x1, 0.0f, z0}, ecs::Vec3{x1, 0.0f, z1},
+                  ecs::Vec3{x0, 0.0f, z1}, ecs::Vec3{x0, 0.0f, z0}};
+    return w;
+}
+
+inline Symbol sym(const char* type, float x, float z) {
+    return Symbol{type, ecs::Vec3{x, 0.0f, z}, 0.0f};
+}
+
+} // namespace detail
+
+/// The ordered onboarding levels (one mechanic introduced per level).
+inline std::vector<TutorialLevel> tutorialLevels() {
+    using detail::roomOutline;
+    using detail::sym;
+    std::vector<TutorialLevel> out;
+
+    // 1. Movement: just reach the exit.
+    {
+        TutorialLevel t;
+        t.name = "First Steps";
+        t.spec.walls = {roomOutline(0, 0, 12, 8)};
+        t.spec.symbols = {sym("player", 2, 2), sym("exit", 10, 6)};
+        t.hints = {"Use the controls to move.", "Reach the glowing exit to finish."};
+        out.push_back(std::move(t));
+    }
+    // 2. Collecting: gather every coin, then exit.
+    {
+        TutorialLevel t;
+        t.name = "Shiny Things";
+        t.spec.walls = {roomOutline(0, 0, 12, 8)};
+        t.spec.symbols = {sym("player", 2, 2), sym("coin", 6, 4), sym("coin", 9, 2), sym("exit", 10, 6)};
+        t.hints = {"Collect every coin.", "The exit opens once all coins are gathered."};
+        out.push_back(std::move(t));
+    }
+    // 3. Keys and doors: grab the key to open the locked door (#319).
+    {
+        TutorialLevel t;
+        t.name = "Locked In";
+        t.spec.walls = {roomOutline(0, -0.9f, 18, 0.9f)};
+        t.spec.symbols = {sym("player", 1.5f, 0), sym("key@1", 5, 0), sym("lock@1", 10, 0),
+                          sym("exit", 16, 0)};
+        t.hints = {"Grab the key.", "The matching locked door opens once you hold its key."};
+        out.push_back(std::move(t));
+    }
+    // 4. Switches and walls: step on the switch to open the wall (#319).
+    {
+        TutorialLevel t;
+        t.name = "Flip the Switch";
+        t.spec.walls = {roomOutline(0, -0.9f, 18, 0.9f)};
+        t.spec.symbols = {sym("player", 1.5f, 0), sym("switch@1", 5, 0), sym("toggle@1", 10, 0),
+                          sym("exit", 16, 0)};
+        t.hints = {"Step on the switch.", "It opens the wall blocking your way."};
+        out.push_back(std::move(t));
+    }
+    // 5. Hazards: go around the spikes (#320).
+    {
+        TutorialLevel t;
+        t.name = "Watch Your Step";
+        t.spec.walls = {roomOutline(0, -4, 16, 4)};
+        t.spec.symbols = {sym("player", 2, 0), sym("hazard", 8, 0), sym("exit", 14, 0)};
+        t.hints = {"Spikes hurt - do not touch them.", "Go around to reach the exit."};
+        out.push_back(std::move(t));
+    }
+    return out;
+}
+
+/// Package the onboarding levels as the campaign's first world (#347). Clearing all of them
+/// (requiredToAdvance == every tutorial level) unlocks the next world.
+inline CampaignWorld tutorialWorld() {
+    const std::vector<TutorialLevel> levels = tutorialLevels();
+    CampaignWorld w;
+    w.name = "Tutorial";
+    w.requiredToAdvance = static_cast<int>(levels.size());
+    for (std::size_t i = 0; i < levels.size(); ++i) {
+        CampaignLevel cl;
+        cl.id = "tut" + std::to_string(i);
+        cl.name = levels[i].name;
+        cl.levelJson = toLevelJson(levels[i].spec);
+        w.levels.push_back(std::move(cl));
+    }
+    return w;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_tutorial.cpp
+++ b/tests/test_tutorial.cpp
@@ -1,0 +1,114 @@
+// Tutorial and onboarding levels - issue #349.
+//
+// The onboarding sequence introduces one mechanic per level (move, collect, key/door,
+// switch/wall, hazard), in order. Each level loads, is Solver-verified solvable, and is
+// actually playable end to end (driving the intended route wins, exercising its mechanic).
+// The set wires up as the campaign's first world (#347): clearing them all unlocks the
+// next world. Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_tutorial.cpp -o test_tutorial
+
+#include "game/Campaign.h"
+#include "game/DungeonGame.h"
+#include "game/Solver.h"
+#include "game/Tutorial.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static int countSym(const LevelSpec& s, const std::string& type) {
+    int n = 0;
+    for (const Symbol& sym : s.symbols) if (sym.type == type) ++n;
+    return n;
+}
+
+static bool drive(DungeonGame g, const std::vector<ecs::Vec3>& wps) {
+    const float dt = 1.0f / 60.0f;
+    for (const ecs::Vec3& wp : wps) {
+        for (int i = 0; i < 3000 && g.status == GameStatus::Playing; ++i) {
+            const float dx = wp.x - g.playerPosition.x, dz = wp.z - g.playerPosition.z;
+            if (dx * dx + dz * dz < 0.0025f) break;
+            g.update(GameInput{dx, dz}, dt);
+        }
+    }
+    return g.won();
+}
+
+int main() {
+    const std::vector<TutorialLevel> levels = tutorialLevels();
+    CHECK(levels.size() == 5);
+
+    // Every level loads, is solver-solvable, and has ordered, non-empty hints.
+    for (const TutorialLevel& t : levels) {
+        const SolveResult r = solve(loadGame(convert(t.spec)));
+        CHECK(r.solvable);
+        CHECK(!t.name.empty());
+        CHECK(!t.hints.empty());
+        for (const std::string& h : t.hints) CHECK(!h.empty());
+    }
+
+    // Mechanics are introduced in order.
+    CHECK(countSym(levels[0].spec, "coin") == 0);          // move only
+    CHECK(countSym(levels[0].spec, "exit") == 1);
+    CHECK(countSym(levels[1].spec, "coin") == 2);          // collecting
+    CHECK(countSym(levels[2].spec, "key@1") == 1);         // keys + doors
+    CHECK(countSym(levels[2].spec, "lock@1") == 1);
+    CHECK(countSym(levels[3].spec, "switch@1") == 1);      // switches + walls
+    CHECK(countSym(levels[3].spec, "toggle@1") == 1);
+    CHECK(countSym(levels[4].spec, "hazard") == 1);        // hazards
+
+    // Each level is actually clearable by playing its mechanic.
+    CHECK(drive(loadGame(convert(levels[0].spec)), {{10, 0, 6}}));
+    CHECK(drive(loadGame(convert(levels[1].spec)), {{6, 0, 4}, {9, 0, 2}, {10, 0, 6}}));
+    CHECK(drive(loadGame(convert(levels[2].spec)), {{5, 0, 0}, {16, 0, 0}}));   // key then door
+    CHECK(drive(loadGame(convert(levels[3].spec)), {{5, 0, 0}, {16, 0, 0}}));   // switch then wall
+    CHECK(drive(loadGame(convert(levels[4].spec)), {{8, 0, 3}, {14, 0, 0}}));   // around the hazard
+
+    // Determinism: the same sequence every call.
+    const std::vector<TutorialLevel> again = tutorialLevels();
+    CHECK(again.size() == levels.size());
+    for (std::size_t i = 0; i < levels.size(); ++i) {
+        CHECK(again[i].name == levels[i].name);
+        CHECK(again[i].spec.symbols.size() == levels[i].spec.symbols.size());
+    }
+
+    // Wire as the campaign's first world (#347): a fresh campaign starts on the tutorial,
+    // and clearing all of it unlocks the next world.
+    CampaignWorld next;
+    next.name = "Grasslands";
+    next.levels = {CampaignLevel{"g0", "G1", ""}};
+    Campaign camp(std::vector<CampaignWorld>{tutorialWorld(), next});
+    CHECK(camp.worldCount() == 2);
+    CHECK(camp.world(0).name == "Tutorial");
+    CHECK(camp.levelCount(0) == 5);
+    CHECK(camp.worldUnlocked(0));
+    CHECK(camp.stateOf(0, 0) == LevelState::Unlocked);
+    CHECK(!camp.worldUnlocked(1));
+    for (std::size_t l = 0; l < camp.levelCount(0); ++l)
+        CHECK(!camp.level(0, l).levelJson.empty()); // each tutorial carries its content
+
+    for (std::size_t l = 0; l < camp.levelCount(0); ++l)
+        camp.recordClear(0, l, /*stars=*/3, /*time=*/10.0);
+    CHECK(camp.worldClears(0) == 5);
+    CHECK(camp.worldUnlocked(1)); // tutorial complete -> next world unlocked
+
+    if (g_failures == 0) {
+        std::printf("test_tutorial: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_tutorial: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #349. Adds a guided onboarding sequence that teaches each mechanic in order.

New header `src/game/Tutorial.h`:
- `tutorialLevels()` returns five ordered authored `TutorialLevel`s (name + `LevelSpec` + ordered hint prompts), each introducing one verb: **move** to the exit, **collect** coins, **key + locked door** (#319), **switch + toggle wall** (#319), then **avoid a hazard** (#320).
- `tutorialWorld()` packages them as a `CampaignWorld` (each level carrying its serialized content via `toLevelJson`), so they wire up as the campaign's first world (#347); `requiredToAdvance` equals the tutorial count, so clearing them all unlocks the next world.

## Testing

`test_tutorial` (headless):
- all five levels load, are Solver-verified solvable, and have ordered non-empty hints;
- mechanics are introduced in order (level 1 move-only, level 2 coins, level 3 key+door, level 4 switch+toggle, level 5 hazard);
- each level is actually playable end to end - driving the intended route wins, exercising its mechanic (grab the key then pass the door; trip the switch then pass the wall; walk around the hazard);
- deterministic across calls;
- wired as the campaign's first world: a fresh campaign starts on the tutorial with the next world locked, each tutorial level carries its content JSON, and clearing all of them unlocks the next world.

Built and run via CTest under the `headless` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_