### PR TITLE
Level tools: in-engine level editor with live solver fairness (#363)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -851,6 +851,11 @@ add_executable(test_level_gen
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_gen.cpp
 )
 
+# In-engine level editor: command layer, undo/redo, live solver fairness (#363) - header-only.
+add_executable(test_level_editor
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_level_editor.cpp
+)
+
 # Weekly challenge rotation + per-week leaderboard: deterministic week/selection,
 # replay-verified submits, week-rollover isolation (#273) - header-only.
 add_executable(test_weekly_challenge
@@ -1225,6 +1230,7 @@ set(HEADLESS_TESTS
     test_input_map
     test_leaderboard
     test_level_catalog
+    test_level_editor
     test_level_format
     test_level_gen
     test_level_review

--- a/src/game/LevelEditor.h
+++ b/src/game/LevelEditor.h
@@ -1,0 +1,235 @@
+#pragma once
+
+#include "game/DungeonGame.h" // DungeonGame, SceneDescription, EntitySpawn, loadGame, world::Box
+#include "game/Solver.h"      // solve, SolveResult, SolveOptions
+
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * @file LevelEditor.h
+ * @brief Headless, command-driven in-engine level editor (issue #363).
+ *
+ * The engine already turns a drawing into a playable DungeonGame; this is the other
+ * direction - authoring a level cell by cell and checking, live, that it is fair. The
+ * editor is a pure command layer over a grid model (a set of wall cells and a map of
+ * object cells), with snapshot undo/redo, so the same logic drives an on-screen editor
+ * and a headless test. game() bakes the current model into a DungeonGame (wall cells
+ * become boxes, object cells become spawns) and fairness() runs the solver on it, so an
+ * author sees "unsolvable" flip to "solvable" the instant they carve an opening. A level
+ * round-trips through serialize()/deserialize() as stable, sorted text.
+ *
+ * Header-only, std only (plus the header-only game/solver cores).
+ */
+namespace IKore {
+namespace game {
+
+/// Grid cell coordinate (gx, gz). Objects and walls are keyed by cell.
+using EditorCell = std::pair<int, int>;
+
+/// The full editable model: everything a snapshot needs to capture for undo/redo.
+struct EditorState {
+    float cellWorld{2.0f};                     ///< world units per grid cell.
+    std::set<EditorCell> walls;                ///< occupied wall cells.
+    std::map<EditorCell, std::string> objects; ///< object spawn type per cell (player/exit/coin/...).
+
+    bool operator==(const EditorState& o) const {
+        return cellWorld == o.cellWorld && walls == o.walls && objects == o.objects;
+    }
+};
+
+/**
+ * @brief A command layer over an EditorState with snapshot undo/redo.
+ *
+ * Every mutator that actually changes the model pushes the pre-change state onto the undo
+ * stack and clears the redo stack; a no-op edit (placing a wall that is already there)
+ * changes nothing and records nothing, so undo/redo never step over phantom edits.
+ */
+class LevelEditor {
+public:
+    LevelEditor() = default;
+
+    const EditorState& state() const { return m_state; }
+    float cellWorld() const { return m_state.cellWorld; }
+    void setCellWorld(float w) {
+        if (w == m_state.cellWorld) return;
+        pushUndo();
+        m_state.cellWorld = w;
+    }
+
+    // --- Editing commands (return true if the model changed) ------------------
+
+    bool placeWall(int gx, int gz) {
+        const EditorCell c{gx, gz};
+        if (m_state.walls.count(c)) return false;
+        pushUndo();
+        m_state.walls.insert(c);
+        // A wall and an object never share a cell: placing a wall clears any object there.
+        m_state.objects.erase(c);
+        return true;
+    }
+
+    bool eraseWall(int gx, int gz) {
+        const EditorCell c{gx, gz};
+        if (!m_state.walls.count(c)) return false;
+        pushUndo();
+        m_state.walls.erase(c);
+        return true;
+    }
+
+    /// Place (or retype) an object spawn at a cell. Clears any wall in that cell.
+    bool placeObject(int gx, int gz, const std::string& type) {
+        const EditorCell c{gx, gz};
+        auto it = m_state.objects.find(c);
+        if (it != m_state.objects.end() && it->second == type && !m_state.walls.count(c))
+            return false;
+        pushUndo();
+        m_state.objects[c] = type;
+        m_state.walls.erase(c);
+        return true;
+    }
+
+    bool eraseObject(int gx, int gz) {
+        const EditorCell c{gx, gz};
+        if (!m_state.objects.count(c)) return false;
+        pushUndo();
+        m_state.objects.erase(c);
+        return true;
+    }
+
+    void clear() {
+        if (m_state.walls.empty() && m_state.objects.empty()) return;
+        pushUndo();
+        m_state.walls.clear();
+        m_state.objects.clear();
+    }
+
+    // --- Undo / redo ----------------------------------------------------------
+
+    bool canUndo() const { return !m_undo.empty(); }
+    bool canRedo() const { return !m_redo.empty(); }
+
+    bool undo() {
+        if (m_undo.empty()) return false;
+        m_redo.push_back(m_state);
+        m_state = m_undo.back();
+        m_undo.pop_back();
+        return true;
+    }
+
+    bool redo() {
+        if (m_redo.empty()) return false;
+        m_undo.push_back(m_state);
+        m_state = m_redo.back();
+        m_redo.pop_back();
+        return true;
+    }
+
+    // --- Baking / evaluation --------------------------------------------------
+
+    /// World center of a grid cell.
+    ecs::Vec3 cellCenter(int gx, int gz) const {
+        return ecs::Vec3{gx * m_state.cellWorld, 0.0f, gz * m_state.cellWorld};
+    }
+
+    /// Bake the current model into a playable DungeonGame: wall cells become full-cell
+    /// boxes, object cells become spawns of their type at the cell center.
+    SceneDescription scene() const {
+        SceneDescription out;
+        const float s = m_state.cellWorld;
+        for (const EditorCell& w : m_state.walls) {
+            world::Box b;
+            b.center = ecs::Vec3{w.first * s, kWallHeight * 0.5f, w.second * s};
+            b.size = ecs::Vec3{s, kWallHeight, s};
+            b.yaw = 0.0f;
+            out.wallBoxes.push_back(b);
+        }
+        for (const auto& kv : m_state.objects)
+            out.spawns.push_back(EntitySpawn{kv.second, cellCenter(kv.first.first, kv.first.second), 0.0f});
+        return out;
+    }
+
+    DungeonGame game() const { return loadGame(scene()); }
+
+    /// Live fairness: run the solver on the current model.
+    SolveResult fairness(const SolveOptions& opt = {}) const { return solve(game(), opt); }
+
+    // --- Serialization (stable, sorted, round-trippable) ----------------------
+
+    std::string serialize() const {
+        std::ostringstream out;
+        out << "leveleditor 1\n";
+        out << "cell " << trimFloat(m_state.cellWorld) << "\n";
+        for (const EditorCell& w : m_state.walls) // std::set -> sorted order
+            out << "wall " << w.first << " " << w.second << "\n";
+        for (const auto& kv : m_state.objects) // std::map -> sorted order
+            out << "obj " << kv.first.first << " " << kv.first.second << " " << kv.second << "\n";
+        return out.str();
+    }
+
+    /// Replace the model with one parsed from @p text. Undo/redo history is preserved,
+    /// with the pre-load state pushed so the load itself is undoable.
+    bool load(const std::string& text) {
+        EditorState parsed;
+        parsed.walls.clear();
+        parsed.objects.clear();
+        std::istringstream in(text);
+        std::string tok;
+        while (in >> tok) {
+            if (tok == "leveleditor") {
+                std::string v;
+                in >> v;
+            } else if (tok == "cell") {
+                in >> parsed.cellWorld;
+            } else if (tok == "wall") {
+                int x = 0, z = 0;
+                in >> x >> z;
+                parsed.walls.insert({x, z});
+            } else if (tok == "obj") {
+                int x = 0, z = 0;
+                std::string type;
+                in >> x >> z >> type;
+                if (!type.empty()) parsed.objects[{x, z}] = type;
+            }
+        }
+        pushUndo();
+        m_state = parsed;
+        return true;
+    }
+
+    /// Build a fresh editor from serialized text (no history).
+    static LevelEditor deserialize(const std::string& text) {
+        LevelEditor ed;
+        ed.load(text);
+        ed.m_undo.clear();
+        ed.m_redo.clear();
+        return ed;
+    }
+
+private:
+    static constexpr float kWallHeight = 3.0f;
+
+    void pushUndo() {
+        m_undo.push_back(m_state);
+        m_redo.clear();
+    }
+
+    /// Compact float text ("2" not "2.000000") that still parses back exactly for the
+    /// simple cell sizes an editor uses.
+    static std::string trimFloat(float v) {
+        std::ostringstream ss;
+        ss << v;
+        return ss.str();
+    }
+
+    EditorState m_state;
+    std::vector<EditorState> m_undo;
+    std::vector<EditorState> m_redo;
+};
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_level_editor.cpp
+++ b/tests/test_level_editor.cpp
@@ -1,0 +1,156 @@
+// In-engine level editor - issue #363 (headless command layer).
+//
+// Verifies the editor's core promises: editing commands mutate a grid model; the solver
+// runs live on the baked game so an author watches "unsolvable" flip to "solvable" the
+// instant they carve an opening; snapshot undo/redo restores exact prior state and skips
+// no-op edits; and a level round-trips through serialize()/deserialize() as stable text.
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_level_editor.cpp -o test_level_editor
+//
+// (Depends on the header-only game/solver cores; no engine link.)
+
+#include "game/LevelEditor.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+// Wall in every cell of the 8-neighbourhood around (cx, cz) - a full ring that seals the
+// centre cell against a 4-connected flood (no orthogonal or diagonal leak).
+static void ringAround(LevelEditor& ed, int cx, int cz) {
+    for (int dx = -1; dx <= 1; ++dx)
+        for (int dz = -1; dz <= 1; ++dz)
+            if (dx != 0 || dz != 0) ed.placeWall(cx + dx, cz + dz);
+}
+
+int main() {
+    // 1. Live fairness flips unsolvable -> solvable when an opening is carved.
+    {
+        LevelEditor ed;
+        ed.placeObject(0, 0, "player");
+        ed.placeObject(2, 0, "coin");
+        ed.placeObject(5, 0, "exit");
+        ringAround(ed, 5, 0); // fully wall in the exit
+
+        const SolveResult before = ed.fairness();
+        CHECK(!before.solvable);         // exit is walled off
+        CHECK(!before.exitReachable);
+
+        // Carve the wall between the exit and the corridor: erase the left neighbour.
+        const bool changed = ed.eraseWall(4, 0);
+        CHECK(changed);
+
+        const SolveResult after = ed.fairness();
+        CHECK(after.solvable);           // now the exit (and the coin) are reachable
+        CHECK(after.exitReachable);
+        CHECK(after.totalCoins == 1 && after.reachableCoins == 1);
+    }
+
+    // 2. A no-op edit records no history; a real edit does.
+    {
+        LevelEditor ed;
+        CHECK(!ed.canUndo());
+        CHECK(ed.placeWall(1, 1));       // real edit
+        CHECK(ed.canUndo());
+        CHECK(!ed.placeWall(1, 1));      // duplicate: no change
+        // Undo once returns to empty (the duplicate did not push a snapshot).
+        CHECK(ed.undo());
+        CHECK(ed.state().walls.empty());
+        CHECK(!ed.canUndo());
+    }
+
+    // 3. Undo/redo restore exact state across a sequence of edits.
+    {
+        LevelEditor ed;
+        ed.placeObject(0, 0, "player");
+        ed.placeObject(1, 0, "coin");
+        const std::string checkpoint = ed.serialize();
+
+        ed.placeObject(3, 0, "exit");
+        ed.placeWall(2, 0);
+        const std::string later = ed.serialize();
+        CHECK(checkpoint != later);
+
+        // Two undos peel off the exit and the wall, back to the checkpoint.
+        CHECK(ed.undo());
+        CHECK(ed.undo());
+        CHECK(ed.serialize() == checkpoint);
+
+        // Redo walks forward to the later state.
+        CHECK(ed.redo());
+        CHECK(ed.redo());
+        CHECK(ed.serialize() == later);
+        CHECK(!ed.canRedo());
+
+        // A fresh edit after undo drops the redo branch.
+        CHECK(ed.undo());
+        CHECK(ed.canRedo());
+        ed.placeObject(9, 9, "coin");
+        CHECK(!ed.canRedo());
+    }
+
+    // 4. Retyping / overwriting: an object cell and a wall cell are mutually exclusive.
+    {
+        LevelEditor ed;
+        ed.placeObject(4, 4, "coin");
+        CHECK(ed.placeWall(4, 4));                        // wall replaces the object
+        CHECK(ed.state().walls.count({4, 4}) == 1);
+        CHECK(ed.state().objects.count({4, 4}) == 0);
+        CHECK(ed.placeObject(4, 4, "enemy"));             // object replaces the wall
+        CHECK(ed.state().walls.count({4, 4}) == 0);
+        CHECK(ed.state().objects.at({4, 4}) == "enemy");
+    }
+
+    // 5. serialize()/deserialize() round-trips to identical text and identical fairness.
+    {
+        LevelEditor ed;
+        ed.placeObject(0, 0, "player");
+        ed.placeObject(1, 0, "coin");
+        ed.placeObject(2, 0, "key@1");
+        ed.placeObject(6, 0, "exit");
+        ed.placeWall(3, 0);
+        ed.placeWall(3, 1);
+        ed.placeWall(3, -1);
+
+        const std::string text = ed.serialize();
+        LevelEditor round = LevelEditor::deserialize(text);
+        CHECK(round.serialize() == text);
+        CHECK(round.state() == ed.state());
+        CHECK(!round.canUndo()); // deserialize starts with no history
+
+        const SolveResult a = ed.fairness();
+        const SolveResult b = round.fairness();
+        CHECK(a.solvable == b.solvable);
+        CHECK(a.exitReachable == b.exitReachable);
+        CHECK(a.totalCoins == b.totalCoins);
+    }
+
+    // 6. Baking maps cells to world centers at the configured cell size.
+    {
+        LevelEditor ed;
+        ed.setCellWorld(2.0f);
+        ed.placeObject(3, -2, "player");
+        const DungeonGame g = ed.game();
+        CHECK(g.playerPosition.x == 6.0f);   // 3 * 2.0
+        CHECK(g.playerPosition.z == -4.0f);  // -2 * 2.0
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_level_editor: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_level_editor: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #363. Adds an in-engine level **editor** as a headless command layer, and closes the loop the other way from the drawing-to-game pipeline: the editable grid model bakes back into a playable `DungeonGame` and the Solver runs on it live, so authoring feedback is immediate.

`src/game/LevelEditor.h` (header-only, std only + the header-only game/solver cores):

- **`EditorState`** - the editable model: a set of wall cells and a map of object-spawn cells keyed by grid coordinate, with a configurable world cell size. This is the unit a snapshot captures.
- **Editing commands** - `placeWall`/`eraseWall`/`placeObject`/`eraseObject`/`clear`, each returning whether it actually changed the model. A no-op edit (placing a wall that is already there) records no history. A wall cell and an object cell are mutually exclusive - placing one clears the other.
- **Snapshot undo/redo** - a real edit pushes the pre-change state onto the undo stack and clears the redo branch, so `undo`/`redo` never step over phantom edits.
- **Baking + live fairness** - `scene()`/`game()` turn wall cells into full-cell boxes and object cells into spawns at cell centers; `fairness()` runs `solve()` on the baked game, so an author watches "unsolvable" flip to "solvable" the instant they carve an opening.
- **Serialization** - `serialize()`/`deserialize()` round-trip through stable, sorted text (a `std::set`/`std::map` model serializes deterministically).

## Testing

`tests/test_level_editor.cpp` (registered in the headless suite) covers:

- the live unsolvable -> solvable flip when a wall between the exit and the corridor is erased;
- no-op edits recording no undo history;
- undo/redo restoring exact state, including dropping the redo branch on a fresh edit;
- wall/object cell exclusivity (each overwrites the other);
- `serialize()`/`deserialize()` round-tripping to identical text, state, and fairness;
- cell-to-world baking at the configured cell size.

Passes standalone (`g++ -std=c++17 -I src`), via CMake/ctest, and clean under `-fsanitize=address,undefined`.

The macOS build job is expected to fail (pre-existing, tracked in #338) and is `continue-on-error`; all other gates should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_