### PR TITLE
Platform: input remapping, gamepad, and DPI-aware UI scaling (#368)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1054,6 +1054,11 @@ add_executable(test_input_map
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_input_map.cpp
 )
 
+# Platform input: rebind -> GameInput, gamepad, DPI/safe-area UI scaling (#368) - header-only.
+add_executable(test_input_mapping
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_input_mapping.cpp
+)
+
 # DPI / resolution UI scaling core (Milestone 9 / #61) - header-only.
 add_executable(test_ui_scaling
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_ui_scaling.cpp
@@ -1239,6 +1244,7 @@ set(HEADLESS_TESTS
     test_hud_framework
     test_ibl_brdf
     test_input_map
+    test_input_mapping
     test_leaderboard
     test_level_autorepair
     test_level_catalog

--- a/src/game/PlatformInput.h
+++ b/src/game/PlatformInput.h
@@ -1,0 +1,223 @@
+#pragma once
+
+#include "core/InputMap.h"      // InputMap, InputMapBinding, InputDevice
+#include "core/Settings.h"      // Settings (persistence path, #61)
+#include "game/DungeonGame.h"   // game::GameInput
+#include "ui/HudFramework.h"    // HudAnchor, HudVec2, resolveAnchor
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+/**
+ * @file PlatformInput.h
+ * @brief Rebindable controls, gamepad support, and DPI-aware UI scaling (issue #368).
+ *
+ * Ship-on-many-devices plumbing, modelled as headless-testable logic separated from the
+ * device glue (GLFW/ImGui): raw input -> action -> normalized game::GameInput, and
+ * resolution/DPI -> HUD layout. It builds on the rebindable InputMap (#60) and persists
+ * through the Settings surface (#61), and lays HUD elements out with the HUD framework's
+ * anchor math so they scale and respect a safe area across resolutions and aspect ratios.
+ *
+ *   - Movement actions (WASD by default) resolve held keys to a GameInput; rebinding an
+ *     action changes the produced input immediately.
+ *   - A gamepad left stick resolves to a GameInput through a radial deadzone; a
+ *     GamepadManager reports connect/disconnect (hot-plug) transitions.
+ *   - computeUiMetrics()/layoutElement() give DPI-scaled, safe-area-aware pixel layout.
+ *
+ * Header-only, std only (plus the header-only InputMap / Settings / HUD / game types).
+ */
+namespace IKore {
+namespace platform {
+
+// --- Movement actions --------------------------------------------------------
+// Direction convention matches the game camera: up = forward = -Z, right = +X.
+
+constexpr const char* kMoveUp = "move_up";
+constexpr const char* kMoveDown = "move_down";
+constexpr const char* kMoveLeft = "move_left";
+constexpr const char* kMoveRight = "move_right";
+
+/// Register the default keyboard movement bindings (WASD) into @p map, if absent.
+inline void addDefaultMovementActions(InputMap& map) {
+    map.addAction(kMoveUp, InputMapBinding{InputDevice::Keyboard, 'W'});
+    map.addAction(kMoveLeft, InputMapBinding{InputDevice::Keyboard, 'A'});
+    map.addAction(kMoveDown, InputMapBinding{InputDevice::Keyboard, 'S'});
+    map.addAction(kMoveRight, InputMapBinding{InputDevice::Keyboard, 'D'});
+}
+
+/// The set of inputs currently held down this frame (device + code pairs).
+struct HeldInputs {
+    std::vector<InputMapBinding> held;
+
+    void press(InputMapBinding b) {
+        if (!isHeld(b)) held.push_back(b);
+    }
+    void release(InputMapBinding b) {
+        held.erase(std::remove(held.begin(), held.end(), b), held.end());
+    }
+    void clear() { held.clear(); }
+    bool isHeld(const InputMapBinding& b) const {
+        if (!b.bound()) return false;
+        for (const InputMapBinding& h : held)
+            if (h == b) return true;
+        return false;
+    }
+};
+
+/// Resolve the movement actions in @p map against the held inputs into a GameInput.
+/// Opposite directions cancel; a diagonal is the (un-normalized) sum, matching how the
+/// game normalizes its own input.
+inline game::GameInput resolveKeyboardMovement(const InputMap& map, const HeldInputs& held) {
+    game::GameInput in;
+    if (held.isHeld(map.binding(kMoveRight))) in.moveX += 1.0f;
+    if (held.isHeld(map.binding(kMoveLeft))) in.moveX -= 1.0f;
+    if (held.isHeld(map.binding(kMoveDown))) in.moveZ += 1.0f;
+    if (held.isHeld(map.binding(kMoveUp))) in.moveZ -= 1.0f;
+    return in;
+}
+
+// --- Gamepad -----------------------------------------------------------------
+
+/// A polled gamepad snapshot: connection, left-stick axes in [-1, 1] (stick up = -Y),
+/// and per-button pressed state indexed by button code.
+struct GamepadState {
+    bool connected{false};
+    float axisLX{0.0f};
+    float axisLY{0.0f};
+    std::vector<bool> buttons;
+
+    bool button(int code) const {
+        return code >= 0 && code < static_cast<int>(buttons.size()) && buttons[static_cast<std::size_t>(code)];
+    }
+};
+
+struct GamepadConfig {
+    float deadzone{0.2f}; ///< radial deadzone; magnitudes below this produce no movement.
+    bool invertY{false};
+};
+
+/// Left stick -> movement with a radial deadzone (rescaled so the deadzone edge is 0 and
+/// full deflection is 1). Stick up (Y = -1) drives forward (moveZ = -1).
+inline game::GameInput resolveGamepadMovement(const GamepadState& pad, const GamepadConfig& cfg = {}) {
+    game::GameInput in;
+    if (!pad.connected) return in;
+    const float x = pad.axisLX;
+    const float y = cfg.invertY ? -pad.axisLY : pad.axisLY;
+    const float mag = std::sqrt(x * x + y * y);
+    if (mag <= cfg.deadzone || mag <= 0.0f) return in;
+    const float rescaled = (mag - cfg.deadzone) / (1.0f - cfg.deadzone);
+    const float k = rescaled / mag; // normalize direction, apply rescaled magnitude
+    in.moveX = x * k;
+    in.moveZ = y * k;
+    return in;
+}
+
+/// Combined resolve: an active gamepad stick takes over, else the keyboard.
+inline game::GameInput resolveMovement(const InputMap& map, const HeldInputs& held,
+                                       const GamepadState& pad, const GamepadConfig& cfg = {}) {
+    const game::GameInput g = resolveGamepadMovement(pad, cfg);
+    if (g.moveX != 0.0f || g.moveZ != 0.0f) return g;
+    return resolveKeyboardMovement(map, held);
+}
+
+/// Tracks gamepad connection across polls to surface hot-plug transitions.
+class GamepadManager {
+public:
+    enum class Event { None, Connected, Disconnected };
+
+    /// Feed this frame's connection state; returns the transition since last call.
+    Event update(bool connectedNow) {
+        Event e = Event::None;
+        if (connectedNow && !m_connected)
+            e = Event::Connected;
+        else if (!connectedNow && m_connected)
+            e = Event::Disconnected;
+        m_connected = connectedNow;
+        return e;
+    }
+    bool connected() const { return m_connected; }
+
+private:
+    bool m_connected{false};
+};
+
+// --- DPI-aware UI / HUD scaling ---------------------------------------------
+
+/// Safe-area insets in pixels (notches, rounded corners, system bars).
+struct SafeAreaInsets {
+    float left{0.0f};
+    float top{0.0f};
+    float right{0.0f};
+    float bottom{0.0f};
+};
+
+struct UiScaleConfig {
+    float referenceDpi{96.0f}; ///< DPI at which scale == 1.0.
+    float minScale{0.5f};
+    float maxScale{4.0f};
+};
+
+/// Resolved UI layout metrics for a framebuffer: a DPI-derived scale, the full screen
+/// size, and the safe-area rect the HUD should stay inside.
+struct UiMetrics {
+    float scale{1.0f};
+    HudVec2 screen{};
+    SafeAreaInsets safe{};
+
+    HudVec2 safeOrigin() const { return {safe.left, safe.top}; }
+    HudVec2 safeSize() const {
+        return {std::max(0.0f, screen.x - safe.left - safe.right),
+                std::max(0.0f, screen.y - safe.top - safe.bottom)};
+    }
+    /// Scale a length authored in reference pixels to this display.
+    float scaled(float dip) const { return dip * scale; }
+};
+
+/// Compute UI metrics from a framebuffer size, DPI, and optional safe-area insets. The
+/// scale is DPI/referenceDpi clamped to [minScale, maxScale], so the HUD keeps a constant
+/// physical size across displays while layout uses the actual pixel dimensions.
+inline UiMetrics computeUiMetrics(float widthPx, float heightPx, float dpi, SafeAreaInsets safe = {},
+                                  const UiScaleConfig& cfg = {}) {
+    UiMetrics m;
+    m.screen = {widthPx, heightPx};
+    m.safe = safe;
+    const float ref = cfg.referenceDpi > 0.0f ? cfg.referenceDpi : 96.0f;
+    m.scale = std::max(cfg.minScale, std::min(cfg.maxScale, dpi / ref));
+    return m;
+}
+
+/// Top-left pixel position of a HUD element authored in reference pixels: its size and
+/// margin are DPI-scaled, then anchored within the safe rect (so it never lands under a
+/// notch), independent of resolution and aspect ratio.
+inline HudVec2 layoutElement(const UiMetrics& m, HudAnchor anchor, HudVec2 sizeDip, HudVec2 offsetDip) {
+    const HudVec2 size{sizeDip.x * m.scale, sizeDip.y * m.scale};
+    const HudVec2 offset{offsetDip.x * m.scale, offsetDip.y * m.scale};
+    HudVec2 p = resolveAnchor(anchor, m.safeSize(), size, offset);
+    p.x += m.safe.left;
+    p.y += m.safe.top;
+    return p;
+}
+
+// --- Settings persistence (#61) ---------------------------------------------
+
+/// Persist each action's binding as its own Settings key ("input.<action>"), so the blob
+/// stays single-line and round-trips through the settings file.
+inline void saveBindings(const InputMap& map, Settings& settings, const std::string& prefix = "input.") {
+    for (std::size_t i = 0; i < map.actionCount(); ++i)
+        settings.setString(prefix + map.actionName(i), toString(map.bindingAt(i)));
+}
+
+/// Load bindings previously written by saveBindings() back into @p map's registered
+/// actions. Actions with no stored value keep their current binding.
+inline void loadBindings(InputMap& map, const Settings& settings, const std::string& prefix = "input.") {
+    for (std::size_t i = 0; i < map.actionCount(); ++i) {
+        const std::string key = prefix + map.actionName(i);
+        const std::string stored = settings.getString(key, "");
+        if (!stored.empty()) map.rebind(map.actionName(i), bindingFromString(stored));
+    }
+}
+
+} // namespace platform
+} // namespace IKore

--- a/tests/test_input_mapping.cpp
+++ b/tests/test_input_mapping.cpp
@@ -1,0 +1,172 @@
+// Platform input: rebinding, gamepad, and UI scaling - issue #368.
+//
+// Verifies the acceptance criteria as headless logic (raw input -> action, resolution ->
+// layout): rebinding an action changes the produced GameInput, a synthetic gamepad axis
+// maps to movement (with a deadzone and hot-plug detection), HUD layout metrics scale
+// correctly across resolutions/DPIs and respect a safe area, and bindings persist through
+// the settings path. Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_input_mapping.cpp -o test_input_mapping
+
+#include "game/PlatformInput.h"
+
+#include <cmath>
+#include <cstdio>
+
+using namespace IKore;
+using namespace IKore::platform;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static bool near(float a, float b) { return std::fabs(a - b) < 1e-4f; }
+
+int main() {
+    // 1. Rebinding an action changes the produced input immediately.
+    {
+        InputMap map;
+        addDefaultMovementActions(map); // WASD
+
+        HeldInputs held;
+        held.press(InputMapBinding{InputDevice::Keyboard, 'D'}); // default = move_right
+        CHECK(near(resolveKeyboardMovement(map, held).moveX, 1.0f));
+
+        // Rebind move_right to 'L'. Holding 'D' now does nothing; holding 'L' moves right.
+        map.rebind(kMoveRight, InputMapBinding{InputDevice::Keyboard, 'L'});
+        CHECK(near(resolveKeyboardMovement(map, held).moveX, 0.0f));
+        held.release(InputMapBinding{InputDevice::Keyboard, 'D'});
+        held.press(InputMapBinding{InputDevice::Keyboard, 'L'});
+        CHECK(near(resolveKeyboardMovement(map, held).moveX, 1.0f));
+
+        // Opposite keys cancel; up is forward (-Z).
+        HeldInputs both;
+        both.press(map.binding(kMoveUp));
+        both.press(map.binding(kMoveDown));
+        CHECK(near(resolveKeyboardMovement(map, both).moveZ, 0.0f));
+        HeldInputs up;
+        up.press(map.binding(kMoveUp));
+        CHECK(near(resolveKeyboardMovement(map, up).moveZ, -1.0f));
+    }
+
+    // 2. A synthetic gamepad axis maps to movement, with a radial deadzone.
+    {
+        GamepadState pad;
+        pad.connected = true;
+        pad.axisLX = 1.0f; // full right
+        pad.axisLY = 0.0f;
+        game::GameInput g = resolveGamepadMovement(pad);
+        CHECK(near(g.moveX, 1.0f) && near(g.moveZ, 0.0f));
+
+        pad.axisLX = 0.0f;
+        pad.axisLY = -1.0f; // stick up -> forward
+        g = resolveGamepadMovement(pad);
+        CHECK(near(g.moveZ, -1.0f));
+
+        // Inside the deadzone -> no movement.
+        pad.axisLX = 0.1f;
+        pad.axisLY = 0.05f;
+        g = resolveGamepadMovement(pad);
+        CHECK(near(g.moveX, 0.0f) && near(g.moveZ, 0.0f));
+
+        // Disconnected pad produces nothing.
+        pad.connected = false;
+        pad.axisLX = 1.0f;
+        CHECK(near(resolveGamepadMovement(pad).moveX, 0.0f));
+    }
+
+    // 3. Combined resolve: an active stick overrides the keyboard; a centered stick defers.
+    {
+        InputMap map;
+        addDefaultMovementActions(map);
+        HeldInputs held;
+        held.press(map.binding(kMoveRight)); // keyboard says +X
+
+        GamepadState pad;
+        pad.connected = true;
+        pad.axisLX = -1.0f; // stick says -X
+        CHECK(resolveMovement(map, held, pad).moveX < 0.0f); // gamepad wins
+
+        pad.axisLX = 0.0f; // centered -> falls back to keyboard
+        CHECK(near(resolveMovement(map, held, pad).moveX, 1.0f));
+    }
+
+    // 4. Hot-plug: connect/disconnect transitions are reported once.
+    {
+        GamepadManager mgr;
+        CHECK(mgr.update(false) == GamepadManager::Event::None);
+        CHECK(mgr.update(true) == GamepadManager::Event::Connected);
+        CHECK(mgr.update(true) == GamepadManager::Event::None);
+        CHECK(mgr.update(false) == GamepadManager::Event::Disconnected);
+        CHECK(!mgr.connected());
+    }
+
+    // 5. HUD layout scales with DPI and respects resolution.
+    {
+        const UiMetrics m1 = computeUiMetrics(1920, 1080, 96.0f);
+        CHECK(near(m1.scale, 1.0f));
+        // TopRight of a 100x40 element with a 20px margin.
+        HudVec2 tr = layoutElement(m1, HudAnchor::TopRight, {100, 40}, {20, 20});
+        CHECK(near(tr.x, 1920 - 100 - 20) && near(tr.y, 20));
+        HudVec2 bl = layoutElement(m1, HudAnchor::BottomLeft, {100, 40}, {20, 20});
+        CHECK(near(bl.x, 20) && near(bl.y, 1080 - 40 - 20));
+
+        const UiMetrics m2 = computeUiMetrics(1920, 1080, 192.0f); // 2x DPI
+        CHECK(near(m2.scale, 2.0f));
+        CHECK(near(m2.scaled(100.0f), 200.0f));
+        // Element and margin both double; the anchor still hugs the corner.
+        HudVec2 tr2 = layoutElement(m2, HudAnchor::TopRight, {100, 40}, {20, 20});
+        CHECK(near(tr2.x, 1920 - 200 - 40) && near(tr2.y, 40));
+        HudVec2 tl2 = layoutElement(m2, HudAnchor::TopLeft, {100, 40}, {20, 20});
+        CHECK(near(tl2.x, 40) && near(tl2.y, 40));
+    }
+
+    // 6. Safe-area insets keep the HUD off notches/system bars.
+    {
+        SafeAreaInsets safe;
+        safe.left = 40;
+        safe.top = 120;
+        safe.right = 40;
+        safe.bottom = 80;
+        const UiMetrics m = computeUiMetrics(1080, 2400, 96.0f, safe);
+        HudVec2 tl = layoutElement(m, HudAnchor::TopLeft, {100, 40}, {0, 0});
+        CHECK(near(tl.x, 40) && near(tl.y, 120)); // pushed in by the insets
+        HudVec2 br = layoutElement(m, HudAnchor::BottomRight, {100, 40}, {0, 0});
+        // Bottom-right element sits flush against the safe rect's bottom-right.
+        CHECK(near(br.x + 100, 1080 - 40));       // right edge == screen - right inset
+        CHECK(near(br.y + 40, 2400 - 80));        // bottom edge == screen - bottom inset
+    }
+
+    // 7. Bindings persist through the settings path and survive a settings round-trip.
+    {
+        InputMap map;
+        addDefaultMovementActions(map);
+        map.rebind(kMoveRight, InputMapBinding{InputDevice::Keyboard, 'L'});
+        map.rebind(kMoveUp, InputMapBinding{InputDevice::Gamepad, 11});
+
+        Settings settings;
+        saveBindings(map, settings);
+
+        // Reload into a fresh default map through a serialized/reloaded Settings.
+        Settings reloaded;
+        reloaded.load(settings.serialize());
+        InputMap map2;
+        addDefaultMovementActions(map2);
+        loadBindings(map2, reloaded);
+        CHECK(map2.binding(kMoveRight) == (InputMapBinding{InputDevice::Keyboard, 'L'}));
+        CHECK(map2.binding(kMoveUp) == (InputMapBinding{InputDevice::Gamepad, 11}));
+        CHECK(map2.binding(kMoveLeft) == (InputMapBinding{InputDevice::Keyboard, 'A'})); // untouched
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_input_mapping: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_input_mapping: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #368. Adds `src/game/PlatformInput.h`, the headless layer between raw device input and the game, modelled as testable logic (raw input -> action, resolution -> layout) separate from the device glue. It builds on the rebindable `InputMap` (#60) and persists through the `Settings` surface (#61), and lays HUD elements out with the HUD framework's anchor math.

- **Rebindable movement** - movement actions (WASD by default) resolve held keys to a normalized `game::GameInput`; rebinding an action changes the produced input immediately, and opposite directions cancel.
- **Gamepad support** - a left-stick snapshot resolves to a `GameInput` through a **radial deadzone** (rescaled so the deadzone edge is 0 and full deflection 1). `resolveMovement()` lets an active stick override the keyboard and defer to it when centered. `GamepadManager` reports connect/disconnect (**hot-plug**) transitions across polls.
- **DPI-aware UI scaling** - `computeUiMetrics()` derives a clamped DPI-based scale and a **safe-area rect**; `layoutElement()` scales an element's size and margin and anchors it within the safe area, so the HUD keeps a constant physical size and stays off notches across resolutions and aspect ratios.
- **Persistence** - bindings save through the settings path as per-action keys (single line each), surviving a `Settings` serialize/reload round-trip.

## Testing

`tests/test_input_mapping.cpp` (registered in the headless suite) covers every acceptance point:

- rebinding changes the produced action;
- a synthetic gamepad axis maps to movement, with deadzone handling and disconnected-pad safety;
- gamepad-over-keyboard precedence;
- hot-plug connect/disconnect transitions reported once;
- HUD layout metrics scale correctly across resolutions/DPIs (1x and 2x) and hug their anchors;
- safe-area insets keep the HUD off notches/system bars;
- bindings persist through a `Settings` serialize/reload round-trip.

Passes standalone (`g++ -std=c++17 -I src`), via CMake/ctest, and clean under `-fsanitize=address,undefined`.

The macOS build job is expected to fail (pre-existing, tracked in #338) and is `continue-on-error`; all other gates should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_