### PR TITLE
Polish: localization scaffold and string table (#373)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,6 +1089,11 @@ add_executable(test_benchmark
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_benchmark.cpp
 )
 
+# Localization: string table, fallback, formatting, completeness (#373) - header-only.
+add_executable(test_localization
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_localization.cpp
+)
+
 # Structured logging system (Milestone 9 / #63) - header-only.
 add_executable(test_log_system
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_log_system.cpp
@@ -1275,6 +1280,7 @@ set(HEADLESS_TESTS
     test_level_gen
     test_level_review
     test_level_share
+    test_localization
     test_log_system
     test_menu_system
     test_multi_room

--- a/src/game/Localization.h
+++ b/src/game/Localization.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "core/Settings.h" // Settings (locale persistence, #61)
+
+#include <map>
+#include <string>
+#include <vector>
+
+/**
+ * @file Localization.h
+ * @brief String-table localization with fallback, formatting, and a completeness check (#373).
+ *
+ * Player-facing text was hard-coded at its use sites; this externalizes it. A StringTable maps
+ * keys to localized strings; a Localizer holds the default (English) table plus additional
+ * locales, resolves a key against the active locale with fallback to the default (and finally
+ * the key itself, so nothing renders blank), formats parameterized strings ({name}/{count}),
+ * switches locale at runtime, and persists the choice through Settings. A completeness check
+ * reports keys missing from a locale or orphaned in it, so translation gaps are caught in CI.
+ *
+ * Header-only, std only (plus the header-only Settings). UI code calls loc.get(...) /
+ * loc.format(...) instead of embedding literals.
+ */
+namespace IKore {
+namespace game {
+
+/// A single locale's key -> string map.
+struct StringTable {
+    std::string locale{"en"};
+    std::map<std::string, std::string> entries;
+
+    void set(const std::string& key, const std::string& value) { entries[key] = value; }
+    bool has(const std::string& key) const { return entries.count(key) != 0; }
+    std::string get(const std::string& key) const {
+        auto it = entries.find(key);
+        return it == entries.end() ? std::string() : it->second;
+    }
+};
+
+class Localizer {
+public:
+    /// The default locale every lookup falls back to (usually English).
+    void setDefault(const StringTable& table) {
+        m_default = table;
+        m_locales[table.locale] = table;
+        if (m_current.empty()) m_current = table.locale;
+    }
+    /// Register (or replace) a locale.
+    void addLocale(const StringTable& table) { m_locales[table.locale] = table; }
+
+    bool hasLocale(const std::string& locale) const { return m_locales.count(locale) != 0; }
+    const std::string& currentLocale() const { return m_current; }
+
+    /// Switch the active locale at runtime; a no-op (returns false) for an unknown locale.
+    bool setLocale(const std::string& locale) {
+        if (!hasLocale(locale)) return false;
+        m_current = locale;
+        return true;
+    }
+
+    /// Resolve @p key against the active locale, then the default locale, then the key itself
+    /// (so a missing string is visible, never blank).
+    std::string get(const std::string& key) const {
+        auto cur = m_locales.find(m_current);
+        if (cur != m_locales.end() && cur->second.has(key)) return cur->second.get(key);
+        if (m_default.has(key)) return m_default.get(key);
+        return key;
+    }
+
+    /// get() with {name} placeholders substituted from @p args. Unreferenced placeholders are
+    /// left as-is, and a placeholder with no matching arg is left intact.
+    std::string format(const std::string& key, const std::map<std::string, std::string>& args) const {
+        std::string s = get(key);
+        for (const auto& kv : args) {
+            const std::string token = "{" + kv.first + "}";
+            std::size_t pos = 0;
+            while ((pos = s.find(token, pos)) != std::string::npos) {
+                s.replace(pos, token.size(), kv.second);
+                pos += kv.second.size();
+            }
+        }
+        return s;
+    }
+
+    // --- Completeness ---------------------------------------------------------
+
+    /// Keys present in the default table but missing from @p locale (untranslated).
+    std::vector<std::string> missingKeys(const std::string& locale) const {
+        std::vector<std::string> out;
+        auto it = m_locales.find(locale);
+        if (it == m_locales.end()) return out;
+        for (const auto& kv : m_default.entries)
+            if (!it->second.has(kv.first)) out.push_back(kv.first);
+        return out;
+    }
+
+    /// Keys present in @p locale but not in the default table (orphaned / stale).
+    std::vector<std::string> orphanKeys(const std::string& locale) const {
+        std::vector<std::string> out;
+        auto it = m_locales.find(locale);
+        if (it == m_locales.end()) return out;
+        for (const auto& kv : it->second.entries)
+            if (!m_default.has(kv.first)) out.push_back(kv.first);
+        return out;
+    }
+
+    /// True if @p locale defines every default key and adds none of its own.
+    bool isComplete(const std::string& locale) const {
+        return missingKeys(locale).empty() && orphanKeys(locale).empty();
+    }
+
+    // --- Settings persistence (#61) ------------------------------------------
+
+    void saveLocale(Settings& settings, const std::string& key = "ui.locale") const {
+        settings.setString(key, m_current);
+    }
+    /// Load and apply a persisted locale; falls back to the current locale if unknown.
+    void loadLocale(const Settings& settings, const std::string& key = "ui.locale") {
+        const std::string stored = settings.getString(key, m_current);
+        setLocale(stored); // no-op if the stored locale is not registered
+    }
+
+private:
+    StringTable m_default;
+    std::map<std::string, StringTable> m_locales;
+    std::string m_current;
+};
+
+/// The default English UI strings the HUD/menus render through (keys, not literals).
+inline StringTable defaultUiStrings() {
+    StringTable t;
+    t.locale = "en";
+    t.set("hud.coins", "Coins: {count}");
+    t.set("hud.score", "Score: {score}");
+    t.set("hud.keys", "Keys: {count}");
+    t.set("menu.play", "Play");
+    t.set("menu.settings", "Settings");
+    t.set("menu.quit", "Quit");
+    t.set("prompt.win", "You win!");
+    t.set("prompt.lose", "You lose");
+    t.set("prompt.pause", "Paused");
+    return t;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_localization.cpp
+++ b/tests/test_localization.cpp
@@ -1,0 +1,104 @@
+// Localization scaffold and string table - issue #373.
+//
+// Verifies: lookups resolve through the active locale, a missing key falls back to the
+// default locale (and finally to the key itself), parameterized strings format from named
+// args, the completeness check flags missing and orphaned keys, locale switches at runtime,
+// and the choice persists via settings. Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_localization.cpp -o test_localization
+
+#include "game/Localization.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static bool contains(const std::vector<std::string>& v, const std::string& s) {
+    return std::find(v.begin(), v.end(), s) != v.end();
+}
+
+int main() {
+    Localizer loc;
+    loc.setDefault(defaultUiStrings()); // en, current locale
+
+    // A Spanish locale: some keys translated, one default key missing, one orphan key added.
+    StringTable es;
+    es.locale = "es";
+    es.set("menu.play", "Jugar");
+    es.set("menu.settings", "Opciones");
+    es.set("prompt.win", "Ganaste");
+    es.set("hud.coins", "Monedas: {count}");
+    es.set("es.only", "solo"); // orphan: not in the default table
+    // (deliberately omits menu.quit, prompt.lose, etc.)
+    loc.addLocale(es);
+
+    // 1. Lookups resolve in the active locale (default = en to start).
+    CHECK(loc.currentLocale() == "en");
+    CHECK(loc.get("menu.play") == "Play");
+
+    // 2. Runtime switch changes resolution; unknown locale is a no-op.
+    CHECK(loc.setLocale("es"));
+    CHECK(loc.get("menu.play") == "Jugar");
+    CHECK(!loc.setLocale("de")); // not registered
+    CHECK(loc.currentLocale() == "es");
+
+    // 3. A key missing from the active locale falls back to the default; a key missing from
+    //    both falls back to itself (never blank).
+    CHECK(loc.get("menu.quit") == "Quit");                 // es lacks it -> en default
+    CHECK(loc.get("totally.unknown") == "totally.unknown"); // absent everywhere
+
+    // 4. Parameterized formatting substitutes named args.
+    CHECK(loc.format("hud.coins", {{"count", "7"}}) == "Monedas: 7");
+    loc.setLocale("en");
+    CHECK(loc.format("hud.coins", {{"count", "12"}}) == "Coins: 12");
+    // An unreferenced placeholder is left intact.
+    CHECK(loc.format("hud.score", {}) == "Score: {score}");
+
+    // 5. Completeness check flags the deliberate gaps.
+    const std::vector<std::string> missing = loc.missingKeys("es");
+    CHECK(contains(missing, "menu.quit"));   // untranslated
+    CHECK(contains(missing, "prompt.lose"));
+    const std::vector<std::string> orphans = loc.orphanKeys("es");
+    CHECK(contains(orphans, "es.only"));     // stale/extra
+    CHECK(!loc.isComplete("es"));
+
+    // A fully-mirrored locale is complete.
+    StringTable full;
+    full.locale = "fr";
+    for (const auto& kv : defaultUiStrings().entries) full.set(kv.first, kv.second + " (fr)");
+    loc.addLocale(full);
+    CHECK(loc.isComplete("fr"));
+    CHECK(loc.missingKeys("fr").empty() && loc.orphanKeys("fr").empty());
+
+    // 6. Locale selection persists through settings.
+    loc.setLocale("es");
+    Settings settings;
+    loc.saveLocale(settings);
+    Settings reloaded;
+    reloaded.load(settings.serialize());
+    Localizer loc2;
+    loc2.setDefault(defaultUiStrings());
+    loc2.addLocale(es);
+    loc2.loadLocale(reloaded);
+    CHECK(loc2.currentLocale() == "es");
+    CHECK(loc2.get("menu.play") == "Jugar");
+
+    if (g_failures == 0) {
+        std::printf("test_localization: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_localization: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #373. Adds `src/game/Localization.h` so player-facing text is externalized instead of hard-coded at its use sites.

- **`StringTable`** - a per-locale key -> string map.
- **`Localizer`** - holds the default (English) table plus additional locales and resolves a key against the **active locale, falling back to the default, then to the key itself**, so a missing string is visible and never blank.
- **`format()`** - substitutes `{name}` / `{count}` placeholders from named args; an unreferenced placeholder is left intact.
- **Runtime switch + persistence** - `setLocale()` switches language at runtime (no-op for an unknown locale); the choice persists through the `Settings` surface (#61).
- **Completeness check** - `missingKeys()` / `orphanKeys()` / `isComplete()` report untranslated and stale keys, so translation gaps trip CI.
- **`defaultUiStrings()`** - the English HUD/menu keys the UI renders through (keys, not literals).

## Testing

`tests/test_localization.cpp` (registered in the headless suite) covers lookup resolution, fallback to the default locale and to the key, parameterized formatting, runtime locale switching (including the unknown-locale no-op), the completeness check catching a deliberately missing key and an orphan key, a fully-mirrored locale reporting complete, and settings persistence round-trip.

Passes standalone (`g++ -std=c++17 -I src`), via CMake/ctest, and clean under `-fsanitize=address,undefined`.

The macOS build job is expected to fail (pre-existing, tracked in #338 / #366) and is `continue-on-error`; all other gates should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_