### PR TITLE
Platform: mobile touch controls and GLES render-path core (#367)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,6 +748,11 @@ add_executable(test_tournament
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tournament.cpp
 )
 
+# Mobile touch controls + GLES render-path selection (#367) - header-only.
+add_executable(test_touch_controls
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_touch_controls.cpp
+)
+
 # First-person tour camera (Milestone 15 / #165) - header-only.
 add_executable(test_tour_camera
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_tour_camera.cpp
@@ -1303,6 +1308,7 @@ set(HEADLESS_TESTS
     test_tone_mapping
     test_tonemap_chain
     test_topology
+    test_touch_controls
     test_tour_camera
     test_tournament
     test_tower_defense

--- a/docs/MOBILE_SHELL.md
+++ b/docs/MOBILE_SHELL.md
@@ -1,0 +1,40 @@
+# Mobile shell (Android/GLES) - status and plan
+
+Issue #367 delivers the mobile game on the portable doodle library (#171) behind the thin
+`AppShell` host (#172). This document records what is in-tree now (the portable, headless
+core) and what remains platform-specific (the device shell), so the boundary stays clean.
+
+## In-tree now (portable, headless-tested)
+
+- `src/game/TouchControls.h` - a virtual movement joystick (fixed or floating) that maps a
+  finger drag to the same normalized `game::GameInput` the keyboard and gamepad produce, plus
+  rectangular touch buttons with single-fire edge detection for the capture entry point.
+- `src/render/GlesProfile.h` - selects the desktop-GL vs GLES3/GLES2 render path and the GLSL
+  dialect (`#version 330 core` / `300 es` / `100`) from the runtime target, so the shared
+  render code branches on capabilities, not platform.
+- `tests/test_touch_controls.cpp` - covers the joystick math, deadzone/clamp, button edge
+  detection, the capture tap, and render-path selection. Runs in the headless suite.
+
+Everything above is pure logic: no GLES context, no NDK, no device. It is unit-tested in CI.
+
+## Remaining (platform-specific shell - built outside this CI)
+
+These require an Android toolchain (NDK + Gradle) and a device/emulator, which the headless CI
+here cannot exercise. They are intentionally out of the portable core:
+
+- A GLES2/3 context + surface via EGL, created by the Android `AppShell` host.
+- `android_native_app_glue` lifecycle (init / focus / pause / resume / terminate) wired to the
+  library's frame loop.
+- Touch event delivery (`AMotionEvent`) feeding `TouchControls`, and the camera / image-picker
+  entry point feeding the existing capture pipeline.
+- A Gradle module producing a runnable APK that boots into the doodle library and plays a
+  captured level.
+
+## Capture -> play -> share loop on device
+
+The capture pipeline (photo/import -> vectorize -> playable `DungeonGame`) and the share-code
+path (#317, exercised by `SaveSync`/`LevelShare`) are already portable and headless-tested; the
+shell only has to feed pixels in and surface the share string out. The shared game core keeps
+passing its headless tests unchanged, satisfying the "core stays headless-testable" requirement
+of #367; the on-device APK build and emulator verification are tracked as the remaining shell
+work.

--- a/src/game/TouchControls.h
+++ b/src/game/TouchControls.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "game/DungeonGame.h" // game::GameInput
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+/**
+ * @file TouchControls.h
+ * @brief Touch movement + action controls for the mobile shell (issue #367).
+ *
+ * The portable doodle core is renderer- and platform-agnostic; a phone drives it through
+ * touch. This is the headless-testable half of that: a virtual movement joystick (fixed or
+ * floating) that turns a finger drag into the same normalized game::GameInput the keyboard
+ * and gamepad produce, plus rectangular touch buttons with edge detection for actions such
+ * as the capture entry point. The Android/NDK surface + lifecycle glue that feeds real touch
+ * events in is the platform-specific shell; everything here is pure math and unit-testable.
+ *
+ * Screen space is pixels with +Y down; up on screen (smaller Y) is forward (-Z), matching
+ * the keyboard/gamepad convention in PlatformInput. Header-only, std only.
+ */
+namespace IKore {
+namespace platform {
+
+/// A single touch sample in screen pixels.
+struct TouchPoint {
+    float x{0.0f};
+    float y{0.0f};
+    bool down{false};
+    int id{0}; ///< finger id for multi-touch.
+};
+
+/// Pure joystick math: the movement from a stick @p origin to the current touch point,
+/// with a radial deadzone and clamped to full deflection at @p radius. Magnitude is 0 at
+/// the deadzone edge and 1 at (or beyond) the radius.
+inline game::GameInput joystickInput(float originX, float originY, float touchX, float touchY,
+                                     float radius, float deadzone = 0.15f) {
+    game::GameInput in;
+    const float dx = touchX - originX;
+    const float dy = touchY - originY;
+    const float dist = std::sqrt(dx * dx + dy * dy);
+    const float deadPx = deadzone * radius;
+    if (radius <= 0.0f || dist <= deadPx || dist <= 0.0f) return in;
+    const float clamped = std::min(dist, radius);
+    const float mag = (clamped - deadPx) / (radius - deadPx); // 0 at deadzone edge -> 1 at radius
+    const float nx = dx / dist, ny = dy / dist;
+    in.moveX = nx * mag;
+    in.moveZ = ny * mag; // screen up (dy < 0) -> forward (-Z)
+    return in;
+}
+
+/// A floating movement stick: its origin snaps to wherever the finger first lands, then the
+/// drag from there drives movement until the finger lifts. (A fixed stick is just this with
+/// a preset origin and no re-centering.)
+class FloatingJoystick {
+public:
+    explicit FloatingJoystick(float radius = 120.0f, float deadzone = 0.15f)
+        : m_radius(radius), m_deadzone(deadzone) {}
+
+    void setFixedOrigin(float x, float y) {
+        m_originX = x;
+        m_originY = y;
+        m_active = true;
+        m_fixed = true;
+    }
+
+    void onTouchDown(float x, float y) {
+        if (!m_fixed) {
+            m_originX = x;
+            m_originY = y;
+        }
+        m_active = true;
+    }
+    game::GameInput onTouchMove(float x, float y) const {
+        return m_active ? joystickInput(m_originX, m_originY, x, y, m_radius, m_deadzone)
+                        : game::GameInput{};
+    }
+    void onTouchUp() {
+        if (!m_fixed) m_active = false;
+    }
+
+    bool active() const { return m_active; }
+    float originX() const { return m_originX; }
+    float originY() const { return m_originY; }
+
+private:
+    float m_radius;
+    float m_deadzone;
+    float m_originX{0.0f};
+    float m_originY{0.0f};
+    bool m_active{false};
+    bool m_fixed{false};
+};
+
+/// A rectangular touch target (top-left origin, size), in screen pixels.
+struct TouchButton {
+    float x{0.0f};
+    float y{0.0f};
+    float w{0.0f};
+    float h{0.0f};
+
+    bool contains(float px, float py) const {
+        return px >= x && px <= x + w && py >= y && py <= y + h;
+    }
+    bool pressedBy(const std::vector<TouchPoint>& touches) const {
+        for (const TouchPoint& t : touches)
+            if (t.down && contains(t.x, t.y)) return true;
+        return false;
+    }
+};
+
+/// Fires exactly once on the frame a boolean condition goes from false to true - so a held
+/// finger on the capture button triggers capture a single time, not every frame.
+class ButtonLatch {
+public:
+    bool update(bool pressedNow) {
+        const bool edge = pressedNow && !m_prev;
+        m_prev = pressedNow;
+        return edge;
+    }
+    bool held() const { return m_prev; }
+
+private:
+    bool m_prev{false};
+};
+
+/// The on-screen touch layout: a movement stick plus a capture button (the entry into the
+/// photograph/import capture pipeline). resolve() maps this frame's touches to a GameInput
+/// and reports whether capture was just tapped.
+struct TouchControls {
+    FloatingJoystick move{120.0f, 0.15f};
+    TouchButton capture; ///< the capture entry-point button.
+
+    struct Frame {
+        game::GameInput input;
+        bool captureTapped{false};
+    };
+
+    /// Feed this frame's active touches. The first touch not on a button drives the stick.
+    Frame resolve(const std::vector<TouchPoint>& touches) {
+        Frame f;
+        bool stickDown = false;
+        float sx = 0.0f, sy = 0.0f;
+        for (const TouchPoint& t : touches) {
+            if (!t.down) continue;
+            if (capture.contains(t.x, t.y)) continue; // reserved for the button
+            stickDown = true;
+            sx = t.x;
+            sy = t.y;
+            break;
+        }
+        if (stickDown) {
+            if (!move.active()) move.onTouchDown(sx, sy);
+            f.input = move.onTouchMove(sx, sy);
+        } else {
+            move.onTouchUp();
+        }
+        f.captureTapped = m_captureLatch.update(capture.pressedBy(touches));
+        return f;
+    }
+
+private:
+    ButtonLatch m_captureLatch;
+};
+
+} // namespace platform
+} // namespace IKore

--- a/src/render/GlesProfile.h
+++ b/src/render/GlesProfile.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <string>
+
+/**
+ * @file GlesProfile.h
+ * @brief Select a desktop-GL vs GLES render path and its shader dialect (issue #367).
+ *
+ * The desktop build targets OpenGL 3.3 core; a phone targets OpenGL ES. Rather than fork the
+ * renderer, this picks a small capability set (which GLSL dialect to emit, whether instancing
+ * and float textures are available) from the runtime/build target, so the shared render code
+ * can branch on capabilities instead of on the platform. The actual context creation
+ * (EGL/GLFW/NDK) is platform glue; this selection logic is pure and unit-testable.
+ * Header-only, std only.
+ */
+namespace IKore {
+namespace render {
+
+enum class GlProfile { DesktopGL, GLES3, GLES2 };
+
+/// The render capabilities a chosen profile exposes.
+struct RenderCaps {
+    GlProfile profile{GlProfile::DesktopGL};
+    int glslVersion{330}; ///< GLSL version number (330 desktop, 300/100 ES).
+    bool es{false};       ///< true for an OpenGL ES profile.
+    bool instancing{true};
+    bool floatTextures{true};
+};
+
+/// Choose the render path: desktop GL off-mobile, else GLES3 when available, GLES2 otherwise
+/// (GLES2 drops instancing and float textures, so the renderer falls back for those).
+inline RenderCaps selectRenderCaps(bool mobile, int glesMajor = 3) {
+    RenderCaps c;
+    if (!mobile) {
+        c.profile = GlProfile::DesktopGL;
+        c.glslVersion = 330;
+        c.es = false;
+        c.instancing = true;
+        c.floatTextures = true;
+        return c;
+    }
+    if (glesMajor >= 3) {
+        c.profile = GlProfile::GLES3;
+        c.glslVersion = 300;
+        c.es = true;
+        c.instancing = true;
+        c.floatTextures = true;
+    } else {
+        c.profile = GlProfile::GLES2;
+        c.glslVersion = 100;
+        c.es = true;
+        c.instancing = false;
+        c.floatTextures = false;
+    }
+    return c;
+}
+
+/// The `#version` directive a shader should be compiled with for these caps.
+inline std::string shaderVersionDirective(const RenderCaps& caps) {
+    if (!caps.es) return "#version 330 core";
+    if (caps.glslVersion >= 300) return "#version 300 es";
+    return "#version 100";
+}
+
+/// Human-readable profile name (logging / diagnostics).
+inline const char* profileName(GlProfile p) {
+    switch (p) {
+        case GlProfile::DesktopGL: return "DesktopGL";
+        case GlProfile::GLES3: return "GLES3";
+        case GlProfile::GLES2: return "GLES2";
+    }
+    return "Unknown";
+}
+
+} // namespace render
+} // namespace IKore

--- a/tests/test_touch_controls.cpp
+++ b/tests/test_touch_controls.cpp
@@ -1,0 +1,130 @@
+// Mobile touch controls + GLES render-path selection - issue #367 (portable core).
+//
+// The device shell (Android/NDK surface, lifecycle, camera) is platform glue; this exercises
+// the headless-testable half: a virtual movement stick turning a finger drag into the same
+// normalized game::GameInput as keyboard/gamepad, touch buttons with single-fire edge
+// detection for the capture entry point, and the desktop-GL vs GLES render-path selection.
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_touch_controls.cpp -o test_touch_controls
+
+#include "game/TouchControls.h"
+#include "render/GlesProfile.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::platform;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static bool near(float a, float b) { return std::fabs(a - b) < 1e-4f; }
+
+int main() {
+    // 1. Joystick math: direction + deadzone + clamp, screen-up = forward (-Z).
+    {
+        game::GameInput right = joystickInput(100, 100, 300, 100, 100.0f); // far right
+        CHECK(near(right.moveX, 1.0f) && near(right.moveZ, 0.0f));
+
+        game::GameInput up = joystickInput(100, 100, 100, 0, 100.0f); // finger up the screen
+        CHECK(near(up.moveZ, -1.0f) && near(up.moveX, 0.0f));
+
+        game::GameInput dead = joystickInput(100, 100, 110, 100, 100.0f); // inside deadzone
+        CHECK(near(dead.moveX, 0.0f) && near(dead.moveZ, 0.0f));
+
+        // Partial deflection is between 0 and 1.
+        game::GameInput part = joystickInput(0, 0, 50, 0, 100.0f);
+        CHECK(part.moveX > 0.0f && part.moveX < 1.0f);
+    }
+
+    // 2. Floating joystick recentres on touch-down and clears on lift.
+    {
+        FloatingJoystick js(120.0f, 0.15f);
+        CHECK(!js.active());
+        js.onTouchDown(200, 200);
+        CHECK(js.active() && near(js.originX(), 200) && near(js.originY(), 200));
+        CHECK(js.onTouchMove(320, 200).moveX > 0.0f); // drag right
+        js.onTouchUp();
+        CHECK(!js.active());
+        CHECK(near(js.onTouchMove(320, 200).moveX, 0.0f)); // inactive -> no input
+
+        // A fixed stick keeps its origin and stays active across lifts.
+        FloatingJoystick fixed(100.0f);
+        fixed.setFixedOrigin(50, 50);
+        fixed.onTouchUp();
+        CHECK(fixed.active());
+    }
+
+    // 3. Touch buttons: hit test and multi-touch press.
+    {
+        TouchButton b{10, 10, 80, 40};
+        CHECK(b.contains(20, 20));
+        CHECK(!b.contains(200, 200));
+        std::vector<TouchPoint> touches = {{5, 5, true, 0}, {50, 25, true, 1}};
+        CHECK(b.pressedBy(touches)); // second finger lands on it
+    }
+
+    // 4. Button latch fires exactly once per press.
+    {
+        ButtonLatch latch;
+        CHECK(!latch.update(false));
+        CHECK(latch.update(true));  // rising edge
+        CHECK(!latch.update(true)); // held -> no repeat
+        CHECK(!latch.update(false));
+        CHECK(latch.update(true));  // fires again on a new press
+    }
+
+    // 5. TouchControls: a capture-button tap fires once and does not drive the stick; a
+    //    finger elsewhere drives movement.
+    {
+        TouchControls tc;
+        tc.capture = TouchButton{0, 0, 80, 80};
+
+        // Tap the capture button.
+        TouchControls::Frame f1 = tc.resolve({{40, 40, true, 0}});
+        CHECK(f1.captureTapped);
+        CHECK(near(f1.input.moveX, 0.0f) && near(f1.input.moveZ, 0.0f)); // button != movement
+        TouchControls::Frame f2 = tc.resolve({{40, 40, true, 0}});       // still held
+        CHECK(!f2.captureTapped);
+
+        // Movement: first frame sets the origin, second frame drags right.
+        tc.resolve({{400, 300, true, 0}});
+        TouchControls::Frame m = tc.resolve({{500, 300, true, 0}});
+        CHECK(m.input.moveX > 0.0f && near(m.input.moveZ, 0.0f));
+        CHECK(!m.captureTapped);
+    }
+
+    // 6. Render-path selection: desktop GL vs GLES3 vs GLES2, with the right shader dialect.
+    {
+        const render::RenderCaps desktop = render::selectRenderCaps(false);
+        CHECK(desktop.profile == render::GlProfile::DesktopGL && !desktop.es);
+        CHECK(desktop.instancing && desktop.floatTextures);
+        CHECK(render::shaderVersionDirective(desktop) == "#version 330 core");
+
+        const render::RenderCaps es3 = render::selectRenderCaps(true, 3);
+        CHECK(es3.profile == render::GlProfile::GLES3 && es3.es);
+        CHECK(es3.instancing);
+        CHECK(render::shaderVersionDirective(es3) == "#version 300 es");
+
+        const render::RenderCaps es2 = render::selectRenderCaps(true, 2);
+        CHECK(es2.profile == render::GlProfile::GLES2 && es2.es);
+        CHECK(!es2.instancing && !es2.floatTextures); // GLES2 renderer falls back
+        CHECK(render::shaderVersionDirective(es2) == "#version 100");
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_touch_controls: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_touch_controls: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Toward #367. Delivers the **portable, headless-testable half** of the mobile target - the part the issue explicitly asks to keep testable ("Keep the core headless-testable; only the shell/GLES glue is platform-specific"). The Android/NDK shell (EGL surface, lifecycle, camera) stays platform-specific and is documented as remaining work, since a headless CI here cannot build or verify an APK.

- **`src/game/TouchControls.h`** - a virtual movement joystick (fixed or floating) that maps a finger drag to the same normalized `game::GameInput` as keyboard and gamepad (radial deadzone, clamp to full deflection, screen-up = forward), plus rectangular touch buttons with single-fire **edge detection** for the capture entry point. Composed into a `TouchControls` layout that resolves a frame's touches into movement plus a capture tap (a finger on the button does not drive the stick).
- **`src/render/GlesProfile.h`** - selects the desktop-GL vs GLES3/GLES2 render path and the GLSL dialect (`#version 330 core` / `300 es` / `100`) from the runtime target, so shared render code branches on capabilities rather than platform (GLES2 falls back off instancing and float textures).
- **`docs/MOBILE_SHELL.md`** - records the clean boundary: what is portable and tested here vs. the Android shell (EGL context, `android_native_app_glue` lifecycle, `AMotionEvent` delivery, Gradle APK) a device toolchain builds.

## Testing

`tests/test_touch_controls.cpp` (registered in the headless suite) covers the joystick direction/deadzone/clamp math, the floating-stick recentre-and-clear, touch-button hit testing and multi-touch press, the button latch firing exactly once per press, the capture-tap-vs-movement split, and desktop/GLES3/GLES2 render-path selection with the correct shader dialect.

Passes standalone (`g++ -std=c++17 -I src`), via CMake/ctest, and clean under `-fsanitize=address,undefined`.

## Scope note

This intentionally does **not** close #367: the on-device APK build and emulator verification need an Android toolchain outside this CI and remain the shell work tracked by the issue. The shared game core continues to pass its headless tests unchanged, and the capture -> play -> share loop it depends on (capture pipeline + #317 share codes) is already portable and tested.

The macOS build job is expected to fail (pre-existing, tracked in #338) and is `continue-on-error`; all other gates should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_