### PR TITLE
Platform: unified save, cloud sync, and share plumbing (#370)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1039,6 +1039,11 @@ add_executable(test_picking
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_picking.cpp
 )
 
+# Unified save model, corruption-resistant writes, cloud sync, share/import (#370) - header-only.
+add_executable(test_save_sync
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_save_sync.cpp
+)
+
 # Persistent settings store (Milestone 9 / #58) - header-only.
 add_executable(test_settings
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_settings.cpp
@@ -1272,6 +1277,7 @@ set(HEADLESS_TESTS
     test_render_pass_graph
     test_replay
     test_rollback
+    test_save_sync
     test_scene_author
     test_scene_hierarchy
     test_settings

--- a/src/game/SaveSync.h
+++ b/src/game/SaveSync.h
@@ -1,0 +1,358 @@
+#pragma once
+
+#include "game/LevelShare.h" // encodeShare/decodeShare + detail::fnv1a64/base64 (#317)
+
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+/**
+ * @file SaveSync.h
+ * @brief Unified save model, corruption-resistant local writes, and cloud sync (issue #370).
+ *
+ * One coherent persistence layer over the scattered pieces (local save/config #58, level
+ * persistence #241, share codes #317): a player's profile, progress, settings, authored
+ * levels, and saved replays, serialized with a version header and forward-compatible,
+ * tolerant parsing so old saves migrate and future fields do not break an older build.
+ *
+ *   - SaveData: the whole model; serialize()/deserialize() round-trip and migrate.
+ *   - frameSave()/unframeSave(): a checksum envelope so a truncated or corrupt blob is
+ *     detected; SaveManager recovers to a valid default rather than loading garbage, and
+ *     SaveStorage writes atomically (temp-write-then-rename for the file backend).
+ *   - syncLastWriterWins()/CloudSync: reconcile a divergent local/remote pair
+ *     deterministically behind a storage interface, so a real backend drops in later.
+ *   - Authored levels and replays are carried as #317 share strings, so the same code
+ *     path shares and imports them.
+ *
+ * Header-only, std only (plus the header-only LevelShare). Behind the SaveStorage
+ * interface it is fully headless-testable.
+ */
+namespace IKore {
+namespace game {
+
+constexpr int kSaveVersion = 2;
+
+/// Per-level progress. bestTimeMs was added in v2; a v1 save migrates it to 0.
+struct LevelProgressEntry {
+    int bestStars{0};
+    int bestTimeMs{0};
+
+    bool operator==(const LevelProgressEntry& o) const {
+        return bestStars == o.bestStars && bestTimeMs == o.bestTimeMs;
+    }
+};
+
+/// The unified save: profile, progress, settings, authored levels, saved replays.
+struct SaveData {
+    int version{kSaveVersion};
+    std::string profile;
+    std::map<std::string, LevelProgressEntry> progress; ///< levelId -> progress
+    std::map<std::string, std::string> settings;        ///< settings kv
+    std::vector<std::string> authoredLevels;            ///< #317 share strings
+    std::vector<std::string> savedReplays;              ///< #317 share strings
+    std::uint64_t updatedAt{0};                         ///< logical clock for last-writer-wins
+
+    bool operator==(const SaveData& o) const {
+        return version == o.version && profile == o.profile && progress == o.progress &&
+               settings == o.settings && authoredLevels == o.authoredLevels &&
+               savedReplays == o.savedReplays && updatedAt == o.updatedAt;
+    }
+};
+
+// --- Serialization (versioned, tolerant, forward-compatible) -----------------
+
+namespace detail {
+
+/// base64-encode a free-text token so serialized records stay whitespace-free.
+inline std::string encTok(const std::string& s) { return base64Encode(s); }
+inline std::string decTok(const std::string& s) {
+    std::string out;
+    return base64Decode(s, out) ? out : std::string();
+}
+
+} // namespace detail
+
+/// Serialize a save to a stable, sorted text form (maps iterate in key order).
+inline std::string serialize(const SaveData& s) {
+    std::ostringstream os;
+    os << "save " << s.version << "\n";
+    os << "profile " << detail::encTok(s.profile) << "\n";
+    os << "clock " << s.updatedAt << "\n";
+    for (const auto& kv : s.settings)
+        os << "setting " << detail::encTok(kv.first) << " " << detail::encTok(kv.second) << "\n";
+    for (const auto& kv : s.progress)
+        os << "progress " << detail::encTok(kv.first) << " " << kv.second.bestStars << " "
+           << kv.second.bestTimeMs << "\n";
+    for (const std::string& code : s.authoredLevels) os << "level " << code << "\n";
+    for (const std::string& code : s.savedReplays) os << "replay " << code << "\n";
+    return os.str();
+}
+
+/// Migrate a parsed save from @p fromVersion to the current version. Field additions are
+/// already handled by tolerant parsing (defaults); this stamps the version and applies any
+/// version-specific transform. Kept explicit so future bumps have a home.
+inline void migrate(SaveData& s, int fromVersion) {
+    // v1 -> v2 added LevelProgressEntry::bestTimeMs (defaulted to 0 by the parser) and the
+    // updatedAt clock. Nothing else to transform.
+    (void)fromVersion;
+    s.version = kSaveVersion;
+}
+
+/// Parse a save produced by serialize(). Unknown record types are ignored (forward
+/// compatible), a v1 progress line without a time defaults it, and the result is migrated
+/// to the current version.
+inline SaveData deserialize(const std::string& text) {
+    SaveData s;
+    int parsedVersion = kSaveVersion;
+    std::istringstream in(text);
+    std::string line;
+    while (std::getline(in, line)) {
+        std::istringstream ls(line);
+        std::string type;
+        if (!(ls >> type)) continue;
+        if (type == "save") {
+            ls >> parsedVersion;
+        } else if (type == "profile") {
+            std::string tok;
+            if (ls >> tok) s.profile = detail::decTok(tok);
+        } else if (type == "clock") {
+            ls >> s.updatedAt;
+        } else if (type == "setting") {
+            std::string k, v;
+            if (ls >> k) {
+                ls >> v; // value token may be empty (encoded empty string)
+                s.settings[detail::decTok(k)] = detail::decTok(v);
+            }
+        } else if (type == "progress") {
+            std::string id;
+            int stars = 0, timeMs = 0;
+            if (ls >> id >> stars) {
+                ls >> timeMs; // absent in v1 -> stays 0
+                s.progress[detail::decTok(id)] = LevelProgressEntry{stars, timeMs};
+            }
+        } else if (type == "level") {
+            std::string code;
+            if (ls >> code) s.authoredLevels.push_back(code);
+        } else if (type == "replay") {
+            std::string code;
+            if (ls >> code) s.savedReplays.push_back(code);
+        }
+        // else: unknown record -> ignored (a newer save's field on an older build)
+    }
+    migrate(s, parsedVersion);
+    return s;
+}
+
+// --- Checksum envelope -------------------------------------------------------
+
+/// Wrap a payload with a checksum header so corruption/truncation is detectable.
+inline std::string frameSave(const std::string& payload) {
+    return "IKSAVE1 " + std::to_string(detail::fnv1a64(payload)) + "\n" + payload;
+}
+
+/// Verify and strip the checksum envelope. Returns false (leaving @p payload empty) on a
+/// missing header, a bad/truncated checksum, or a mismatch.
+inline bool unframeSave(const std::string& framed, std::string& payload) {
+    payload.clear();
+    const std::size_t nl = framed.find('\n');
+    if (nl == std::string::npos) return false;
+    std::istringstream hs(framed.substr(0, nl));
+    std::string magic, sum;
+    if (!(hs >> magic >> sum) || magic != "IKSAVE1") return false;
+    const std::string body = framed.substr(nl + 1);
+    std::uint64_t want = 0;
+    try {
+        want = std::stoull(sum);
+    } catch (...) {
+        return false;
+    }
+    if (detail::fnv1a64(body) != want) return false;
+    payload = body;
+    return true;
+}
+
+// --- Storage interface + backends -------------------------------------------
+
+/// A key/value blob store: the seam a real backend (files, cloud) implements.
+struct SaveStorage {
+    virtual ~SaveStorage() = default;
+    virtual bool read(const std::string& key, std::string& out) const = 0;
+    virtual bool write(const std::string& key, const std::string& data) = 0;
+};
+
+/// In-memory store (headless tests, and a stub cloud backend).
+class MemoryStorage : public SaveStorage {
+public:
+    bool read(const std::string& key, std::string& out) const override {
+        auto it = m_data.find(key);
+        if (it == m_data.end()) return false;
+        out = it->second;
+        return true;
+    }
+    bool write(const std::string& key, const std::string& data) override {
+        m_data[key] = data;
+        return true;
+    }
+    bool has(const std::string& key) const { return m_data.count(key) != 0; }
+    /// Test helper: truncate a stored blob to simulate corruption.
+    void truncate(const std::string& key, std::size_t keep) {
+        auto it = m_data.find(key);
+        if (it != m_data.end()) it->second = it->second.substr(0, keep);
+    }
+
+private:
+    std::map<std::string, std::string> m_data;
+};
+
+/// File store with an atomic write: serialize to "<path>.tmp" then rename over the target,
+/// so a crash mid-write never leaves a half-written save.
+class FileStorage : public SaveStorage {
+public:
+    bool read(const std::string& key, std::string& out) const override {
+        std::ifstream in(key, std::ios::binary);
+        if (!in) return false;
+        std::ostringstream ss;
+        ss << in.rdbuf();
+        out = ss.str();
+        return true;
+    }
+    bool write(const std::string& key, const std::string& data) override {
+        const std::string tmp = key + ".tmp";
+        {
+            std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+            if (!out) return false;
+            out << data;
+            if (!out) return false;
+        }
+        return std::rename(tmp.c_str(), key.c_str()) == 0;
+    }
+};
+
+// --- Save manager (frame + recover) -----------------------------------------
+
+struct LoadResult {
+    bool ok{false};        ///< false only when nothing is stored at @p key.
+    bool recovered{false}; ///< true when the stored blob was corrupt and a default was used.
+    SaveData data;
+};
+
+/// Frames on save; verifies and recovers on load.
+class SaveManager {
+public:
+    explicit SaveManager(SaveStorage& storage) : m_storage(storage) {}
+
+    bool save(const std::string& key, const SaveData& data) {
+        return m_storage.write(key, frameSave(serialize(data)));
+    }
+
+    LoadResult load(const std::string& key) {
+        LoadResult r;
+        std::string framed;
+        if (!m_storage.read(key, framed)) return r; // nothing stored: ok == false
+        std::string payload;
+        if (!unframeSave(framed, payload)) {
+            r.ok = true;
+            r.recovered = true; // corrupt/truncated -> recover to a valid default
+            return r;
+        }
+        r.ok = true;
+        r.data = deserialize(payload);
+        return r;
+    }
+
+private:
+    SaveStorage& m_storage;
+};
+
+// --- Cloud sync (last-writer-wins) ------------------------------------------
+
+struct SyncOutcome {
+    enum Source { Local, Remote, Equal };
+    Source source{Equal};
+    SaveData merged;
+};
+
+/// Reconcile two saves by last-writer-wins on the logical clock. A clock tie is broken
+/// deterministically by content hash, so the result is independent of argument order.
+inline SyncOutcome syncLastWriterWins(const SaveData& local, const SaveData& remote) {
+    SyncOutcome o;
+    if (local.updatedAt > remote.updatedAt) {
+        o.source = SyncOutcome::Local;
+        o.merged = local;
+    } else if (remote.updatedAt > local.updatedAt) {
+        o.source = SyncOutcome::Remote;
+        o.merged = remote;
+    } else {
+        const std::uint64_t hl = detail::fnv1a64(serialize(local));
+        const std::uint64_t hr = detail::fnv1a64(serialize(remote));
+        if (hr > hl) {
+            o.source = SyncOutcome::Remote;
+            o.merged = remote;
+        } else {
+            o.source = (hr == hl) ? SyncOutcome::Equal : SyncOutcome::Local;
+            o.merged = local;
+        }
+    }
+    return o;
+}
+
+/// Cloud-sync over any SaveStorage backend (a stub MemoryStorage or a real remote).
+class CloudSync {
+public:
+    explicit CloudSync(SaveStorage& remote) : m_remote(remote) {}
+
+    bool push(const std::string& key, const SaveData& data) {
+        return m_remote.write(key, frameSave(serialize(data)));
+    }
+    /// Pull the remote save; a missing or corrupt blob recovers to a default (clock 0).
+    SaveData pull(const std::string& key) {
+        std::string framed, payload;
+        if (!m_remote.read(key, framed)) return SaveData{};
+        if (!unframeSave(framed, payload)) return SaveData{};
+        return deserialize(payload);
+    }
+    /// Pull, last-writer-wins merge with @p local, push the winner back. Returns the outcome.
+    SyncOutcome reconcile(const std::string& key, const SaveData& local) {
+        const SyncOutcome o = syncLastWriterWins(local, pull(key));
+        push(key, o.merged);
+        return o;
+    }
+
+private:
+    SaveStorage& m_remote;
+};
+
+// --- Share / import (reuses #317) -------------------------------------------
+
+/// Add an authored level to a save as a #317 share string.
+inline void addAuthoredLevel(SaveData& s, const std::string& levelJson) {
+    s.authoredLevels.push_back(encodeShare(levelJson));
+}
+/// Add a saved replay to a save as a #317 share string (the share format is payload-agnostic).
+inline void addReplay(SaveData& s, const std::string& replayText) {
+    s.savedReplays.push_back(encodeShare(replayText));
+}
+
+struct ImportResult {
+    bool ok{false};
+    std::string payload; ///< the recovered level/replay text.
+};
+
+/// Import a shared level or replay code into a save, validating it through the #317 path.
+/// A tampered or malformed code yields ok == false and does not modify the save.
+inline ImportResult importShared(SaveData& s, const std::string& shareString, bool asReplay = false) {
+    ImportResult r;
+    const ShareImport imp = decodeShare(shareString);
+    if (!imp.ok) return r;
+    (asReplay ? s.savedReplays : s.authoredLevels).push_back(shareString);
+    r.ok = true;
+    r.payload = imp.levelJson;
+    return r;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_save_sync.cpp
+++ b/tests/test_save_sync.cpp
@@ -1,0 +1,184 @@
+// Save, cloud sync, and share plumbing - issue #370.
+//
+// Verifies the unified save layer behind a storage interface: a save round-trips (including
+// free text with spaces), a v1 blob migrates across a version bump, a truncated blob
+// recovers to a valid default, last-writer-wins reconciles a divergent local/remote pair
+// deterministically, and a shared level/replay code imports through the #317 path. Pure std
+// + header-only:
+//   g++ -std=c++17 -I src tests/test_save_sync.cpp -o test_save_sync
+
+#include "game/SaveSync.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static SaveData sampleSave() {
+    SaveData s;
+    s.profile = "Ada Lovelace"; // free text with a space
+    s.updatedAt = 42;
+    s.progress["world1/level3"] = LevelProgressEntry{3, 15200};
+    s.progress["world1/level1"] = LevelProgressEntry{2, 9800};
+    s.settings["audio.master"] = "0.8";
+    s.settings["ui.language"] = "en GB"; // value with a space
+    addAuthoredLevel(s, "{\"name\":\"my level\"}");
+    addReplay(s, "replay:frames=1234;seed=7");
+    return s;
+}
+
+int main() {
+    // 1. Round-trip at the current version through the manager + a memory store.
+    {
+        MemoryStorage store;
+        SaveManager mgr(store);
+        const SaveData in = sampleSave();
+        CHECK(mgr.save("slot0", in));
+        const LoadResult out = mgr.load("slot0");
+        CHECK(out.ok && !out.recovered);
+        CHECK(out.data == in); // exact, including spaced strings and share codes
+    }
+
+    // 2. A v1 save (no per-level time, no clock) migrates across the version bump.
+    {
+        // Hand-author a v1 payload: progress lines carry only stars.
+        std::ostringstream v1;
+        v1 << "save 1\n";
+        v1 << "profile " << detail::encTok("Grace") << "\n";
+        v1 << "progress " << detail::encTok("w1/l1") << " 3\n";
+        v1 << "setting " << detail::encTok("audio.master") << " " << detail::encTok("1.0") << "\n";
+        v1 << "future_record ignored payload\n"; // forward-compat: unknown record skipped
+        const std::string framed = frameSave(v1.str());
+
+        MemoryStorage store;
+        store.write("slot0", framed);
+        SaveManager mgr(store);
+        const LoadResult out = mgr.load("slot0");
+        CHECK(out.ok && !out.recovered);
+        CHECK(out.data.version == kSaveVersion); // migrated to current
+        CHECK(out.data.profile == "Grace");
+        CHECK(out.data.progress.at("w1/l1").bestStars == 3);
+        CHECK(out.data.progress.at("w1/l1").bestTimeMs == 0); // defaulted by migration
+        CHECK(out.data.settings.at("audio.master") == "1.0");
+        // Re-saving yields a current-version blob that round-trips.
+        CHECK(mgr.save("slot1", out.data));
+        CHECK(mgr.load("slot1").data == out.data);
+    }
+
+    // 3. A truncated/corrupt blob is detected and recovers to a valid default.
+    {
+        MemoryStorage store;
+        SaveManager mgr(store);
+        CHECK(mgr.save("slot0", sampleSave()));
+        std::string blob;
+        store.read("slot0", blob);
+        store.truncate("slot0", blob.size() / 2); // corrupt the payload
+        const LoadResult out = mgr.load("slot0");
+        CHECK(out.ok && out.recovered);            // corruption detected, not loaded as garbage
+        CHECK(out.data == SaveData{});             // recovered to a valid empty save
+        CHECK(out.data.version == kSaveVersion);
+        // A missing key is a clean miss (not a recovery).
+        const LoadResult missing = mgr.load("does_not_exist");
+        CHECK(!missing.ok && !missing.recovered);
+    }
+
+    // 4. Last-writer-wins reconciles deterministically, regardless of argument order.
+    {
+        SaveData local = sampleSave();
+        local.updatedAt = 100;
+        SaveData remote = sampleSave();
+        remote.updatedAt = 50;
+        remote.profile = "Older";
+
+        CHECK(syncLastWriterWins(local, remote).source == SyncOutcome::Local);
+        CHECK(syncLastWriterWins(local, remote).merged == local);
+        // The newer save wins regardless of argument order (the source label is arg-relative).
+        CHECK(syncLastWriterWins(remote, local).merged == local);
+
+        // A clock tie is broken deterministically: same winner whichever order.
+        SaveData a = sampleSave();
+        SaveData b = sampleSave();
+        a.updatedAt = b.updatedAt = 7;
+        b.profile = "Different"; // same clock, different content
+        const SyncOutcome ab = syncLastWriterWins(a, b);
+        const SyncOutcome ba = syncLastWriterWins(b, a);
+        CHECK(ab.merged == ba.merged); // order-independent
+    }
+
+    // 5. CloudSync over a stub backend: pull, merge, push the winner back.
+    {
+        MemoryStorage cloud;
+        CloudSync sync(cloud);
+        SaveData remote = sampleSave();
+        remote.updatedAt = 3;
+        remote.profile = "Remote";
+        sync.push("slot0", remote);
+
+        SaveData local = sampleSave();
+        local.updatedAt = 9; // newer
+        local.profile = "Local";
+        const SyncOutcome out = sync.reconcile("slot0", local);
+        CHECK(out.source == SyncOutcome::Local);
+        CHECK(out.merged.profile == "Local");
+        // The winner was pushed back to the cloud.
+        CHECK(sync.pull("slot0").profile == "Local");
+    }
+
+    // 6. Share/import round-trips a level and a replay through the #317 code path.
+    {
+        const std::string levelJson = "{\"walls\":[[0,0],[1,0]],\"name\":\"shared\"}";
+        SaveData author;
+        addAuthoredLevel(author, levelJson);
+
+        SaveData importer;
+        const ImportResult ir = importShared(importer, author.authoredLevels[0]);
+        CHECK(ir.ok && ir.payload == levelJson);
+        CHECK(importer.authoredLevels.size() == 1);
+
+        // A tampered/malformed code is rejected and does not modify the save.
+        const ImportResult bad = importShared(importer, "DDL1:DD-BOGUS:@@notbase64@@");
+        CHECK(!bad.ok);
+        CHECK(importer.authoredLevels.size() == 1);
+
+        // Replays share through the same path.
+        const std::string replay = "replay:seed=99;len=4321";
+        SaveData rAuthor;
+        addReplay(rAuthor, replay);
+        const ImportResult rr = importShared(importer, rAuthor.savedReplays[0], /*asReplay=*/true);
+        CHECK(rr.ok && rr.payload == replay);
+        CHECK(importer.savedReplays.size() == 1);
+    }
+
+    // 7. FileStorage writes atomically (temp-then-rename) and reads back intact.
+    {
+        const std::string path = "test_save_sync_scratch.iksave";
+        FileStorage fs;
+        SaveManager mgr(fs);
+        const SaveData in = sampleSave();
+        if (mgr.save(path, in)) { // skip silently if the CWD is not writable
+            const LoadResult out = mgr.load(path);
+            CHECK(out.ok && !out.recovered);
+            CHECK(out.data == in);
+            std::remove(path.c_str());
+            std::remove((path + ".tmp").c_str());
+        }
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_save_sync: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_save_sync: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #370. Adds `src/game/SaveSync.h`, one coherent persistence layer over the scattered pieces (local save/config #58, level persistence #241, share codes #317), fully headless-testable behind a storage interface.

- **Unified model** - `SaveData` carries profile, progress, settings, authored levels, and saved replays under a version header. `serialize()`/`deserialize()` round-trip through **tolerant, forward-compatible** parsing: a v1 save **migrates** (per-level time defaults, clock added) and an unknown record from a newer build is ignored rather than failing the load.
- **Corruption resistance** - `frameSave()`/`unframeSave()` wrap the payload in an FNV-1a **checksum envelope**, so a truncated or corrupt blob is detected. `SaveManager` **recovers to a valid default** instead of loading garbage, and distinguishes a corrupt blob from a clean miss.
- **Atomic writes** - the `SaveStorage` interface has a `MemoryStorage` stub and a `FileStorage` that writes **temp-then-rename**, so a crash mid-write never leaves a half-written save.
- **Cloud sync** - `syncLastWriterWins()` / `CloudSync` reconcile a divergent local/remote pair by **last-writer-wins** on a logical clock, with ties broken deterministically by content hash so the result is independent of argument order. Sync runs over any `SaveStorage` backend, so a real provider drops in later with no core changes.
- **Share/import** - authored levels and replays are carried as #317 share strings, so the same encode/decode path shares and imports them (a tampered code is rejected).

## Testing

`tests/test_save_sync.cpp` (registered in the headless suite) covers every acceptance point:

- a save round-trips at the current version, including free text with spaces;
- a **v1 blob migrates** across the version bump (defaults filled, unknown record skipped) and re-saves cleanly;
- a **truncated blob recovers** to a valid default, while a missing key is a clean miss;
- **last-writer-wins** reconciles deterministically regardless of argument order, including a clock tie;
- `CloudSync` over a stub backend pulls, merges, and pushes the winner back;
- level and replay **share codes round-trip** through the #317 path, and a tampered code is rejected;
- `FileStorage` writes atomically and reads back intact.

Passes standalone (`g++ -std=c++17 -I src`), via CMake/ctest, and clean under `-fsanitize=address,undefined`.

The macOS build job is expected to fail (pre-existing, tracked in #338) and is `continue-on-error`; all other gates should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_