### PR TITLE
Platform: fix sol2 optional under clang-21 to restore macOS build (#366)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,24 @@ if(NOT sol2_POPULATED)
   FetchContent_Populate(sol2)
 endif()
 
+# clang-21 (macOS / Xcode 26) rejects sol2 v3.3.0's bundled optional<T&>::emplace: it calls a
+# non-existent construct() and is missing its return (#338 / #366). That member is only
+# instantiated under libc++/clang-21 - Linux and Windows compile the unpatched header fine -
+# but the fix (rebind the reference exactly as the type's own operator= does) is valid C++ on
+# every toolchain, so patch it unconditionally in the fetched header. The regex targets only
+# the reference specialization (its construct() call is immediately followed by the closing
+# brace, unlike the primary template's, which returns value()), and is idempotent: once
+# rewritten the pattern no longer matches, so re-running configure is a no-op.
+set(_sol2_optional "${sol2_SOURCE_DIR}/include/sol/optional_implementation.hpp")
+if(EXISTS "${_sol2_optional}")
+  file(READ "${_sol2_optional}" _sol2_optional_src)
+  string(REGEX REPLACE
+    "this->construct\\(std::forward<Args>\\(args\\)\\.\\.\\.\\);([ \t\r\n]*)}"
+    "this->operator=(std::forward<Args>(args)...); return *m_value;\\1}"
+    _sol2_optional_src "${_sol2_optional_src}")
+  file(WRITE "${_sol2_optional}" "${_sol2_optional_src}")
+endif()
+
 # OpenAL for 3D Audio
 find_package(PkgConfig)
 if(PkgConfig_FOUND)


### PR DESCRIPTION
## Summary

Toward #366 / resolves the #338 blocker. macOS CI has been informational (`continue-on-error`) because Xcode 26's **clang-21** fails to compile **sol2 v3.3.0**. The exact and *only* remaining macOS error, from the build log, is:

```
sol2-src/include/sol/optional_implementation.hpp:2194:10: error:
  no member named 'construct' in 'optional<T &>'
   2194 |    this->construct(std::forward<Args>(args)...);
```

sol2's bundled `optional<T&>::emplace` calls a non-existent `construct()` and is also missing its `return`. That member is only instantiated under libc++/clang-21, which is why **Linux and Windows compile the unpatched header fine** but macOS breaks building the scripting layer.

## Fix

Patch the fetched sol2 header at configure time to rebind the reference exactly as the type's own `operator=` already does (`m_value = std::addressof(...)`, then return the referee) - valid C++ on every toolchain. The `string(REGEX REPLACE)` targets **only the reference specialization**: its `construct(...)` call is immediately followed by the closing brace, unlike the primary `optional<T>` template's, which is followed by `return value();`. It is idempotent - once rewritten the pattern no longer matches, so re-running configure is a no-op.

## Testing

Verified locally on Linux:
- configuring patches **only** line 2194 (the reference `emplace`); the primary template at line 1284 is untouched;
- `test_scripting` still builds and passes with the patched header.

The fix can't be compiled on macOS from this environment, so this PR **keeps `continue-on-error` for now** and lets the macOS CI job here confirm the toolchain builds green. Once this PR's macOS build is green, a follow-up flips macOS to a required gate and closes #338 (the second half of #366). All Linux/Windows gates should stay green - the patched code is valid on those toolchains and that emplace path is not even instantiated there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_