### PR TITLE
Capture: auto-repair unsolvable captured levels (#362)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -836,6 +836,11 @@ add_executable(test_symbol_recognizer
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_symbol_recognizer.cpp
 )
 
+# Solver-guided auto-repair of unsolvable captured levels (#362) - header-only.
+add_executable(test_level_autorepair
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_autorepair.cpp
+)
+
 # UGC catalog: share codes, feed, stars (Milestone 17 / #174) - header-only.
 add_executable(test_level_catalog
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_catalog.cpp
@@ -1213,6 +1218,7 @@ set(HEADLESS_TESTS
     test_ibl_brdf
     test_input_map
     test_leaderboard
+    test_level_autorepair
     test_level_catalog
     test_level_format
     test_level_gen

--- a/src/game/LevelRepair.h
+++ b/src/game/LevelRepair.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "game/DungeonGame.h" // DungeonGame, ecs::Vec3
+#include "game/Solver.h"      // solve, SolveResult, SolveOptions, detail::buildGrid
+
+#include <cmath>
+#include <queue>
+#include <string>
+#include <vector>
+
+/**
+ * @file LevelRepair.h
+ * @brief Auto-repair an unsolvable captured level with minimal, reported edits (issue #362).
+ *
+ * The Solver (#316) reports exactly why a level fails - an unreachable exit or coin. A
+ * captured drawing often just misses playability that way. Rather than reject it, this
+ * proposes the smallest fix: relocate each unreachable objective (the exit, or a coin) onto
+ * the nearest cell the player can actually reach, guided by the same walkability the Solver
+ * uses. Every change is reported so it is reviewable, not silent; an already-solvable level
+ * is returned untouched; and the repair is deterministic and idempotent (repairing a
+ * repaired level is a no-op). A suggest-only mode returns the edits without applying them.
+ * Header-only, std only.
+ */
+namespace IKore {
+namespace game {
+
+struct RepairEdit {
+    std::string what;   ///< "exit" or "coin".
+    ecs::Vec3 from{};
+    ecs::Vec3 to{};
+};
+
+struct RepairOptions {
+    SolveOptions solve{};
+    bool apply{true};   ///< false = suggest only (edits computed, level left unchanged).
+};
+
+struct RepairResult {
+    bool wasSolvable{false}; ///< the input was already solvable.
+    bool nowSolvable{false}; ///< solvable after the (proposed) edits.
+    std::vector<RepairEdit> edits;
+    DungeonGame level;       ///< repaired level (or the original if suggest-only / already ok).
+};
+
+namespace detail {
+
+/// Cell centers reachable from the player start over the game's static-wall walkability.
+inline std::vector<ecs::Vec3> reachableCenters(const DungeonGame& game, const SolveOptions& opt) {
+    const SolverGrid grid = buildGrid(game, opt);
+    const int cells = grid.nx * grid.nz;
+    std::vector<ecs::Vec3> out;
+    if (cells <= 0) return out;
+    std::vector<char> walkable(static_cast<std::size_t>(cells), 0);
+    for (int i = 0; i < cells; ++i)
+        walkable[static_cast<std::size_t>(i)] = game.hitsWall(grid.center(i), game.playerRadius) ? 0 : 1;
+    const int start = grid.cellOf(game.playerPosition.x, game.playerPosition.z);
+    if (start < 0 || !walkable[static_cast<std::size_t>(start)]) return out;
+    std::vector<char> seen(static_cast<std::size_t>(cells), 0);
+    std::queue<int> q;
+    q.push(start);
+    seen[static_cast<std::size_t>(start)] = 1;
+    const int dxs[4] = {1, -1, 0, 0}, dzs[4] = {0, 0, 1, -1};
+    while (!q.empty()) {
+        const int cur = q.front();
+        q.pop();
+        out.push_back(grid.center(cur));
+        const int gx = cur % grid.nx, gz = cur / grid.nx;
+        for (int d = 0; d < 4; ++d) {
+            const int nb = grid.index(gx + dxs[d], gz + dzs[d]);
+            if (nb < 0 || seen[static_cast<std::size_t>(nb)] || !walkable[static_cast<std::size_t>(nb)]) continue;
+            seen[static_cast<std::size_t>(nb)] = 1;
+            q.push(nb);
+        }
+    }
+    return out;
+}
+
+inline float dist2(const ecs::Vec3& a, const ecs::Vec3& b) {
+    const float dx = a.x - b.x, dz = a.z - b.z;
+    return dx * dx + dz * dz;
+}
+
+/// The reachable cell nearest to @p p (assumes @p centers non-empty).
+inline ecs::Vec3 nearestReachable(const std::vector<ecs::Vec3>& centers, const ecs::Vec3& p) {
+    ecs::Vec3 best = centers.front();
+    float bestD = dist2(best, p);
+    for (const ecs::Vec3& c : centers) {
+        const float d = dist2(c, p);
+        if (d < bestD) { bestD = d; best = c; }
+    }
+    return best;
+}
+
+} // namespace detail
+
+/**
+ * @brief Repair @p base so every objective is reachable, moving each unreachable objective to
+ *        the nearest reachable cell. Returns the edits made and the (optionally applied)
+ *        result. An already-solvable level is returned unchanged.
+ */
+inline RepairResult repairLevel(const DungeonGame& base, const RepairOptions& opt = {}) {
+    RepairResult res;
+    res.level = base;
+    const SolveResult sr0 = solve(base, opt.solve);
+    if (sr0.solvable) {
+        res.wasSolvable = true;
+        res.nowSolvable = true;
+        return res; // untouched
+    }
+
+    const std::vector<ecs::Vec3> reachable = detail::reachableCenters(base, opt.solve);
+    if (reachable.empty()) return res; // player boxed in: nothing to relocate onto
+
+    DungeonGame fixed = base;
+    // Relocate an unreachable exit.
+    if (fixed.hasExit && !sr0.exitReachable) {
+        const ecs::Vec3 to = detail::nearestReachable(reachable, fixed.exitPosition);
+        res.edits.push_back(RepairEdit{"exit", fixed.exitPosition, to});
+        fixed.exitPosition = to;
+    }
+    // Relocate each unreachable coin (no reachable cell within its pickup radius).
+    const float coinR = base.playerRadius + base.coinRadius;
+    for (Coin& c : fixed.coins) {
+        bool reachableCoin = false;
+        for (const ecs::Vec3& center : reachable)
+            if (detail::dist2(center, c.position) <= coinR * coinR) { reachableCoin = true; break; }
+        if (!reachableCoin) {
+            const ecs::Vec3 to = detail::nearestReachable(reachable, c.position);
+            res.edits.push_back(RepairEdit{"coin", c.position, to});
+            c.position = to;
+        }
+    }
+
+    res.nowSolvable = solve(fixed, opt.solve).solvable;
+    if (opt.apply) res.level = fixed; // suggest-only leaves res.level == base
+    return res;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_level_autorepair.cpp
+++ b/tests/test_level_autorepair.cpp
@@ -1,0 +1,124 @@
+// Auto-repair unsolvable captured levels - issue #362.
+//
+// The Solver's diagnostics drive minimal, reported fixes: an unreachable exit or coin is
+// relocated onto the nearest reachable cell, an already-solvable level is untouched, the
+// repair is deterministic and idempotent, and a suggest-only mode reports edits without
+// applying them. Pure std + the header-only game / solver:
+//   g++ -std=c++17 -I src tests/test_level_autorepair.cpp -o test_level_autorepair
+
+#include "game/LevelRepair.h"
+
+#include <cstdio>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static world::Box wall(float cx, float cz, float sx, float sz) {
+    world::Box b;
+    b.center = ecs::Vec3{cx, 0.0f, cz};
+    b.size = ecs::Vec3{sx, 3.0f, sz};
+    b.yaw = 0.0f;
+    return b;
+}
+// Four walls fully enclosing (cx,cz) in a 2*half square, so anything inside is stranded.
+static std::vector<world::Box> boxAround(float cx, float cz, float half = 1.5f) {
+    const float t = 0.4f, span = 2.0f * half + t;
+    return {wall(cx, cz + half, span, t), wall(cx, cz - half, span, t),
+            wall(cx - half, cz, t, span), wall(cx + half, cz, t, span)};
+}
+static EntitySpawn sp(const char* t, float x, float z) { return EntitySpawn{t, ecs::Vec3{x, 0.0f, z}, 0.0f}; }
+static DungeonGame makeGame(std::vector<world::Box> walls, std::vector<EntitySpawn> spawns) {
+    SceneDescription s;
+    s.wallBoxes = std::move(walls);
+    s.spawns = std::move(spawns);
+    return loadGame(s);
+}
+static int countEdit(const std::vector<RepairEdit>& e, const char* what) {
+    int n = 0;
+    for (const RepairEdit& x : e) if (x.what == what) ++n;
+    return n;
+}
+
+int main() {
+    // 1. An already-solvable level is returned untouched.
+    {
+        const DungeonGame g = makeGame({}, {sp("player", 0, 0), sp("coin", 2, 0), sp("exit", 4, 0)});
+        const RepairResult r = repairLevel(g);
+        CHECK(r.wasSolvable && r.nowSolvable);
+        CHECK(r.edits.empty());
+        CHECK(r.level.exitPosition.x == g.exitPosition.x); // unchanged
+    }
+
+    // 2. An unreachable exit is relocated onto a reachable cell.
+    {
+        const DungeonGame g = makeGame(boxAround(10, 0), {sp("player", 0, 0), sp("coin", 2, 0), sp("exit", 10, 0)});
+        CHECK(!solve(g).solvable); // stranded exit
+        const RepairResult r = repairLevel(g);
+        CHECK(!r.wasSolvable);
+        CHECK(r.nowSolvable);
+        CHECK(countEdit(r.edits, "exit") == 1);
+        CHECK(r.level.exitPosition.x != g.exitPosition.x); // moved
+        CHECK(solve(r.level).solvable);
+    }
+
+    // 3. An unreachable coin is relocated so all coins become collectible.
+    {
+        const DungeonGame g = makeGame(boxAround(10, 0), {sp("player", 0, 0), sp("coin", 10, 0), sp("exit", 2, 0)});
+        CHECK(!solve(g).solvable);
+        const RepairResult r = repairLevel(g);
+        CHECK(r.nowSolvable);
+        CHECK(countEdit(r.edits, "coin") == 1);
+        const SolveResult sr = solve(r.level);
+        CHECK(sr.solvable);
+        CHECK(sr.reachableCoins == sr.totalCoins);
+    }
+
+    // 4. Idempotent: repairing a repaired level is a no-op.
+    {
+        const DungeonGame g = makeGame(boxAround(10, 0), {sp("player", 0, 0), sp("coin", 2, 0), sp("exit", 10, 0)});
+        const RepairResult r1 = repairLevel(g);
+        const RepairResult r2 = repairLevel(r1.level);
+        CHECK(r2.wasSolvable);
+        CHECK(r2.edits.empty());
+    }
+
+    // 5. Suggest-only reports the edits but leaves the level unchanged.
+    {
+        const DungeonGame g = makeGame(boxAround(10, 0), {sp("player", 0, 0), sp("coin", 2, 0), sp("exit", 10, 0)});
+        RepairOptions opt;
+        opt.apply = false;
+        const RepairResult r = repairLevel(g, opt);
+        CHECK(!r.edits.empty());               // a fix is proposed
+        CHECK(r.nowSolvable);                  // ...and it would work
+        CHECK(r.level.exitPosition.x == g.exitPosition.x); // but nothing was applied
+        CHECK(!solve(r.level).solvable);       // still unsolvable as-is
+    }
+
+    // 6. Deterministic: same input -> same edits.
+    {
+        const DungeonGame g = makeGame(boxAround(10, 0), {sp("player", 0, 0), sp("coin", 2, 0), sp("exit", 10, 0)});
+        const RepairResult a = repairLevel(g);
+        const RepairResult b = repairLevel(g);
+        CHECK(a.edits.size() == b.edits.size());
+        CHECK(!a.edits.empty());
+        CHECK(a.edits[0].to.x == b.edits[0].to.x && a.edits[0].to.z == b.edits[0].to.z);
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_level_autorepair: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_level_autorepair: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #362. Rather than reject an unsolvable captured level, propose the smallest fix from the `Solver`'s diagnostics (#316).

New header `src/game/LevelRepair.h` — `repairLevel(base)`:
- computes the cells reachable from the player start over the same walkability the Solver uses;
- relocates each unreachable objective (the exit, or a coin) onto the **nearest reachable cell**;
- reports every change as a `RepairEdit` (reviewable, not silent);
- returns an already-solvable level untouched; is deterministic and idempotent (repairing a repaired level is a no-op);
- offers a **suggest-only** mode (`apply=false`) that returns the edits without mutating.

Header-only, std only.

## Testing

`test_level_autorepair` (headless):
- a solvable level is returned untouched with no edits;
- a stranded exit is relocated onto a reachable cell and the level becomes solvable;
- a stranded coin is relocated so all coins become collectible (`reachableCoins == totalCoins`);
- the repair is idempotent;
- suggest-only reports a working fix but leaves the level unchanged (still unsolvable as-is);
- deterministic — same input yields the same edits.

Built and run via CTest under the `headless` label; also verified ASan/UBSan-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_