### PR TITLE
Multiplayer: tournament brackets over verified match records (#358)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,6 +728,11 @@ add_executable(test_tower_defense
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tower_defense.cpp
 )
 
+# Single-elimination tournament bracket over verified match records (#358) - header-only.
+add_executable(test_tournament
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tournament.cpp
+)
+
 # First-person tour camera (Milestone 15 / #165) - header-only.
 add_executable(test_tour_camera
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tour_camera.cpp
@@ -1245,6 +1250,7 @@ set(HEADLESS_TESTS
     test_tonemap_chain
     test_topology
     test_tour_camera
+    test_tournament
     test_tower_defense
     test_tutorial
     test_ui_scaling

--- a/src/game/Tournament.h
+++ b/src/game/Tournament.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "game/Versus.h" // MatchRecord, VersusResult, verifyMatch
+
+#include <cstddef>
+#include <vector>
+
+/**
+ * @file Tournament.h
+ * @brief Single-elimination bracket over verified match records (issue #358).
+ *
+ * Ties the versus stack together into a tournament: seed N players, run rounds, advance
+ * winners, crown a champion - with every advancement backed by a replay-verified MatchRecord
+ * (#293), so a forged result cannot move a player forward. Each round pairs the surviving
+ * players in bracket order; an odd survivor takes a bye to the next round (so non-power-of-two
+ * fields are handled). reportMatch() resolves the next pending pairing from a record whose
+ * inputs0/inputs1 are that pairing's A/B: verifyMatch() must reproduce the claimed winner or
+ * the report is rejected. Deterministic (same records rebuild the same bracket), header-only.
+ */
+namespace IKore {
+namespace game {
+
+struct BracketMatch {
+    int round{0};
+    int playerA{-1};
+    int playerB{-1};
+    int winner{-1}; ///< resolved winner (a seed index), or -1 while pending.
+};
+
+class Tournament {
+public:
+    explicit Tournament(int numPlayers) {
+        if (numPlayers < 1) numPlayers = 1;
+        for (int i = 0; i < numPlayers; ++i) m_current.push_back(i);
+        startRound();
+    }
+
+    bool complete() const { return m_current.size() <= 1; }
+    /// The champion's seed index once complete, else -1.
+    int champion() const { return complete() && !m_current.empty() ? m_current.front() : -1; }
+    int round() const { return m_round; }
+
+    /// Real (non-bye) matches still to play in the current round.
+    int pendingMatches() const { return static_cast<int>(m_matches.size()) - m_nextIdx; }
+    /// The next pairing to resolve (A vs B); playerA == -1 if none is pending.
+    BracketMatch nextMatch() const {
+        if (m_nextIdx >= static_cast<int>(m_matches.size())) return BracketMatch{};
+        return m_matches[static_cast<std::size_t>(m_nextIdx)];
+    }
+    /// Every resolved match across all rounds (for standings / summary).
+    const std::vector<BracketMatch>& history() const { return m_history; }
+
+    /**
+     * @brief Resolve the next pending pairing from a verified record. The record's
+     *        inputs0/inputs1 are player A/B of that pairing; the replayed winner advances.
+     *        Returns false (no change) if the tournament is done, no pairing is pending, or
+     *        the record does not verify to its claimed winner.
+     */
+    bool reportMatch(const MatchRecord& rec) {
+        if (complete()) return false;
+        if (m_nextIdx >= static_cast<int>(m_matches.size())) return false;
+        VersusResult vr;
+        if (!verifyMatch(rec, vr)) return false; // anti-cheat: must reproduce its claim
+
+        BracketMatch& m = m_matches[static_cast<std::size_t>(m_nextIdx)];
+        m.winner = (vr.winner == 0) ? m.playerA : m.playerB;
+        m_advancers.push_back(m.winner);
+        m_history.push_back(m);
+        ++m_nextIdx;
+
+        if (m_nextIdx == static_cast<int>(m_matches.size())) {
+            if (m_byeAdvancer >= 0) m_advancers.push_back(m_byeAdvancer);
+            m_current = m_advancers;
+            ++m_round;
+            if (m_current.size() > 1) startRound();
+        }
+        return true;
+    }
+
+private:
+    void startRound() {
+        m_matches.clear();
+        m_advancers.clear();
+        m_nextIdx = 0;
+        m_byeAdvancer = -1;
+        for (std::size_t i = 0; i + 1 < m_current.size(); i += 2)
+            m_matches.push_back(BracketMatch{m_round, m_current[i], m_current[i + 1], -1});
+        if (m_current.size() % 2 == 1) m_byeAdvancer = m_current.back(); // odd survivor byes
+    }
+
+    int m_round{0};
+    std::vector<int> m_current;    ///< players still in, this round (bracket order).
+    std::vector<BracketMatch> m_matches; ///< this round's real pairings.
+    std::vector<int> m_advancers;  ///< winners (+ bye) collected this round, in bracket order.
+    std::vector<BracketMatch> m_history;
+    int m_nextIdx{0};
+    int m_byeAdvancer{-1};
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_tournament.cpp
+++ b/tests/test_tournament.cpp
@@ -1,0 +1,129 @@
+// Single-elimination tournament over verified match records - issue #358.
+//
+// Seeds N players, runs rounds off replay-verified MatchRecords, advances winners, and
+// crowns a champion. Checks: an 8-player bracket resolves to one champion in 7 matches; a
+// 2-player bracket lets player B win; byes are handled for a 6-player field; and a forged
+// record (claimed winner != replay) is rejected and advances no one. Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_tournament.cpp -o test_tournament
+
+#include "game/LevelFormat.h" // toLevelJson
+#include "game/Tournament.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static const double kDt = 1.0 / 60.0;
+
+static std::string makeLevelJson() {
+    LevelSpec s;
+    s.walls.push_back(Wall{{{0, 0, 0}, {30, 0, 0}, {30, 0, 30}, {0, 0, 30}, {0, 0, 0}}});
+    s.symbols.push_back(Symbol{"player", ecs::Vec3{4, 0, 4}, 0.0f});
+    s.symbols.push_back(Symbol{"coin", ecs::Vec3{12, 0, 12}, 0.0f});
+    s.symbols.push_back(Symbol{"exit", ecs::Vec3{24, 0, 24}, 0.0f});
+    return s.walls.empty() ? std::string() : toLevelJson(s);
+}
+
+static std::vector<GameInput> winTrace(const std::string& json) {
+    LevelSpec spec;
+    fromLevelJson(json, spec);
+    DungeonGame g = loadGame(convert(spec));
+    std::vector<GameInput> ins;
+    for (int i = 0; i < 800 && g.status == GameStatus::Playing; ++i) {
+        const GameInput in{1.0f, 1.0f};
+        g.update(in, static_cast<float>(kDt));
+        ins.push_back(in);
+    }
+    return ins;
+}
+
+// A record where `winner` (0 or 1) plays the clearing trace and the other idles.
+static MatchRecord record(const std::string& json, const std::vector<GameInput>& win, int winner) {
+    MatchRecord r;
+    r.levelJson = json;
+    r.dt = kDt;
+    const std::vector<GameInput> idle(win.size(), GameInput{0.0f, 0.0f});
+    r.inputs0 = winner == 0 ? win : idle;
+    r.inputs1 = winner == 0 ? idle : win;
+    r.claimedWinner = winner;
+    return r;
+}
+
+int main() {
+    const std::string json = makeLevelJson();
+    const std::vector<GameInput> win = winTrace(json);
+
+    // 1. An 8-player bracket resolves to one champion in 7 matches (player A always wins,
+    //    so the top seed advances all the way).
+    {
+        Tournament t(8);
+        CHECK(!t.complete());
+        CHECK(t.nextMatch().playerA == 0 && t.nextMatch().playerB == 1);
+        int reports = 0;
+        while (!t.complete()) {
+            CHECK(t.reportMatch(record(json, win, 0)));
+            ++reports;
+        }
+        CHECK(reports == 7);
+        CHECK(t.champion() == 0);
+        CHECK(t.history().size() == 7);
+        CHECK(t.round() == 3); // 8 -> 4 -> 2 -> 1
+    }
+
+    // 2. Player B can win a pairing.
+    {
+        Tournament t(2);
+        CHECK(t.reportMatch(record(json, win, 1)));
+        CHECK(t.complete());
+        CHECK(t.champion() == 1);
+    }
+
+    // 3. Byes are handled for a non-power-of-two (6-player) field.
+    {
+        Tournament t(6);
+        int reports = 0;
+        while (!t.complete()) {
+            CHECK(t.reportMatch(record(json, win, 0)));
+            ++reports;
+        }
+        CHECK(reports == 5); // round0: 3, round1: 1 (+bye), round2: 1
+        CHECK(t.champion() == 0);
+    }
+
+    // 4. A forged record (claimed winner disagrees with the replay) advances no one.
+    {
+        Tournament t(8);
+        MatchRecord forged;
+        forged.levelJson = json;
+        forged.dt = kDt;
+        forged.inputs0 = win;                              // player 0 actually clears
+        forged.inputs1 = std::vector<GameInput>(win.size(), GameInput{0, 0});
+        forged.claimedWinner = 1;                          // ...but claims player 1 won
+        const int pendingBefore = t.pendingMatches();
+        CHECK(!t.reportMatch(forged));                     // rejected
+        CHECK(t.pendingMatches() == pendingBefore);        // nothing advanced
+        // A truthful record still advances the bracket.
+        CHECK(t.reportMatch(record(json, win, 0)));
+        CHECK(t.pendingMatches() == pendingBefore - 1);
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_tournament: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_tournament: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #358. A single-elimination tournament that seeds N players, runs rounds, advances winners, and crowns a champion — with every advancement backed by a replay-verified `MatchRecord` (#293).

New header `src/game/Tournament.h`:
- Each round pairs the surviving players in bracket order; an odd survivor takes a **bye** to the next round, so non-power-of-two fields work.
- `reportMatch(rec)` resolves the next pending pairing from a record whose `inputs0`/`inputs1` are that pairing's A/B: `verifyMatch()` must reproduce the record's claimed winner or the report is **rejected and no one advances** (anti-cheat).
- `nextMatch()`, `pendingMatches()`, `champion()`, `round()`, and `history()` (every resolved match, for standings). Deterministic — the same records rebuild the same bracket.

## Testing

`test_tournament` (headless):
- an 8-player bracket resolves to one champion in exactly 7 matches (3 rounds);
- a 2-player pairing lets **player B** win;
- **byes** are handled for a 6-player field (round 0: 3 matches, round 1: 1 match + 1 bye, round 2: 1 match);
- a **forged** record (claimed winner disagreeing with the replay) is rejected and advances no one, while a truthful record still advances the bracket.

Built and run via CTest under the `headless` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_