### PR TITLE
Polish: audio cues, volume mix, and accessibility options (#372)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -987,6 +987,11 @@ add_executable(test_audio_streaming
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_audio_streaming.cpp
 )
 
+# Audio cues, volume mix, colorblind-safe palettes and accessibility toggles (#372) - header-only.
+add_executable(test_audio_accessibility
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_audio_accessibility.cpp
+)
+
 # OGG/MP3 decode via vendored stb_vorbis + dr_mp3, against real embedded test
 # vectors (#258). Links the decoders' implementation TU.
 add_executable(test_audio_compressed
@@ -1229,6 +1234,7 @@ set(HEADLESS_TESTS
     test_ai_opponent
     test_app_shell
     test_archetype_ecs
+    test_audio_accessibility
     test_audio_decode
     test_audio_streaming
     test_benchmark

--- a/src/game/AudioAccessibility.h
+++ b/src/game/AudioAccessibility.h
@@ -1,0 +1,196 @@
+#pragma once
+
+#include "core/Settings.h"             // Settings (persistence, #61)
+#include "game/DungeonRenderData.h"    // RenderColor, renderColorForType
+#include "game/GameEvents.h"           // GameEventType (#353)
+
+#include <cmath>
+#include <map>
+#include <string>
+#include <vector>
+
+/**
+ * @file AudioAccessibility.h
+ * @brief Event-driven audio cues, a volume mix, and colorblind-safe palettes (issue #372).
+ *
+ * Cohesive sound and the accessibility options players expect at launch, kept as
+ * headless-testable logic (the audio subsystem #258 plays the chosen cues; the renderer
+ * applies the chosen palette):
+ *   - cueForEvent maps each game event (coin/key/door/switch/win/lose) to a sound cue.
+ *   - AudioMix gives independent master/music/SFX volumes and a mute, with an effective-gain
+ *     computation, persisted through Settings.
+ *   - Colorblind palettes recolor the feature types so they stay pairwise distinguishable
+ *     under deuteranopia / protanopia / tritanopia by a contrast metric (luminance plus the
+ *     chroma axis that deficiency preserves), not by hue alone.
+ *   - AccessibilityOptions carries reduced-motion and cue-subtitle toggles.
+ *
+ * Header-only, std only (plus the header-only Settings / render / event types).
+ */
+namespace IKore {
+namespace game {
+
+// --- Event -> sound cue ------------------------------------------------------
+
+enum class SoundCue { None, Coin, Key, Door, Switch, Hazard, Win, Lose, MenuMove, MenuSelect };
+
+/// The sound cue a game event triggers. A hazard death arrives as Lose (there is no separate
+/// hazard event); SoundCue::Hazard is available for a caller that detects the hazard touch.
+inline SoundCue cueForEvent(GameEventType type) {
+    switch (type) {
+        case GameEventType::CoinPickup: return SoundCue::Coin;
+        case GameEventType::KeyPickup: return SoundCue::Key;
+        case GameEventType::DoorOpen: return SoundCue::Door;
+        case GameEventType::SwitchToggle: return SoundCue::Switch;
+        case GameEventType::Win: return SoundCue::Win;
+        case GameEventType::Lose: return SoundCue::Lose;
+    }
+    return SoundCue::None;
+}
+
+inline const char* soundCueName(SoundCue cue) {
+    switch (cue) {
+        case SoundCue::Coin: return "coin";
+        case SoundCue::Key: return "key";
+        case SoundCue::Door: return "door";
+        case SoundCue::Switch: return "switch";
+        case SoundCue::Hazard: return "hazard";
+        case SoundCue::Win: return "win";
+        case SoundCue::Lose: return "lose";
+        case SoundCue::MenuMove: return "menu_move";
+        case SoundCue::MenuSelect: return "menu_select";
+        case SoundCue::None: return "none";
+    }
+    return "none";
+}
+
+// --- Volume mix --------------------------------------------------------------
+
+enum class AudioChannel { Master, Music, Sfx };
+
+/// Independent master / music / SFX gains plus a mute. effectiveGain multiplies the channel by
+/// the master (and is 0 when muted), so a mixer applies one number per channel.
+struct AudioMix {
+    float master{1.0f};
+    float music{0.8f};
+    float sfx{1.0f};
+    bool muted{false};
+
+    float channel(AudioChannel ch) const {
+        switch (ch) {
+            case AudioChannel::Master: return master;
+            case AudioChannel::Music: return music;
+            case AudioChannel::Sfx: return sfx;
+        }
+        return 1.0f;
+    }
+    float effectiveGain(AudioChannel ch) const {
+        if (muted) return 0.0f;
+        const float c = ch == AudioChannel::Master ? 1.0f : channel(ch);
+        return clamp01(master) * clamp01(c);
+    }
+
+    void save(Settings& s, const std::string& prefix = "audio.") const {
+        s.setFloat(prefix + "master", master);
+        s.setFloat(prefix + "music", music);
+        s.setFloat(prefix + "sfx", sfx);
+        s.setBool(prefix + "muted", muted);
+    }
+    void load(const Settings& s, const std::string& prefix = "audio.") {
+        master = s.getFloat(prefix + "master", master);
+        music = s.getFloat(prefix + "music", music);
+        sfx = s.getFloat(prefix + "sfx", sfx);
+        muted = s.getBool(prefix + "muted", muted);
+    }
+
+    static float clamp01(float v) { return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v); }
+};
+
+// --- Accessibility toggles ---------------------------------------------------
+
+struct AccessibilityOptions {
+    bool reducedMotion{false}; ///< suppress screen shake / large motion effects.
+    bool cueSubtitles{false};  ///< show a text label when a sound cue fires.
+
+    void save(Settings& s, const std::string& prefix = "a11y.") const {
+        s.setBool(prefix + "reduced_motion", reducedMotion);
+        s.setBool(prefix + "cue_subtitles", cueSubtitles);
+    }
+    void load(const Settings& s, const std::string& prefix = "a11y.") {
+        reducedMotion = s.getBool(prefix + "reduced_motion", reducedMotion);
+        cueSubtitles = s.getBool(prefix + "cue_subtitles", cueSubtitles);
+    }
+};
+
+// --- Colorblind-safe palettes -----------------------------------------------
+
+enum class ColorVisionMode { Default, Deuteranopia, Protanopia, Tritanopia };
+
+/// The feature types a level palette must keep distinguishable.
+inline const std::vector<std::string>& paletteTypes() {
+    static const std::vector<std::string> t = {"wall", "player", "enemy", "coin",
+                                               "exit", "key", "switch", "hazard"};
+    return t;
+}
+
+inline float luminance(const RenderColor& c) { return 0.299f * c.r + 0.587f * c.g + 0.114f * c.b; }
+
+/// Perceived separation of two colors for @p mode. Luminance is preserved under every
+/// deficiency, so it is always weighted; the second term is the chroma axis the deficiency
+/// still resolves (blue-yellow for red-green deficiencies, red-green for blue deficiency).
+/// Default uses the full RGB distance.
+inline float colorContrast(const RenderColor& a, const RenderColor& b, ColorVisionMode mode) {
+    const float dL = luminance(a) - luminance(b);
+    if (mode == ColorVisionMode::Default) {
+        const float dr = a.r - b.r, dg = a.g - b.g, db = a.b - b.b;
+        return std::sqrt(dr * dr + dg * dg + db * db);
+    }
+    float dC = 0.0f;
+    if (mode == ColorVisionMode::Tritanopia) {
+        dC = (a.r - a.g) - (b.r - b.g); // red-green axis
+    } else {
+        // deuteranopia / protanopia: blue-yellow axis
+        dC = (a.b - (a.r + a.g) * 0.5f) - (b.b - (b.r + b.g) * 0.5f);
+    }
+    return std::sqrt((2.0f * dL) * (2.0f * dL) + dC * dC);
+}
+
+/// A recoloring of the feature types for a given vision mode.
+struct AccessibilityPalette {
+    ColorVisionMode mode{ColorVisionMode::Default};
+    std::map<std::string, RenderColor> overrides;
+
+    RenderColor colorFor(const std::string& type) const {
+        auto it = overrides.find(type);
+        return it != overrides.end() ? it->second : renderColorForType(type);
+    }
+    /// Smallest pairwise contrast among the core feature types (higher = more distinguishable).
+    float minPairwiseContrast() const {
+        const std::vector<std::string>& types = paletteTypes();
+        float m = 1e9f;
+        for (std::size_t i = 0; i < types.size(); ++i)
+            for (std::size_t j = i + 1; j < types.size(); ++j)
+                m = std::min(m, colorContrast(colorFor(types[i]), colorFor(types[j]), mode));
+        return m;
+    }
+};
+
+/// A colorblind-safe palette: the feature types are spread across luminance (which survives
+/// every deficiency) and given distinct hues, so they stay separable by hue for normal vision
+/// and by brightness otherwise.
+inline AccessibilityPalette accessibilityPalette(ColorVisionMode mode) {
+    AccessibilityPalette p;
+    p.mode = mode;
+    // Luminance-ordered from dark to light, with distinct hues.
+    p.overrides["enemy"]  = {0.45f, 0.05f, 0.05f}; // darkest - deep red
+    p.overrides["hazard"] = {0.70f, 0.25f, 0.05f}; // dark orange
+    p.overrides["wall"]   = {0.40f, 0.40f, 0.42f}; // mid gray
+    p.overrides["exit"]   = {0.15f, 0.55f, 0.85f}; // blue
+    p.overrides["switch"] = {0.20f, 0.75f, 0.70f}; // teal
+    p.overrides["key"]    = {0.90f, 0.55f, 0.85f}; // light magenta
+    p.overrides["player"] = {0.55f, 0.90f, 0.55f}; // light green
+    p.overrides["coin"]   = {0.98f, 0.92f, 0.35f}; // brightest - yellow
+    return p;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_audio_accessibility.cpp
+++ b/tests/test_audio_accessibility.cpp
@@ -1,0 +1,113 @@
+// Audio cues, volume mix, and accessibility palettes - issue #372.
+//
+// Verifies each game event maps to the expected sound cue, the volume/mute mix computes and
+// persists, accessibility toggles persist, and every colorblind palette keeps all feature
+// types pairwise-distinguishable by a contrast metric (where the raw engine palette does not).
+// Pure std + header-only:
+//   g++ -std=c++17 -I src tests/test_audio_accessibility.cpp -o test_audio_accessibility
+
+#include "game/AudioAccessibility.h"
+
+#include <cstdio>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+static bool near(float a, float b) { return std::fabs(a - b) < 1e-4f; }
+
+// The accessibility contrast floor: below the accessible palettes' observed min (~0.24) and
+// well above the raw engine palette's (~0.04-0.07), so it asserts colorblind-safety.
+static constexpr float kContrastFloor = 0.15f;
+
+int main() {
+    // 1. Each game event maps to its sound cue.
+    {
+        CHECK(cueForEvent(GameEventType::CoinPickup) == SoundCue::Coin);
+        CHECK(cueForEvent(GameEventType::KeyPickup) == SoundCue::Key);
+        CHECK(cueForEvent(GameEventType::DoorOpen) == SoundCue::Door);
+        CHECK(cueForEvent(GameEventType::SwitchToggle) == SoundCue::Switch);
+        CHECK(cueForEvent(GameEventType::Win) == SoundCue::Win);
+        CHECK(cueForEvent(GameEventType::Lose) == SoundCue::Lose);
+        CHECK(std::string(soundCueName(SoundCue::Coin)) == "coin");
+    }
+
+    // 2. Volume mix: effective gain folds in master and mute; it persists via settings.
+    {
+        AudioMix mix;
+        mix.master = 0.5f;
+        mix.music = 0.8f;
+        mix.sfx = 1.0f;
+        CHECK(near(mix.effectiveGain(AudioChannel::Sfx), 0.5f));    // master * sfx
+        CHECK(near(mix.effectiveGain(AudioChannel::Music), 0.4f));  // master * music
+        CHECK(near(mix.effectiveGain(AudioChannel::Master), 0.5f));
+        mix.muted = true;
+        CHECK(near(mix.effectiveGain(AudioChannel::Sfx), 0.0f));    // mute overrides
+        mix.muted = false;
+
+        Settings s;
+        mix.save(s);
+        Settings reloaded;
+        reloaded.load(s.serialize());
+        AudioMix mix2;
+        mix2.load(reloaded);
+        CHECK(near(mix2.master, 0.5f) && near(mix2.music, 0.8f) && near(mix2.sfx, 1.0f));
+        CHECK(mix2.muted == false);
+    }
+
+    // 3. Accessibility toggles persist.
+    {
+        AccessibilityOptions opt;
+        opt.reducedMotion = true;
+        opt.cueSubtitles = true;
+        Settings s;
+        opt.save(s);
+        Settings reloaded;
+        reloaded.load(s.serialize());
+        AccessibilityOptions opt2;
+        opt2.load(reloaded);
+        CHECK(opt2.reducedMotion && opt2.cueSubtitles);
+    }
+
+    // 4. Every colorblind palette keeps all feature types pairwise-distinguishable.
+    {
+        const ColorVisionMode modes[] = {ColorVisionMode::Default, ColorVisionMode::Deuteranopia,
+                                         ColorVisionMode::Protanopia, ColorVisionMode::Tritanopia};
+        for (ColorVisionMode mode : modes) {
+            const AccessibilityPalette p = accessibilityPalette(mode);
+            const float m = p.minPairwiseContrast();
+            std::printf("[info] palette mode %d: min pairwise contrast %.3f\n",
+                        static_cast<int>(mode), m);
+            CHECK(m >= kContrastFloor);
+        }
+        // colorFor falls back to the engine palette for a type the palette does not override.
+        const AccessibilityPalette p = accessibilityPalette(ColorVisionMode::Deuteranopia);
+        const RenderColor coin = p.colorFor("coin");
+        const RenderColor player = p.colorFor("player");
+        CHECK(colorContrast(coin, player, ColorVisionMode::Deuteranopia) >= kContrastFloor);
+    }
+
+    // 5. The metric has teeth: the raw engine palette (no accessibility overrides) fails the
+    //    colorblind floor - which is exactly why the accessible palette exists.
+    {
+        AccessibilityPalette raw; // empty overrides -> renderColorForType for every type
+        raw.mode = ColorVisionMode::Deuteranopia;
+        CHECK(raw.minPairwiseContrast() < kContrastFloor);
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_audio_accessibility: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_audio_accessibility: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Closes #372. Adds `src/game/AudioAccessibility.h`, the headless-testable half of launch audio and accessibility (the audio subsystem #258 plays the chosen cues; the renderer applies the chosen palette).

- **Event -> cue** - `cueForEvent` maps each game event (coin/key/door/switch/win/lose) to a `SoundCue`; the enum also covers hazard and menu cues.
- **Volume mix** - `AudioMix` gives independent master/music/SFX volumes and a mute, with an effective-gain computation (master-folded, zero when muted), persisted through `Settings`.
- **Colorblind-safe palettes** - recolor the feature types so they stay **pairwise distinguishable** under deuteranopia / protanopia / tritanopia by a contrast metric: **luminance** (preserved under every deficiency) plus the chroma axis the deficiency still resolves - not hue alone. The types are spread across luminance and given distinct hues.
- **Accessibility toggles** - `AccessibilityOptions` carries reduced-motion and cue-subtitle flags, persisted.

## Testing

`tests/test_audio_accessibility.cpp` (registered in the headless suite) checks the event-to-cue mapping, effective gain and mute, settings persistence for both the mix and the toggles, and that **every shipped palette clears the colorblind contrast floor (~0.24-0.28 observed) while the raw engine palette does not (~0.04-0.07)** - so the metric has teeth and proves the accessible palettes are needed.

Passes standalone (`g++ -std=c++17 -I src`), via CMake/ctest, and clean under `-fsanitize=address,undefined`.

The macOS build job is expected to fail (pre-existing, tracked in #338 / #366) and is `continue-on-error`; all other gates should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_