### PR TITLE
Multiplayer: spectator lobby and shareable replay flow (#359)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,6 +909,11 @@ add_executable(test_spectator_controls
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_spectator_controls.cpp
 )
 
+# Spectator lobby: list live/finished sessions + route to standings/replay (#359) - header-only.
+add_executable(test_spectator_lobby
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_spectator_lobby.cpp
+)
+
 # GL render of the spectator HUD (scrubber bar + panels) offscreen (#352). Links glad/glfw/
 # glm and needs a GL context, so it is a gl-labelled test (run under Xvfb + software GL).
 add_executable(test_spectator_hud_gl
@@ -1231,6 +1236,7 @@ set(HEADLESS_TESTS
     test_skinning
     test_solver
     test_spectator_controls
+    test_spectator_lobby
     test_spectator_ui
     test_ssao_kernel
     test_star_rating

--- a/src/game/SpectatorLobby.h
+++ b/src/game/SpectatorLobby.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "game/Replay.h"      // Replay, decodeReplay
+#include "game/SpectatorUi.h" // ReplayScrubber, VersusFFA, ffaStandingsLines
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/**
+ * @file SpectatorLobby.h
+ * @brief The front door to watching: list live/finished sessions and route in (issue #359).
+ *
+ * The watch primitives exist in isolation - SpectatorUi (#335) renders live standings and a
+ * ReplayScrubber, and Replay (#317) round-trips a match to a shareable code. This is the
+ * lobby that ties them together: it lists joinable live sessions and finished-match replays
+ * with metadata in a deterministic order (live first, then most recent, then id), lets a
+ * spectator read a live session's standings (driving SpectatorUi), opens a finished entry's
+ * replay into a scrubber, and decodes a pasted share code straight into a scrubber (an
+ * invalid code yields an invalid scrubber, reported cleanly). Header-only, deterministic.
+ */
+namespace IKore {
+namespace game {
+
+struct LobbyEntry {
+    std::string id;
+    std::string title;
+    bool live{false};
+    int players{0};
+    std::int64_t updatedAt{0}; ///< caller-supplied timestamp (no wall clock here).
+    std::string replayCode;    ///< finished entries carry a Replay share code (#317).
+};
+
+class SpectatorLobby {
+public:
+    /// Add a joinable live session. @p match (optional) binds a live VersusFFA so a spectator
+    /// can read its standings; it must outlive the lobby.
+    void addLive(const std::string& id, const std::string& title, int players,
+                 std::int64_t updatedAt, const VersusFFA* match = nullptr) {
+        m_entries.push_back(LobbyEntry{id, title, true, players, updatedAt, std::string()});
+        m_live.push_back(match);
+    }
+    /// Add a finished match watchable from its Replay share code.
+    void addFinished(const std::string& id, const std::string& title, int players,
+                     std::int64_t updatedAt, const std::string& replayCode) {
+        m_entries.push_back(LobbyEntry{id, title, false, players, updatedAt, replayCode});
+        m_live.push_back(nullptr);
+    }
+
+    std::size_t size() const { return m_entries.size(); }
+
+    /// The lobby listing: live sessions first, then most-recently-updated, then id ascending.
+    std::vector<LobbyEntry> list() const {
+        std::vector<LobbyEntry> out = m_entries;
+        std::sort(out.begin(), out.end(), [](const LobbyEntry& a, const LobbyEntry& b) {
+            if (a.live != b.live) return a.live > b.live;          // live first
+            if (a.updatedAt != b.updatedAt) return a.updatedAt > b.updatedAt; // newest first
+            return a.id < b.id;                                    // stable tie-break
+        });
+        return out;
+    }
+
+    /// Read a live session's standings (drives SpectatorUi). False if not a bound live entry.
+    bool liveStandings(const std::string& id, std::vector<std::string>& out) const {
+        for (std::size_t i = 0; i < m_entries.size(); ++i) {
+            if (m_entries[i].id != id) continue;
+            if (!m_entries[i].live || m_live[i] == nullptr) return false;
+            out = ffaStandingsLines(*m_live[i]);
+            return true;
+        }
+        return false;
+    }
+
+    /// Open a finished entry's replay into a scrubber (invalid scrubber if unknown/undecodable).
+    ReplayScrubber openReplay(const std::string& id) const {
+        for (const LobbyEntry& e : m_entries) {
+            if (e.id == id && !e.live) return openCode(e.replayCode);
+        }
+        return ReplayScrubber(Replay{});
+    }
+
+    /// Paste-a-code: decode a Replay share code straight into a scrubber. Check valid().
+    static ReplayScrubber openCode(const std::string& code) {
+        Replay r;
+        if (decodeReplay(code, r)) return ReplayScrubber(std::move(r));
+        return ReplayScrubber(Replay{});
+    }
+
+private:
+    std::vector<LobbyEntry> m_entries;
+    std::vector<const VersusFFA*> m_live; ///< parallel to m_entries (nullptr unless a bound live).
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_spectator_lobby.cpp
+++ b/tests/test_spectator_lobby.cpp
@@ -1,0 +1,116 @@
+// Spectator lobby: list live/finished sessions and route in - issue #359.
+//
+// Verifies the lobby lists a mix of live sessions and finished-match replays in a
+// deterministic order (live first, then most recent, then id), reads a live session's
+// standings (driving SpectatorUi), opens a finished entry's replay into a scrubbable
+// timeline, decodes a pasted share code into a scrubber, and reports an invalid code as an
+// invalid scrubber. Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_spectator_lobby.cpp -o test_spectator_lobby
+
+#include "game/LevelFormat.h" // toLevelJson
+#include "game/Replay.h"      // makeRunReplay, encodeReplay
+#include "game/SpectatorLobby.h"
+#include "game/VersusFFA.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static const float kDt = 1.0f / 60.0f;
+
+static std::string makeLevelJson() {
+    LevelSpec s;
+    s.walls.push_back(Wall{{{0, 0, 0}, {40, 0, 0}, {40, 0, 40}, {0, 0, 40}, {0, 0, 0}}});
+    s.symbols.push_back(Symbol{"player", ecs::Vec3{5, 0, 5}, 0.0f});
+    s.symbols.push_back(Symbol{"coin", ecs::Vec3{9, 0, 9}, 0.0f});
+    s.symbols.push_back(Symbol{"exit", ecs::Vec3{14, 0, 14}, 0.0f});
+    return toLevelJson(s);
+}
+
+static std::string finishedCode(const std::string& json) {
+    LevelSpec spec;
+    fromLevelJson(json, spec);
+    DungeonGame g = loadGame(convert(spec));
+    RunTrace t;
+    t.dt = kDt;
+    for (int i = 0; i < 400 && g.status == GameStatus::Playing; ++i) {
+        const GameInput in{1.0f, 1.0f};
+        g.update(in, kDt);
+        t.inputs.push_back(in);
+    }
+    return encodeReplay(makeRunReplay(json, t));
+}
+
+int main() {
+    const std::string json = makeLevelJson();
+    const std::string code = finishedCode(json);
+
+    VersusFFA live(json, /*local=*/0, /*players=*/3, kDt);
+    for (int f = 0; f < 60; ++f) {
+        live.advance(GameInput{1.0f, 1.0f});
+        live.addRemoteInput(1, f, GameInput{});
+        live.addRemoteInput(2, f, GameInput{});
+    }
+
+    SpectatorLobby lobby;
+    lobby.addFinished("f1", "Finished A", 2, /*updatedAt=*/100, code);
+    lobby.addLive("live1", "Live Match", 3, /*updatedAt=*/50, &live);
+    lobby.addFinished("f2", "Finished B", 2, /*updatedAt=*/200, code);
+    CHECK(lobby.size() == 3);
+
+    // 1. Listing: live first, then most-recent finished, then id.
+    {
+        const std::vector<LobbyEntry> l = lobby.list();
+        CHECK(l.size() == 3);
+        CHECK(l[0].id == "live1" && l[0].live);   // live first
+        CHECK(l[1].id == "f2");                    // newer finished (200) before...
+        CHECK(l[2].id == "f1");                    // ...older finished (100)
+    }
+
+    // 2. A live session's standings drive SpectatorUi.
+    {
+        std::vector<std::string> standings;
+        CHECK(lobby.liveStandings("live1", standings));
+        CHECK(standings.size() == 3);
+        CHECK(standings == ffaStandingsLines(live)); // bound to the live match
+        std::vector<std::string> none;
+        CHECK(!lobby.liveStandings("f1", none)); // a finished entry is not live
+    }
+
+    // 3. Opening a finished entry yields a scrubbable timeline.
+    {
+        ReplayScrubber sc = lobby.openReplay("f2");
+        CHECK(sc.valid());
+        CHECK(sc.length() > 0);
+        sc.seek(sc.length());
+        CHECK(sc.tick() == sc.length());
+        // Unknown id -> invalid scrubber.
+        CHECK(!lobby.openReplay("nope").valid());
+    }
+
+    // 4. Paste-a-code opens the right replay; an invalid code is reported cleanly.
+    {
+        CHECK(SpectatorLobby::openCode(code).valid());
+        CHECK(!SpectatorLobby::openCode("not-a-real-code").valid());
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_spectator_lobby: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_spectator_lobby: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #359. The front door to watching, tying together the existing watch primitives.

New header `src/game/SpectatorLobby.h`:
- Lists joinable **live** sessions and **finished-match replays** with metadata in a deterministic order (live first, then most recently updated, then id).
- `liveStandings(id)` reads a bound live session's standings via `ffaStandingsLines` (drives `SpectatorUi` #335).
- `openReplay(id)` opens a finished entry's replay into a `ReplayScrubber`; `openCode(code)` decodes a pasted `Replay` share code (#317) straight into a scrubber. An unknown id or an undecodable code yields an invalid scrubber, reported via `valid()`.

Header-only, deterministic.

## Testing

`test_spectator_lobby` (headless):
- a mixed live/finished lobby lists in the right order (live first, newer finished before older);
- a live session's standings are read from the bound match, and a finished entry is not "live";
- opening a finished entry yields a scrubbable timeline (seek to end), and an unknown id is an invalid scrubber;
- paste-a-code opens the right replay, and an invalid code is reported cleanly.

Built and run via CTest under the `headless` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_