### PR TITLE
Rendering: game camera and theme pass for Doodlebound (#354)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -733,6 +733,18 @@ add_executable(test_tour_camera
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tour_camera.cpp
 )
 
+# Top-down/follow game camera + theme palette for Doodlebound (#354) - header-only.
+add_executable(test_game_camera
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_game_camera.cpp
+)
+
+# GL render from the game camera with a theme, offscreen (#354). Links glad/glfw/glm and
+# needs a GL context, so it is a gl-labelled test (run under Xvfb + software GL).
+add_executable(test_game_camera_gl
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_game_camera_gl.cpp
+)
+target_link_libraries(test_game_camera_gl PRIVATE glad glfw glm::glm)
+
 # Camera capture + perspective rectification (Milestone 16 / #166) - header-only.
 add_executable(test_rectify
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_rectify.cpp
@@ -1174,6 +1186,7 @@ set(HEADLESS_TESTS
     test_fairness_gate
     test_file_watcher
     test_frame_graph
+    test_game_camera
     test_game_events
     test_geojson_importer
     test_ghost_race
@@ -1278,6 +1291,7 @@ set(GL_TESTS
     test_dungeon_render_gl
     test_event_system
     test_event_system_simple
+    test_game_camera_gl
     test_game_fx_gl
     test_material_component
     test_mesh_component

--- a/src/game/GameCamera.h
+++ b/src/game/GameCamera.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "game/DungeonGame.h"       // DungeonGame, ecs::Vec3
+#include "game/DungeonRenderData.h" // RenderColor, renderColorForType
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+/**
+ * @file GameCamera.h
+ * @brief Top-down / follow game camera and a theme palette for Doodlebound (issue #354).
+ *
+ * TourCamera (#165) is the first-person walkthrough; this is the normal play view: a camera
+ * that frames the player (and, on demand, the whole level) either straight top-down or from
+ * a fixed follow angle, plus a theme - a cohesive material/background palette so a level
+ * reads clearly. Both are renderer-agnostic and deterministic: update() computes the eye/
+ * target the engine's GL camera consumes (with optional smoothing), and themedColor() maps a
+ * spawn/feature type to the active theme's color (falling back to the default #333 palette).
+ * Header-only, std only.
+ */
+namespace IKore {
+namespace game {
+
+enum class GameCameraMode { TopDown, Follow };
+
+/// A framing camera: an eye looking at a target with an up vector.
+struct GameCamera {
+    ecs::Vec3 eye{0.0f, 12.0f, 0.0f};
+    ecs::Vec3 target{};
+    ecs::Vec3 up{0.0f, 1.0f, 0.0f};
+
+    GameCameraMode mode{GameCameraMode::TopDown};
+    float height{12.0f};       ///< top-down: eye height above the target.
+    float followDist{8.0f};    ///< follow: horizontal distance behind (-Z).
+    float followHeight{7.0f};  ///< follow: eye height.
+    float smooth{0.0f};        ///< 0 = snap; (0,1] = fraction moved toward the goal per update.
+
+    /// Desired eye for @p player under the current mode. Top-down uses +Z as up (the view
+    /// looks straight down -Y); follow looks down at the player from behind and above.
+    ecs::Vec3 desiredEye(const ecs::Vec3& player) const {
+        if (mode == GameCameraMode::TopDown)
+            return ecs::Vec3{player.x, player.y + height, player.z};
+        return ecs::Vec3{player.x, player.y + followHeight, player.z - followDist};
+    }
+    ecs::Vec3 desiredUp() const {
+        return mode == GameCameraMode::TopDown ? ecs::Vec3{0.0f, 0.0f, 1.0f}
+                                               : ecs::Vec3{0.0f, 1.0f, 0.0f};
+    }
+
+    /// Frame the player this update (snapping or smoothing toward the goal).
+    void update(const ecs::Vec3& player, float /*dt*/ = 0.0f) {
+        const ecs::Vec3 goalEye = desiredEye(player);
+        up = desiredUp();
+        if (smooth <= 0.0f) {
+            eye = goalEye;
+            target = player;
+        } else {
+            const float t = smooth > 1.0f ? 1.0f : smooth;
+            eye = lerp(eye, goalEye, t);
+            target = lerp(target, player, t);
+        }
+    }
+
+    /// Frame the whole level top-down: center on the bounds and lift the eye to fit them.
+    void frameLevel(const ecs::Vec3& minB, const ecs::Vec3& maxB) {
+        const ecs::Vec3 center{(minB.x + maxB.x) * 0.5f, 0.0f, (minB.z + maxB.z) * 0.5f};
+        const float span = std::max(maxB.x - minB.x, maxB.z - minB.z);
+        height = std::max(span * 0.7f, 4.0f);
+        mode = GameCameraMode::TopDown;
+        target = center;
+        up = desiredUp();
+        eye = ecs::Vec3{center.x, center.y + height, center.z};
+    }
+
+private:
+    static ecs::Vec3 lerp(const ecs::Vec3& a, const ecs::Vec3& b, float t) {
+        return ecs::Vec3{a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t};
+    }
+};
+
+/// Axis-aligned bounds of a game's walls + actors (for frameLevel).
+inline void levelBounds(const DungeonGame& game, ecs::Vec3& minB, ecs::Vec3& maxB) {
+    minB = maxB = game.playerPosition;
+    auto grow = [&](const ecs::Vec3& p) {
+        minB.x = std::min(minB.x, p.x); maxB.x = std::max(maxB.x, p.x);
+        minB.z = std::min(minB.z, p.z); maxB.z = std::max(maxB.z, p.z);
+    };
+    for (const world::Box& b : game.walls) grow(b.center);
+    for (const Coin& c : game.coins) grow(c.position);
+    if (game.hasExit) grow(game.exitPosition);
+}
+
+// --- Theme / material palette ------------------------------------------------
+
+/// A cohesive palette: a background plus the core material colors.
+struct Theme {
+    std::string name{"default"};
+    RenderColor background{0.10f, 0.10f, 0.12f};
+    RenderColor wall{0.50f, 0.50f, 0.55f};
+    RenderColor player{0.20f, 0.80f, 0.35f};
+    RenderColor enemy{0.85f, 0.20f, 0.20f};
+    RenderColor coin{0.92f, 0.85f, 0.20f};
+    RenderColor exit{0.25f, 0.45f, 0.92f};
+};
+
+/// A cool, dark dungeon theme.
+inline Theme dungeonTheme() {
+    Theme t;
+    t.name = "dungeon";
+    t.background = {0.06f, 0.06f, 0.10f};
+    t.wall = {0.38f, 0.40f, 0.52f};
+    t.player = {0.30f, 0.85f, 0.55f};
+    t.enemy = {0.90f, 0.25f, 0.30f};
+    t.coin = {0.95f, 0.82f, 0.25f};
+    t.exit = {0.30f, 0.55f, 0.95f};
+    return t;
+}
+
+/// A warm, bright grassland theme (distinct from dungeon so themes are visibly different).
+inline Theme grassTheme() {
+    Theme t;
+    t.name = "grass";
+    t.background = {0.30f, 0.55f, 0.30f};
+    t.wall = {0.55f, 0.42f, 0.28f};
+    t.player = {0.20f, 0.45f, 0.90f};
+    t.enemy = {0.85f, 0.35f, 0.10f};
+    t.coin = {0.98f, 0.88f, 0.30f};
+    t.exit = {0.90f, 0.30f, 0.75f};
+    return t;
+}
+
+/// The active theme's color for a spawn/feature type; falls back to the #333 palette for
+/// types the theme does not override (keys, switches, hazards, ...).
+inline RenderColor themedColor(const std::string& type, const Theme& theme) {
+    if (type == "wall") return theme.wall;
+    if (type == "player") return theme.player;
+    if (type == "enemy" || (type.size() >= 5 && type.compare(0, 5, "enemy") == 0)) return theme.enemy;
+    if (type == "coin" || type == "treasure") return theme.coin;
+    if (type == "exit" || type == "door") return theme.exit;
+    return renderColorForType(type);
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_game_camera.cpp
+++ b/tests/test_game_camera.cpp
@@ -1,0 +1,124 @@
+// Game camera and theme pass for Doodlebound - issue #354 (headless core).
+//
+// Verifies the play-view camera frames the player (top-down and follow), tracks the player
+// as it moves, smooths toward its goal, and frames a whole level to fit its bounds; and that
+// the theme palette gives distinct, cohesive colors per material with a fallback to the
+// default palette. The GL render from the camera + theme is exercised by test_game_camera_gl.
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_game_camera.cpp -o test_game_camera
+
+#include "game/GameCamera.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static bool near(float a, float b) { return std::fabs(a - b) < 1e-4f; }
+
+int main() {
+    // 1. Top-down frames directly above the player and tracks it.
+    {
+        GameCamera cam;
+        cam.mode = GameCameraMode::TopDown;
+        cam.height = 12.0f;
+        cam.update(ecs::Vec3{3, 0, 5});
+        CHECK(near(cam.eye.x, 3.0f) && near(cam.eye.z, 5.0f));
+        CHECK(near(cam.eye.y, 12.0f));
+        CHECK(near(cam.target.x, 3.0f) && near(cam.target.z, 5.0f));
+        CHECK(near(cam.up.z, 1.0f) && near(cam.up.y, 0.0f)); // top-down up is +Z
+
+        cam.update(ecs::Vec3{6, 0, 5}); // player moved east
+        CHECK(near(cam.eye.x, 6.0f) && near(cam.target.x, 6.0f));
+    }
+
+    // 2. Follow frames from behind and above, looking at the player.
+    {
+        GameCamera cam;
+        cam.mode = GameCameraMode::Follow;
+        cam.followDist = 8.0f;
+        cam.followHeight = 7.0f;
+        cam.update(ecs::Vec3{2, 0, 2});
+        CHECK(near(cam.eye.x, 2.0f));
+        CHECK(near(cam.eye.y, 7.0f));
+        CHECK(near(cam.eye.z, 2.0f - 8.0f));
+        CHECK(near(cam.target.x, 2.0f) && near(cam.target.z, 2.0f));
+        CHECK(near(cam.up.y, 1.0f)); // follow up is +Y
+    }
+
+    // 3. Smoothing eases toward the goal instead of snapping.
+    {
+        GameCamera cam;
+        cam.mode = GameCameraMode::TopDown;
+        cam.height = 10.0f;
+        cam.smooth = 0.5f;
+        cam.eye = ecs::Vec3{0, 0, 0};
+        cam.target = ecs::Vec3{0, 0, 0};
+        cam.update(ecs::Vec3{10, 0, 0}); // goal eye x = 10
+        CHECK(near(cam.eye.x, 5.0f));    // moved halfway
+        cam.update(ecs::Vec3{10, 0, 0});
+        CHECK(cam.eye.x > 5.0f && cam.eye.x < 10.0f); // converging, not snapping
+    }
+
+    // 4. frameLevel fits the level bounds: a bigger level lifts the eye higher and centers it.
+    {
+        SceneDescription small, big;
+        world::Box a; a.center = ecs::Vec3{0, 0, 0}; a.size = ecs::Vec3{1, 1, 1};
+        world::Box b; b.center = ecs::Vec3{6, 0, 6}; b.size = ecs::Vec3{1, 1, 1};
+        small.wallBoxes = {a, b};
+        world::Box c; c.center = ecs::Vec3{0, 0, 0}; c.size = ecs::Vec3{1, 1, 1};
+        world::Box d; d.center = ecs::Vec3{30, 0, 30}; d.size = ecs::Vec3{1, 1, 1};
+        big.wallBoxes = {c, d};
+        small.spawns = {EntitySpawn{"player", ecs::Vec3{0, 0, 0}, 0.0f}};
+        big.spawns = {EntitySpawn{"player", ecs::Vec3{0, 0, 0}, 0.0f}};
+
+        ecs::Vec3 minB, maxB;
+        GameCamera camS;
+        levelBounds(loadGame(small), minB, maxB);
+        camS.frameLevel(minB, maxB);
+        GameCamera camB;
+        levelBounds(loadGame(big), minB, maxB);
+        camB.frameLevel(minB, maxB);
+        CHECK(camB.eye.y > camS.eye.y);        // bigger level -> higher eye
+        CHECK(near(camB.target.x, 15.0f));     // centered on the bounds
+        CHECK(near(camB.eye.x, 15.0f));
+    }
+
+    // 5. Theme palette: distinct cohesive colors, with a fallback to the default palette.
+    {
+        const Theme dun = dungeonTheme();
+        const Theme grs = grassTheme();
+        CHECK(dun.name == "dungeon" && grs.name == "grass");
+        // The two themes are visibly different.
+        CHECK(!(dun.background.r == grs.background.r && dun.background.g == grs.background.g &&
+                dun.background.b == grs.background.b));
+        CHECK(!(dun.wall.r == grs.wall.r && dun.wall.g == grs.wall.g && dun.wall.b == grs.wall.b));
+        // themedColor returns the theme's color for core types...
+        const RenderColor w = themedColor("wall", dun);
+        CHECK(w.r == dun.wall.r && w.g == dun.wall.g && w.b == dun.wall.b);
+        const RenderColor p = themedColor("player", grs);
+        CHECK(p.r == grs.player.r);
+        // ...and falls back to the default palette for types it does not override.
+        const RenderColor key = themedColor("key", dun);
+        const RenderColor keyDefault = renderColorForType("key");
+        CHECK(key.r == keyDefault.r && key.g == keyDefault.g && key.b == keyDefault.b);
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_game_camera: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_game_camera: %d check(s) failed\n", g_failures);
+    return 1;
+}

--- a/tests/test_game_camera_gl.cpp
+++ b/tests/test_game_camera_gl.cpp
@@ -1,0 +1,173 @@
+// GL render from the game camera with a theme - issue #354.
+//
+// Renders a small level from the top-down game camera (GameCamera, #354) with a theme
+// palette into an offscreen FBO, using a perspective lookAt from the camera's eye/target/up.
+// It asserts the camera frames the player (the player's themed color lands near the image
+// center) and the theme applies (its background and wall colors are present), then re-renders
+// with a second theme and confirms that theme's distinct player color appears. A gl-labelled
+// tool (hidden GLFW window + software GL under Xvfb); skips if no GL context.
+//   built as test_game_camera_gl (links glad/glfw/glm)
+
+#include <glad/glad.h>
+#include <GLFW/glfw3.h>
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#include "game/GameCamera.h"
+
+using namespace IKore;
+using namespace IKore::game;
+
+namespace {
+constexpr int kW = 200, kH = 200;
+
+GLuint compile(GLenum type, const char* src) {
+    GLuint s = glCreateShader(type);
+    glShaderSource(s, 1, &src, nullptr);
+    glCompileShader(s);
+    return s;
+}
+int toByte(float f) { return int(f * 255.0f + 0.5f); }
+int countColor(const std::vector<unsigned char>& rgb, int r, int g, int b, int tol) {
+    int n = 0;
+    for (std::size_t i = 0; i + 2 < rgb.size(); i += 3)
+        if (std::abs(int(rgb[i]) - r) <= tol && std::abs(int(rgb[i + 1]) - g) <= tol && std::abs(int(rgb[i + 2]) - b) <= tol) ++n;
+    return n;
+}
+void centroid(const std::vector<unsigned char>& rgb, int w, int h, int r, int g, int b, int tol, float& cx, float& cy, int& n) {
+    double sx = 0, sy = 0; n = 0;
+    for (int y = 0; y < h; ++y)
+        for (int x = 0; x < w; ++x) {
+            const std::size_t i = (std::size_t(y) * w + x) * 3;
+            if (std::abs(int(rgb[i]) - r) <= tol && std::abs(int(rgb[i+1]) - g) <= tol && std::abs(int(rgb[i+2]) - b) <= tol) { sx += x; sy += y; ++n; }
+        }
+    cx = n ? float(sx / n) : -1; cy = n ? float(sy / n) : -1;
+}
+// A unit cube (triangle soup, positions only).
+std::vector<float> cube() {
+    const float v[8][3] = {{-0.5f,-0.5f,-0.5f},{0.5f,-0.5f,-0.5f},{0.5f,0.5f,-0.5f},{-0.5f,0.5f,-0.5f},
+                           {-0.5f,-0.5f,0.5f},{0.5f,-0.5f,0.5f},{0.5f,0.5f,0.5f},{-0.5f,0.5f,0.5f}};
+    const int f[12][3] = {{0,1,2},{0,2,3},{4,6,5},{4,7,6},{0,4,5},{0,5,1},{3,2,6},{3,6,7},{1,5,6},{1,6,2},{0,3,7},{0,7,4}};
+    std::vector<float> out;
+    for (auto& tri : f) for (int k = 0; k < 3; ++k) { out.push_back(v[tri[k]][0]); out.push_back(v[tri[k]][1]); out.push_back(v[tri[k]][2]); }
+    return out;
+}
+} // namespace
+
+int main() {
+    if (!glfwInit()) { std::printf("skip: GLFW init failed\n"); return 0; }
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+    GLFWwindow* win = glfwCreateWindow(64, 64, "cam", nullptr, nullptr);
+    if (!win) { std::printf("skip: no GL context\n"); glfwTerminate(); return 0; }
+    glfwMakeContextCurrent(win);
+    if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) { std::printf("skip: no GL\n"); glfwDestroyWindow(win); glfwTerminate(); return 0; }
+
+    GLuint fbo = 0, tex = 0, depth = 0;
+    glGenFramebuffers(1, &fbo); glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glGenTextures(1, &tex); glBindTexture(GL_TEXTURE_2D, tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, kW, kH, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tex, 0);
+    glGenRenderbuffers(1, &depth); glBindRenderbuffer(GL_RENDERBUFFER, depth);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, kW, kH);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) { std::printf("skip: FBO\n"); return 0; }
+    glViewport(0, 0, kW, kH);
+    glEnable(GL_DEPTH_TEST);
+
+    const char* vs = "#version 330 core\nlayout(location=0) in vec3 aPos;\nuniform mat4 uMVP;\n"
+                     "void main(){ gl_Position = uMVP * vec4(aPos,1.0); }\n";
+    const char* fs = "#version 330 core\nuniform vec3 uColor; out vec4 F; void main(){ F=vec4(uColor,1.0); }\n";
+    GLuint prog = glCreateProgram();
+    glAttachShader(prog, compile(GL_VERTEX_SHADER, vs));
+    glAttachShader(prog, compile(GL_FRAGMENT_SHADER, fs));
+    glLinkProgram(prog); glUseProgram(prog);
+    const GLint uMVP = glGetUniformLocation(prog, "uMVP"), uColor = glGetUniformLocation(prog, "uColor");
+
+    const std::vector<float> cubeMesh = cube();
+    GLuint vao = 0, vbo = 0;
+    glGenVertexArrays(1, &vao); glGenBuffers(1, &vbo);
+    glBindVertexArray(vao); glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glBufferData(GL_ARRAY_BUFFER, cubeMesh.size() * sizeof(float), cubeMesh.data(), GL_STATIC_DRAW);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(0);
+
+    // A small level: player centered, walls/coin/exit around it.
+    struct Obj { ecs::Vec3 pos; std::string type; float s; };
+    const std::vector<Obj> objs = {
+        {{5, 0, 5}, "player", 1.2f}, {{5, 0, 1}, "wall", 1.0f}, {{1, 0, 5}, "wall", 1.0f},
+        {{8, 0, 8}, "coin", 1.0f},  {{2, 0, 8}, "exit", 1.0f}};
+
+    GameCamera cam;
+    cam.mode = GameCameraMode::TopDown;
+    cam.height = 12.0f;
+    cam.update(ecs::Vec3{5, 0, 5});
+
+    const glm::mat4 proj = glm::perspective(glm::radians(50.0f), float(kW) / kH, 0.1f, 100.0f);
+    auto renderWith = [&](const Theme& theme) {
+        const glm::mat4 view = glm::lookAt(glm::vec3(cam.eye.x, cam.eye.y, cam.eye.z),
+                                           glm::vec3(cam.target.x, cam.target.y, cam.target.z),
+                                           glm::vec3(cam.up.x, cam.up.y, cam.up.z));
+        glClearColor(theme.background.r, theme.background.g, theme.background.b, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        for (const Obj& o : objs) {
+            const RenderColor c = themedColor(o.type, theme);
+            glm::mat4 model = glm::translate(glm::mat4(1.0f), glm::vec3(o.pos.x, o.pos.y, o.pos.z));
+            model = glm::scale(model, glm::vec3(o.s, o.s, o.s));
+            const glm::mat4 mvp = proj * view * model;
+            glUniformMatrix4fv(uMVP, 1, GL_FALSE, glm::value_ptr(mvp));
+            glUniform3f(uColor, c.r, c.g, c.b);
+            glDrawArrays(GL_TRIANGLES, 0, GLsizei(cubeMesh.size() / 3));
+        }
+        glFinish();
+    };
+    auto readback = [&]() {
+        std::vector<unsigned char> rgba(std::size_t(kW) * kH * 4);
+        glReadPixels(0, 0, kW, kH, GL_RGBA, GL_UNSIGNED_BYTE, rgba.data());
+        std::vector<unsigned char> rgb(std::size_t(kW) * kH * 3);
+        for (std::size_t i = 0; i < std::size_t(kW) * kH; ++i) { rgb[i*3]=rgba[i*4]; rgb[i*3+1]=rgba[i*4+1]; rgb[i*3+2]=rgba[i*4+2]; }
+        return rgb;
+    };
+
+    int failures = 0;
+    // Dungeon theme: player framed near center; theme background + wall present.
+    const Theme dun = dungeonTheme();
+    renderWith(dun);
+    std::vector<unsigned char> rgb = readback();
+    float pcx, pcy; int pn;
+    centroid(rgb, kW, kH, toByte(dun.player.r), toByte(dun.player.g), toByte(dun.player.b), 12, pcx, pcy, pn);
+    if (pn <= 0) { std::fprintf(stderr, "FAIL: player not rendered\n"); ++failures; }
+    else if (std::fabs(pcx - kW / 2) > 40 || std::fabs(pcy - kH / 2) > 40) {
+        std::fprintf(stderr, "FAIL: player not framed near center (%.0f,%.0f)\n", pcx, pcy); ++failures;
+    }
+    if (countColor(rgb, toByte(dun.background.r), toByte(dun.background.g), toByte(dun.background.b), 10) <= 0) {
+        std::fprintf(stderr, "FAIL: dungeon background missing\n"); ++failures;
+    }
+    if (countColor(rgb, toByte(dun.wall.r), toByte(dun.wall.g), toByte(dun.wall.b), 12) <= 0) {
+        std::fprintf(stderr, "FAIL: dungeon wall missing\n"); ++failures;
+    }
+
+    // Grass theme applies its own distinct player color.
+    const Theme grs = grassTheme();
+    renderWith(grs);
+    rgb = readback();
+    if (countColor(rgb, toByte(grs.player.r), toByte(grs.player.g), toByte(grs.player.b), 12) <= 0) {
+        std::fprintf(stderr, "FAIL: grass theme player color missing\n"); ++failures;
+    }
+
+    glDeleteFramebuffers(1, &fbo); glDeleteTextures(1, &tex); glDeleteRenderbuffers(1, &depth);
+    glDeleteBuffers(1, &vbo); glDeleteVertexArrays(1, &vao);
+    glfwDestroyWindow(win); glfwTerminate();
+
+    if (failures == 0) { std::printf("test_game_camera_gl: all checks passed\n"); return 0; }
+    std::printf("test_game_camera_gl: %d check(s) failed\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #354. Adds the normal play-view camera (TourCamera #165 is the first-person walkthrough) and a cohesive theme palette.

New header `src/game/GameCamera.h`:
- `GameCamera` frames the player either straight **top-down** or from a fixed **follow** angle, exposing the `eye`/`target`/`up` the engine's GL camera consumes. `update(player)` tracks the player each frame with optional smoothing; `frameLevel(min, max)` lifts and centers the eye to fit a level's bounds (`levelBounds()` computes them from walls + actors).
- `Theme` is a cohesive palette (background + core material colors) with `dungeonTheme()` / `grassTheme()` presets; `themedColor(type, theme)` returns the theme's color for core types and falls back to the default #333 palette for the rest (keys, switches, hazards).

## Testing

- `test_game_camera` (headless): top-down and follow framing + player tracking; smoothing eases toward the goal instead of snapping; `frameLevel` fits bounds (a bigger level lifts the eye higher and centers it); the theme palette is distinct per theme with a default-palette fallback.
- `test_game_camera_gl` (gl, Xvfb + software GL): renders a level from the camera via a perspective `lookAt`, asserts the player is framed near the image center and the theme background + wall render, then swaps to a second theme and confirms its distinct player color appears.

Built and run via CTest (`test_game_camera_gl` under the `gl` label, run locally under Xvfb + llvmpipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_