### PR TITLE
World: richer OSM import into CityGame (#365)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,6 +712,11 @@ add_executable(test_city_game
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_city_game.cpp
 )
 
+# Richer OSM import: region kinds, POIs, barriers -> hazards/walls/coins (#365) - header-only.
+add_executable(test_city_osm_rich
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_city_osm_rich.cpp
+)
+
 # Deterministic solvability validator + auto-solver over DungeonGame rules (#316) - header-only.
 add_executable(test_solver
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_solver.cpp
@@ -1198,6 +1203,7 @@ set(HEADLESS_TESTS
     test_benchmark
     test_campaign
     test_city_game
+    test_city_osm_rich
     test_coop_shared_world
     test_crowd
     test_cv_robust

--- a/src/game/CityGame.h
+++ b/src/game/CityGame.h
@@ -20,6 +20,11 @@
  *     first road, coins are dropped on the road graph (intersections, else road
  *     midpoints), and the exit is the road endpoint farthest from the spawn.
  *
+ * Richer OSM semantics (#365) layer on top and are inert when absent, so a plain
+ * building+road import is unchanged: barrier ways (walls/fences) become thin wall
+ * obstacles, water regions are tiled with hazards so stepping into water is a loss, and
+ * map POIs (amenities/shops/...) become the preferred coin placements (real destinations).
+ *
  * So the output is a SceneDescription (wallBoxes + EntitySpawns) fed straight into
  * loadGame(), i.e. the same playable contract as a hand-drawn Doodlebound level.
  * Header-only, dependency-free (std + the header-only importer / game types), so it
@@ -32,6 +37,13 @@ struct CityGameOptions {
     float wallHeight{3.0f};        ///< building obstacle height (collision is XZ-only, but kept sensible).
     bool coinsAtIntersections{true}; ///< drop coins at road intersections; else at road midpoints.
     bool coinsAtRoadMidpoints{true}; ///< fallback when there are no intersections.
+
+    // Richer OSM semantics (#365). All default on, but inert on a City with no water /
+    // barriers / POIs, so a plain building+road import plays exactly as before.
+    bool coinsAtPois{true};      ///< when the map has POIs, seed coins there (preferred source).
+    bool waterAsHazard{true};    ///< tile hazards across water regions so water is deadly.
+    float hazardSpacing{3.0f};   ///< grid step (world units) for tiling water hazards.
+    bool barriersAsWalls{true};  ///< emit thin wall boxes along barrier (wall/fence) ways.
 };
 
 namespace detail {
@@ -40,6 +52,37 @@ namespace detail {
 inline float distSqXZ(const ecs::Vec3& a, const ecs::Vec3& b) {
     const float dx = a.x - b.x, dz = a.z - b.z;
     return dx * dx + dz * dz;
+}
+
+/// Ray-cast point-in-polygon test on the XZ footprint (ring need not be closed).
+inline bool pointInPolygonXZ(const std::vector<ecs::Vec3>& ring, float x, float z) {
+    bool inside = false;
+    const std::size_t n = ring.size();
+    for (std::size_t i = 0, j = n - 1; i < n; j = i++) {
+        const float xi = ring[i].x, zi = ring[i].z;
+        const float xj = ring[j].x, zj = ring[j].z;
+        if (((zi > z) != (zj > z)) &&
+            (x < (xj - xi) * (z - zi) / ((zj - zi) != 0.0f ? (zj - zi) : 1e-6f) + xi))
+            inside = !inside;
+    }
+    return inside;
+}
+
+/// Append a thin wall box for each segment of a barrier polyline (#365).
+inline void emitBarrierWalls(const std::vector<ecs::Vec3>& line, float width, float wallHeight,
+                             std::vector<world::Box>& out) {
+    for (std::size_t i = 0; i + 1 < line.size(); ++i) {
+        const ecs::Vec3& a = line[i];
+        const ecs::Vec3& b = line[i + 1];
+        const float dx = b.x - a.x, dz = b.z - a.z;
+        const float length = std::sqrt(dx * dx + dz * dz);
+        if (length <= 0.0f) continue;
+        world::Box box;
+        box.center = ecs::Vec3{(a.x + b.x) * 0.5f, wallHeight * 0.5f, (a.z + b.z) * 0.5f};
+        box.size = ecs::Vec3{length, wallHeight, width};
+        box.yaw = std::atan2(dz, dx);
+        out.push_back(box);
+    }
 }
 
 } // namespace detail
@@ -61,6 +104,12 @@ inline SceneDescription cityToScene(const world::City& city, const CityGameOptio
         box.size = ecs::Vec3{b.size.x, wallHeight, b.size.z};
         box.yaw = 0.0f;
         scene.wallBoxes.push_back(box);
+    }
+
+    // Barrier ways (walls/fences) become thin wall obstacles (#365).
+    if (opt.barriersAsWalls) {
+        for (const world::Barrier& bar : city.barriers)
+            detail::emitBarrierWalls(bar.line, bar.width, wallHeight, scene.wallBoxes);
     }
 
     // Gather every road endpoint (walkable). The first is the player spawn.
@@ -95,8 +144,13 @@ inline SceneDescription cityToScene(const world::City& city, const CityGameOptio
         if (best > 0.0f) scene.spawns.push_back(EntitySpawn{"exit", exit, 0.0f});
     }
 
-    // Coins on the road graph: intersections if present, else road midpoints.
-    if (opt.coinsAtIntersections && !city.intersections.empty()) {
+    // Coins: prefer map POIs (real places) when present, else the road graph
+    // (intersections if any, else road midpoints).
+    if (opt.coinsAtPois && !city.pois.empty()) {
+        for (const world::Poi& poi : city.pois) {
+            scene.spawns.push_back(EntitySpawn{"coin", ecs::Vec3{poi.position.x, 0.0f, poi.position.z}, 0.0f});
+        }
+    } else if (opt.coinsAtIntersections && !city.intersections.empty()) {
         for (const ecs::Vec3& node : city.intersections) {
             scene.spawns.push_back(EntitySpawn{"coin", node, 0.0f});
         }
@@ -107,6 +161,22 @@ inline SceneDescription cityToScene(const world::City& city, const CityGameOptio
             const ecs::Vec3& b = road.centerline.back();
             scene.spawns.push_back(
                 EntitySpawn{"coin", ecs::Vec3{(a.x + b.x) * 0.5f, 0.0f, (a.z + b.z) * 0.5f}, 0.0f});
+        }
+    }
+
+    // Water regions become deadly: tile hazards across each water footprint on a grid,
+    // keeping only points actually inside the polygon (#365).
+    if (opt.waterAsHazard && opt.hazardSpacing > 0.0f) {
+        for (const world::Region& r : city.regions) {
+            if (r.kind != world::RegionKind::Water) continue;
+            const float minX = r.center.x - r.size.x * 0.5f, maxX = r.center.x + r.size.x * 0.5f;
+            const float minZ = r.center.z - r.size.z * 0.5f, maxZ = r.center.z + r.size.z * 0.5f;
+            for (float z = minZ; z <= maxZ; z += opt.hazardSpacing) {
+                for (float x = minX; x <= maxX; x += opt.hazardSpacing) {
+                    if (detail::pointInPolygonXZ(r.footprint, x, z))
+                        scene.spawns.push_back(EntitySpawn{"hazard", ecs::Vec3{x, 0.0f, z}, 0.0f});
+                }
+            }
         }
     }
 

--- a/src/world/GeoJsonImporter.h
+++ b/src/world/GeoJsonImporter.h
@@ -47,18 +47,42 @@ struct Building {
 struct Road {
     std::vector<ecs::Vec3> centerline; // projected + smoothed, y = 0
     float width{0.0f};
+    std::string kind;                  // highway class (motorway/residential/footway/...)
 };
 
-struct Region { // water / park, as a flat slab
+/// What a Region represents, so downstream can treat water as dangerous, parks as walkable
+/// green space, etc. (issue #365).
+enum class RegionKind { Generic, Water, Park, Grass };
+
+struct Region { // water / park / grass, as a flat slab
     std::vector<ecs::Vec3> footprint;
     ecs::Vec3 center{};
     ecs::Vec3 size{};
+    RegionKind kind{RegionKind::Generic};
+};
+
+/// A point-of-interest node imported from a Point feature (amenity/shop/tourism/...) - a
+/// map-faithful place to seed an objective (issue #365).
+struct Poi {
+    ecs::Vec3 position{};
+    std::string category; // the tag value (e.g. "restaurant", "fountain"), or "poi"
+    std::string name;
+};
+
+/// A barrier way (wall/fence/hedge) imported from a tagged LineString - a thin obstacle the
+/// player collides with (issue #365).
+struct Barrier {
+    std::vector<ecs::Vec3> line; // projected + smoothed, y = 0
+    float width{0.5f};
+    std::string kind;            // wall/fence/hedge/...
 };
 
 struct City {
     std::vector<Building> buildings;
     std::vector<Road> roads;
     std::vector<Region> regions;
+    std::vector<Poi> pois;        // point features (#365)
+    std::vector<Barrier> barriers; // barrier ways (#365)
     std::vector<ecs::Vec3> intersections; // nodes shared by >= 2 roads
 };
 
@@ -69,6 +93,8 @@ struct GeoImportOptions {
     float roadThickness{0.05f};
     float regionThickness{0.02f};
     int roadSmoothingIterations{1};
+    float barrierWidth{0.5f};          // default barrier thickness when the kind is unknown (#365)
+    int barrierSmoothingIterations{0}; // barriers are usually straight; no smoothing by default
 };
 
 namespace detail {
@@ -263,6 +289,27 @@ inline float roadWidthFor(const std::string& highway) {
     return 5.0f;
 }
 
+/// Classify a polygon region from its natural / leisure / landuse tags (#365).
+inline RegionKind regionKindFor(const std::string& natural, const std::string& leisure,
+                                const std::string& landuse) {
+    if (natural == "water" || natural == "wetland" || landuse == "reservoir" ||
+        landuse == "basin")
+        return RegionKind::Water;
+    if (leisure == "park" || leisure == "garden") return RegionKind::Park;
+    if (landuse == "grass" || landuse == "meadow" || natural == "grassland" ||
+        leisure == "pitch")
+        return RegionKind::Grass;
+    return RegionKind::Generic;
+}
+
+/// Thickness of a barrier way from its kind (#365).
+inline float barrierWidthFor(const std::string& barrier, float fallback) {
+    if (barrier == "wall" || barrier == "city_wall" || barrier == "retaining_wall") return 0.5f;
+    if (barrier == "fence" || barrier == "guard_rail") return 0.3f;
+    if (barrier == "hedge") return 0.6f;
+    return fallback;
+}
+
 inline std::vector<ecs::Vec3> chaikin(const std::vector<ecs::Vec3>& pts, int iterations) {
     std::vector<ecs::Vec3> cur = pts;
     for (int it = 0; it < iterations && cur.size() >= 3; ++it) {
@@ -350,8 +397,9 @@ inline City importString(const std::string& geojson, const GeoImportOptions& opt
                                 (props.has("height") && gtype == "Polygon");
         const std::string natural = props.at("natural").asStr();
         const std::string leisure = props.at("leisure").asStr();
-        const bool isRegion = (natural == "water") || (leisure == "park") ||
-                              props.at("landuse").asStr() == "grass";
+        const std::string landuse = props.at("landuse").asStr();
+        const RegionKind regionKind = detail::regionKindFor(natural, leisure, landuse);
+        const bool isRegion = regionKind != RegionKind::Generic;
 
         if (gtype == "Polygon" && isBuilding) {
             std::vector<ecs::Vec3> ring = projectRing(coords[0]);
@@ -376,6 +424,7 @@ inline City importString(const std::string& geojson, const GeoImportOptions& opt
             if (ring.size() < 3) continue;
             Region r;
             r.footprint = ring;
+            r.kind = regionKind;
             bounds(ring, r.center, r.size);
             r.center.y = -options.regionThickness * 0.5f;
             r.size.y = options.regionThickness;
@@ -384,7 +433,8 @@ inline City importString(const std::string& geojson, const GeoImportOptions& opt
             std::vector<ecs::Vec3> line = projectRing(coords);
             if (line.size() < 2) continue;
             Road road;
-            road.width = detail::roadWidthFor(props.at("highway").asStr());
+            road.kind = props.at("highway").asStr();
+            road.width = detail::roadWidthFor(road.kind);
             road.centerline = detail::chaikin(line, options.roadSmoothingIterations);
             // Record endpoints for intersection detection (use pre-smoothing ends).
             for (const ecs::Vec3& end : {line.front(), line.back()}) {
@@ -394,6 +444,27 @@ inline City importString(const std::string& geojson, const GeoImportOptions& opt
                 use.second = end;
             }
             city.roads.push_back(std::move(road));
+        } else if (gtype == "LineString" && props.has("barrier")) {
+            std::vector<ecs::Vec3> line = projectRing(coords);
+            if (line.size() < 2) continue;
+            Barrier bar;
+            bar.kind = props.at("barrier").asStr();
+            bar.width = detail::barrierWidthFor(bar.kind, options.barrierWidth);
+            bar.line = detail::chaikin(line, options.barrierSmoothingIterations);
+            city.barriers.push_back(std::move(bar));
+        } else if (gtype == "Point" && coords.size() >= 2) {
+            Poi poi;
+            poi.position = project(coords);
+            for (const char* tag : {"amenity", "shop", "tourism", "leisure", "natural",
+                                    "historic", "man_made"}) {
+                if (props.has(tag)) {
+                    poi.category = props.at(tag).asStr();
+                    break;
+                }
+            }
+            if (poi.category.empty()) poi.category = "poi";
+            poi.name = props.at("name").asStr();
+            city.pois.push_back(std::move(poi));
         }
     }
 

--- a/tests/test_city_osm_rich.cpp
+++ b/tests/test_city_osm_rich.cpp
@@ -1,0 +1,156 @@
+// Richer OSM import into CityGame - issue #365.
+//
+// The GeoJSON importer now classifies regions (water/park/grass), imports Point POIs, and
+// imports barrier ways; CityGame turns that richer data into gameplay: barrier ways become
+// thin wall obstacles, water regions are tiled with hazards so stepping into water is a
+// loss, and map POIs become the preferred coin placements. Verifies parsing, the scene
+// conversion, and the resulting playable behavior. Pure std + the header-only importer /
+// game:
+//   g++ -std=c++17 -I src tests/test_city_osm_rich.cpp -o test_city_osm_rich
+
+#include "game/CityGame.h"
+#include "world/GeoJsonImporter.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static bool approx(float a, float b, float eps = 0.1f) { return std::fabs(a - b) <= eps; }
+
+// Origin = first coordinate (0,0), lat0=0 so 1 deg = 111320 m (square). Layout (meters):
+//   road:    (0,0) -> (89.056,0)                 along +X at z=0 (spawn at 0, exit at 89)
+//   water:   x[11.132,33.396]  z[22.264,44.528]  natural=water (north of the road)
+//   park:    x[55.660,77.924]  z[22.264,44.528]  leisure=park
+//   barrier: x=66.792  z[-11.132,11.132]         barrier=fence crossing the road
+//   pois:    cafe @ (22.264,0), fountain @ (44.528,0)  (on the road, before the barrier)
+static const char* kGeoJson = R"JSON({
+  "type": "FeatureCollection",
+  "features": [
+    { "type":"Feature", "properties":{"highway":"residential"},
+      "geometry":{"type":"LineString","coordinates":[[0,0],[0.0008,0]]} },
+    { "type":"Feature", "properties":{"natural":"water"},
+      "geometry":{"type":"Polygon","coordinates":[[[0.0001,0.0002],[0.0003,0.0002],[0.0003,0.0004],[0.0001,0.0004],[0.0001,0.0002]]]} },
+    { "type":"Feature", "properties":{"leisure":"park"},
+      "geometry":{"type":"Polygon","coordinates":[[[0.0005,0.0002],[0.0007,0.0002],[0.0007,0.0004],[0.0005,0.0004],[0.0005,0.0002]]]} },
+    { "type":"Feature", "properties":{"barrier":"fence"},
+      "geometry":{"type":"LineString","coordinates":[[0.0006,-0.0001],[0.0006,0.0001]]} },
+    { "type":"Feature", "properties":{"amenity":"cafe","name":"Corner Cafe"},
+      "geometry":{"type":"Point","coordinates":[0.0002,0]} },
+    { "type":"Feature", "properties":{"amenity":"fountain"},
+      "geometry":{"type":"Point","coordinates":[0.0004,0]} }
+  ]
+})JSON";
+
+static int countType(const game::SceneDescription& s, const char* t) {
+    int n = 0;
+    for (const auto& sp : s.spawns) if (sp.type == t) ++n;
+    return n;
+}
+
+int main() {
+    const world::City city = world::importString(kGeoJson, world::GeoImportOptions{});
+
+    // 1. Regions are classified; POIs and barriers are imported as new geometry.
+    CHECK(city.roads.size() == 1);
+    CHECK(city.buildings.empty());
+    CHECK(city.regions.size() == 2);
+    CHECK(city.regions[0].kind == world::RegionKind::Water);
+    CHECK(city.regions[1].kind == world::RegionKind::Park);
+    CHECK(city.pois.size() == 2);
+    CHECK(city.pois[0].category == "cafe" && city.pois[0].name == "Corner Cafe");
+    CHECK(city.pois[1].category == "fountain");
+    CHECK(city.barriers.size() == 1);
+    CHECK(city.barriers[0].kind == "fence");
+    CHECK(city.barriers[0].line.size() == 2);
+
+    const game::SceneDescription scene = game::cityToScene(city);
+
+    // 2. POIs are the preferred coin source (two POIs -> two coins, at the POI positions).
+    CHECK(countType(scene, "coin") == 2);
+    CHECK(countType(scene, "player") == 1 && countType(scene, "exit") == 1);
+    // Find the coins and confirm they sit on the POIs.
+    bool cafeCoin = false, fountainCoin = false;
+    for (const auto& sp : scene.spawns) {
+        if (sp.type != "coin") continue;
+        if (approx(sp.position.x, 22.264f) && approx(sp.position.z, 0.0f)) cafeCoin = true;
+        if (approx(sp.position.x, 44.528f) && approx(sp.position.z, 0.0f)) fountainCoin = true;
+    }
+    CHECK(cafeCoin && fountainCoin);
+
+    // 3. The barrier became exactly one thin wall box (no buildings in this map).
+    CHECK(scene.wallBoxes.size() == 1);
+
+    // 4. Water is tiled with hazards; every hazard lies within the water footprint (x < 40,
+    //    z in ~[22,45]) and none appear in the park's x-range (>= 55).
+    const int hazards = countType(scene, "hazard");
+    CHECK(hazards > 0);
+    ecs::Vec3 aHazard{};
+    for (const auto& sp : scene.spawns) {
+        if (sp.type != "hazard") continue;
+        aHazard = sp.position;
+        CHECK(sp.position.x >= 11.0f && sp.position.x <= 34.0f);
+        CHECK(sp.position.z >= 22.0f && sp.position.z <= 45.0f);
+    }
+
+    // 5. The imported map is playable: spawn is clear, the barrier is solid, off to the side
+    //    it is not.
+    game::DungeonGame gm = game::loadCityGame(city);
+    CHECK(gm.totalCoins == 2);
+    CHECK(gm.hasExit);
+    CHECK(!gm.hitsWall(gm.playerPosition, gm.playerRadius)); // spawns on the road
+    CHECK(gm.hitsWall(ecs::Vec3{66.792f, 0.0f, 0.0f}, 0.4f)); // barrier crosses the road
+    CHECK(!gm.hitsWall(ecs::Vec3{66.792f, 0.0f, 20.0f}, 0.4f)); // ...but only where it spans
+
+    // 6. Stepping into water is a loss; standing on the road is not.
+    {
+        game::DungeonGame water = game::loadCityGame(city);
+        water.playerPosition = aHazard; // stand in the water
+        water.update(game::GameInput{0.0f, 0.0f}, 1.0f / 60.0f);
+        CHECK(water.lost());
+    }
+    {
+        game::DungeonGame safe = game::loadCityGame(city);
+        safe.update(game::GameInput{0.0f, 0.0f}, 1.0f / 60.0f);
+        CHECK(!safe.lost());
+    }
+
+    // 7. Driving east collects both POI coins, then the fence blocks further progress.
+    {
+        game::DungeonGame drive = game::loadCityGame(city);
+        const float dt = 1.0f / 60.0f;
+        for (int i = 0; i < 6000 && drive.status == game::GameStatus::Playing; ++i)
+            drive.update(game::GameInput{1.0f, 0.0f}, dt);
+        CHECK(drive.coinsCollected == 2);       // both roadside POIs grabbed
+        CHECK(drive.playerPosition.x < 67.0f);  // stopped at the fence
+        CHECK(drive.playerPosition.x > 60.0f);  // ...having reached it
+        CHECK(!drive.won());                    // exit is beyond the fence
+    }
+
+    // 8. Determinism: converting the same city twice yields identical spawns.
+    const game::SceneDescription scene2 = game::cityToScene(city);
+    bool identical = scene.spawns.size() == scene2.spawns.size();
+    for (std::size_t i = 0; i < scene.spawns.size() && identical; ++i)
+        identical = scene.spawns[i].type == scene2.spawns[i].type &&
+                    scene.spawns[i].position.x == scene2.spawns[i].position.x &&
+                    scene.spawns[i].position.z == scene2.spawns[i].position.z;
+    CHECK(identical);
+
+    if (g_failures == 0) {
+        std::printf("test_city_osm_rich: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_city_osm_rich: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #365. Extends the GeoJSON/OSM importer (#150) and the City-to-game bridge (#313) to carry and use more map semantics, so an imported extract plays as a richer level rather than just buildings + roads.

### Importer (`world/GeoJsonImporter.h`)

- **Region kinds** - polygon regions are classified `Water` / `Park` / `Grass` / `Generic` from `natural` / `leisure` / `landuse` tags (`Region.kind`), so downstream can treat water differently from green space.
- **POIs** - `Point` features (`amenity` / `shop` / `tourism` / `leisure` / ...) import as a category + name at a projected position (`City.pois`). Point geometry was previously ignored entirely.
- **Barriers** - barrier ways (`wall` / `fence` / `hedge`) import as thin obstacle polylines with a kind-derived width (`City.barriers`).
- **Road class** - roads now carry their `highway` class (`Road.kind`).

All additions are backward compatible: existing building/road/region parsing and `emitToRegistry` are unchanged, and the new fields default empty.

### CityGame (`game/CityGame.h`)

- **Barriers become walls** - a thin wall box per barrier segment (collidable).
- **Water becomes deadly** - each water region is tiled with hazards on a grid, keeping only points inside the footprint (ray-cast point-in-polygon), so stepping into water is a loss.
- **POIs become coins** - map POIs are the preferred coin placements (real destinations), falling back to intersections then road midpoints.

The new behavior is **inert on a City with no water / barriers / POIs**, so a plain building+road import plays exactly as before.

## Testing

- New `tests/test_city_osm_rich.cpp` (registered in the headless suite): region classification, POI/barrier parsing, scene conversion (POI coins, one barrier wall, water hazards confined to the water footprint and absent from the park), and playable behavior - the barrier blocks forward progress, stepping into water loses, standing on the road does not, and driving the road collects both POI coins before the fence.
- Backward compatibility verified: the existing `test_city_game` and `test_geojson_importer` are unchanged and still pass.
- Passes standalone (`g++ -std=c++17 -I src`), via CMake/ctest, and clean under `-fsanitize=address,undefined`.

The macOS build job is expected to fail (pre-existing, tracked in #338) and is `continue-on-error`; all other gates should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_