### PR TITLE
Capture: digit-glyph recognition for @id feature links (#361)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,6 +830,11 @@ add_executable(test_glyph_net
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_glyph_net.cpp
 )
 
+# Digit-glyph recognition -> @id feature links via GlyphNet (#361) - header-only.
+add_executable(test_glyph_digits
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_glyph_digits.cpp
+)
+
 # Phase 4 symbol recognizer: data pipeline, export, accuracy/confusion harness,
 # heuristic fallback (Milestone 16/17 / #240) - header-only.
 add_executable(test_symbol_recognizer
@@ -1208,6 +1213,7 @@ set(HEADLESS_TESTS
     test_geojson_importer
     test_ghost_race
     test_ghost_replay
+    test_glyph_digits
     test_glyph_net
     test_hud_framework
     test_ibl_brdf

--- a/src/game/GlyphDigits.h
+++ b/src/game/GlyphDigits.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "cv/Vectorize.h"  // cv::Mask
+#include "ml/GlyphNet.h"   // ml::normalizeGlyph, ml::GlyphClassifier
+
+#include <array>
+#include <cmath>
+#include <set>
+#include <string>
+#include <vector>
+
+/**
+ * @file GlyphDigits.h
+ * @brief Read a hand-drawn digit next to a linkable symbol to form its @id (issue #361).
+ *
+ * The drawing vocabulary links features by an @id (a drawn key opens the matching drawn door,
+ * #319/#336), but the id had to be supplied out of band. This lets players write the link on
+ * paper: it trains the GlyphNet classifier (#173) on a small digit font, recognizes the digit
+ * drawn beside a linkable symbol, and emits the correct "type@id" spawn string. An unreadable
+ * digit falls back to auto-numbering rather than a wrong link, so a smudge never mispairs.
+ *
+ * Header-only, deterministic (the classifier trains from a fixed synthetic font with a fixed
+ * seed), and dependency-free beyond the header-only CV / GlyphNet cores - unit-testable
+ * headless with no external model.
+ */
+namespace IKore {
+namespace game {
+
+/// A 5x7 bitmap for digit @p d (0-9); rows top-to-bottom, '#' = ink.
+inline std::array<const char*, 7> digitFont(int d) {
+    static const std::array<std::array<const char*, 7>, 10> kFont = {{
+        {{".###.", "#...#", "#..##", "#.#.#", "##..#", "#...#", ".###."}}, // 0
+        {{"..#..", ".##..", "..#..", "..#..", "..#..", "..#..", ".###."}}, // 1
+        {{".###.", "#...#", "....#", "...#.", "..#..", ".#...", "#####"}}, // 2
+        {{"#####", "...#.", "..#..", "...#.", "....#", "#...#", ".###."}}, // 3
+        {{"...#.", "..##.", ".#.#.", "#..#.", "#####", "...#.", "...#."}}, // 4
+        {{"#####", "#....", "####.", "....#", "....#", "#...#", ".###."}}, // 5
+        {{"..##.", ".#...", "#....", "####.", "#...#", "#...#", ".###."}}, // 6
+        {{"#####", "....#", "...#.", "..#..", ".#...", ".#...", ".#..."}}, // 7
+        {{".###.", "#...#", "#...#", ".###.", "#...#", "#...#", ".###."}}, // 8
+        {{".###.", "#...#", "#...#", ".####", "....#", "...#.", ".##.."}}, // 9
+    }};
+    return kFont[static_cast<std::size_t>(d < 0 ? 0 : (d > 9 ? 9 : d))];
+}
+
+/// Rasterize digit @p d into an ink mask, each font pixel a @p scale square, @p pad border.
+inline cv::Mask renderDigit(int d, int scale = 3, int pad = 2) {
+    const auto font = digitFont(d);
+    cv::Mask m(5 * scale + 2 * pad, 7 * scale + 2 * pad);
+    for (int r = 0; r < 7; ++r)
+        for (int c = 0; c < 5; ++c)
+            if (font[static_cast<std::size_t>(r)][static_cast<std::size_t>(c)] == '#')
+                for (int yy = 0; yy < scale; ++yy)
+                    for (int xx = 0; xx < scale; ++xx)
+                        m.set(pad + c * scale + xx, pad + r * scale + yy, 1);
+    return m;
+}
+
+/// Train a digit classifier (0-9) on the synthetic font at a few scales. Deterministic.
+inline ml::GlyphClassifier trainDigitClassifier(int size = 12) {
+    std::vector<std::vector<float>> X;
+    std::vector<int> y;
+    const std::vector<std::string> labels = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+    for (int d = 0; d <= 9; ++d)
+        for (int scale : {2, 3, 4}) {
+            X.push_back(ml::normalizeGlyph(renderDigit(d, scale), size));
+            y.push_back(d);
+        }
+    ml::GlyphClassifier clf;
+    clf.train(X, y, labels, /*epochs=*/400, /*lr=*/0.5f, /*seed=*/1);
+    return clf;
+}
+
+/// Recognize a single digit from an ink mask; -1 if below @p minConfidence (unreadable).
+inline int recognizeDigit(const ml::GlyphClassifier& clf, const cv::Mask& mask, int size = 12,
+                          float minConfidence = 0.6f) {
+    const ml::GlyphClassifier::Result r = clf.classifyGlyph(mask, size, minConfidence);
+    if (r.lowConfidence || r.label.empty()) return -1;
+    return r.label[0] - '0';
+}
+
+// --- @id linking -------------------------------------------------------------
+
+struct LinkableSymbol {
+    std::string type; ///< "key" / "lockeddoor" / "switch" / "togglewall".
+    float x{0.0f}, z{0.0f};
+};
+struct DigitMark {
+    cv::Mask mask;
+    float x{0.0f}, z{0.0f};
+};
+
+/**
+ * @brief Assign each linkable symbol an @id and emit "type@id" spawn strings. A recognized
+ *        digit is attached to its nearest symbol; symbols left without a confident digit are
+ *        auto-numbered with the smallest unused id (so an unreadable digit never mispairs).
+ */
+inline std::vector<std::string> linkDigitIds(const std::vector<LinkableSymbol>& symbols,
+                                             const std::vector<DigitMark>& marks,
+                                             const ml::GlyphClassifier& clf, int size = 12,
+                                             float minConfidence = 0.6f) {
+    std::vector<int> id(symbols.size(), -1);
+    for (const DigitMark& mk : marks) {
+        const int d = recognizeDigit(clf, mk.mask, size, minConfidence);
+        if (d < 0 || symbols.empty()) continue;
+        std::size_t best = 0;
+        float bestDist = 1e30f;
+        for (std::size_t j = 0; j < symbols.size(); ++j) {
+            const float dx = symbols[j].x - mk.x, dz = symbols[j].z - mk.z;
+            const float dist = dx * dx + dz * dz;
+            if (dist < bestDist) { bestDist = dist; best = j; }
+        }
+        if (id[best] < 0) id[best] = d; // first confident digit wins the symbol
+    }
+    std::set<int> used;
+    for (int v : id) if (v >= 0) used.insert(v);
+    int nextAuto = 1;
+    std::vector<std::string> out;
+    out.reserve(symbols.size());
+    for (std::size_t j = 0; j < symbols.size(); ++j) {
+        if (id[j] < 0) {
+            while (used.count(nextAuto)) ++nextAuto;
+            id[j] = nextAuto;
+            used.insert(nextAuto);
+        }
+        out.push_back(symbols[j].type + "@" + std::to_string(id[j]));
+    }
+    return out;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_glyph_digits.cpp
+++ b/tests/test_glyph_digits.cpp
@@ -1,0 +1,77 @@
+// Digit-glyph recognition for @id feature links - issue #361.
+//
+// Trains the GlyphNet classifier (#173) on a synthetic digit font, recognizes a digit drawn
+// beside a linkable symbol, and forms "type@id" spawn strings - pairing a key and door that
+// share the drawn digit, while an unreadable (smudged) digit falls back to auto-numbering
+// rather than a wrong link. Pure std + the header-only CV / GlyphNet cores:
+//   g++ -std=c++17 -I src tests/test_glyph_digits.cpp -o test_glyph_digits
+
+#include "game/GlyphDigits.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+int main() {
+    const ml::GlyphClassifier clf = trainDigitClassifier();
+
+    // 1. Every digit is recognized (at a trained scale and at an unseen scale - the
+    //    normalization makes recognition scale/position invariant).
+    for (int d = 0; d <= 9; ++d) {
+        CHECK(recognizeDigit(clf, renderDigit(d, /*scale=*/3)) == d);
+        CHECK(recognizeDigit(clf, renderDigit(d, /*scale=*/5, /*pad=*/4)) == d);
+    }
+
+    // 2. An empty / smudged crop is unreadable (-1), not a wrong digit.
+    {
+        cv::Mask smudge(12, 12); // no ink
+        CHECK(recognizeDigit(clf, smudge) == -1);
+    }
+
+    // 3. A key and a door labelled with the same drawn digit pair up via @id.
+    {
+        const std::vector<LinkableSymbol> symbols = {
+            {"key", 0.0f, 0.0f}, {"lockeddoor", 10.0f, 0.0f}, {"switch", 20.0f, 0.0f}};
+        std::vector<DigitMark> marks;
+        marks.push_back(DigitMark{renderDigit(2), 0.6f, 0.0f});   // "2" by the key
+        marks.push_back(DigitMark{renderDigit(2), 10.6f, 0.0f});  // "2" by the door
+        marks.push_back(DigitMark{cv::Mask(12, 12), 20.6f, 0.0f}); // a smudge by the switch
+
+        const std::vector<std::string> out = linkDigitIds(symbols, marks, clf);
+        CHECK(out.size() == 3);
+        CHECK(out[0] == "key@2");
+        CHECK(out[1] == "lockeddoor@2"); // the matching pair
+        // The unreadable one is auto-numbered, never mispaired onto @2.
+        CHECK(out[2] == "switch@1");
+    }
+
+    // 4. A different drawn digit links a distinct pair.
+    {
+        const std::vector<LinkableSymbol> symbols = {{"switch", 0.0f, 0.0f}, {"togglewall", 5.0f, 0.0f}};
+        std::vector<DigitMark> marks = {DigitMark{renderDigit(7), 0.5f, 0.0f},
+                                        DigitMark{renderDigit(7), 5.5f, 0.0f}};
+        const std::vector<std::string> out = linkDigitIds(symbols, marks, clf);
+        CHECK(out[0] == "switch@7");
+        CHECK(out[1] == "togglewall@7");
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_glyph_digits: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_glyph_digits: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #361. Lets players write a feature's `@id` on paper.

New header `src/game/GlyphDigits.h`:
- Trains the GlyphNet classifier (#173) on a synthetic 5x7 digit font at a few scales (fixed seed → deterministic).
- `recognizeDigit()` reads a digit from an ink crop via the scale/position-invariant normalization frontend; returns -1 below a confidence threshold (unreadable).
- `linkDigitIds()` attaches each recognized digit to its nearest linkable symbol and emits `type@id` spawn strings, so a key and door sharing the drawn digit pair up (#319/#336). Symbols left without a confident digit are **auto-numbered** with the smallest unused id, so a smudge never mispairs.

Header-only, deterministic, no external model.

## Testing

`test_glyph_digits` (headless):
- every digit 0-9 is recognized at a trained scale **and** an unseen scale (normalization invariance);
- an empty/smudged crop is unreadable (-1), not a wrong digit;
- a key and door labelled with the same drawn "2" become `key@2` / `lockeddoor@2`, while a smudge by the switch auto-numbers to `switch@1` (never mispaired onto @2);
- a distinct drawn digit links a distinct pair (`switch@7` / `togglewall@7`).

Built and run via CTest under the `headless` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_