### PR TITLE
Balance: seeded determinism fuzzing at scale (#374)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,6 +672,11 @@ add_executable(test_desync_recovery
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_desync_recovery.cpp
 )
 
+# Seeded determinism fuzzer over the sim with minimal-repro shrinking (#374) - header-only.
+add_executable(test_determinism_fuzz
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_determinism_fuzz.cpp
+)
+
 # Renderer-agnostic drawing->scene converter (Milestone 15 / #162) - header-only.
 add_executable(test_doodle_scene
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_doodle_scene.cpp
@@ -1263,6 +1268,7 @@ set(HEADLESS_TESTS
     test_desync_features
     test_desync_recovery
     test_determinism
+    test_determinism_fuzz
     test_doodle_library
     test_doodle_rollback
     test_doodle_scene

--- a/src/game/DeterminismFuzz.h
+++ b/src/game/DeterminismFuzz.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include "game/DungeonGame.h" // DungeonGame, GameInput, loadGame
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+/**
+ * @file DeterminismFuzz.h
+ * @brief Seeded determinism fuzzing over the sim, with minimal-repro shrinking (issue #374).
+ *
+ * The sim/rollback is meant to be bit-reproducible; a fuzzer proves it at scale and catches
+ * rare divergences. This drives the deterministic DungeonGame loop with seeded random input
+ * streams and digests each trajectory, so a large seeded batch can be re-simulated and
+ * checked for identical digests. When two implementations disagree (a real nondeterminism
+ * bug, or an injected one in a test), fuzzDivergence scans ascending to report the minimal
+ * failing seed, and shrinkSteps reduces it to the shortest failing input prefix - a minimal
+ * repro. Pure std + the header-only game core; header-only.
+ */
+namespace IKore {
+namespace game {
+
+namespace detail {
+
+/// A small, portable LCG so seeded streams are identical on every platform.
+struct FuzzLcg {
+    std::uint64_t state;
+    explicit FuzzLcg(std::uint64_t seed) : state(seed * 6364136223846793005ULL + 1442695040888963407ULL) {}
+    std::uint32_t next() {
+        state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+        return static_cast<std::uint32_t>(state >> 32);
+    }
+    /// A move component in {-1, 0, +1}.
+    float axis() { return static_cast<float>(static_cast<int>(next() % 3u) - 1); }
+};
+
+/// Fold a float into a running FNV-1a digest, quantized so tiny float noise does not alias
+/// but a real state difference does.
+inline void hashFloat(std::uint64_t& h, float f) {
+    const std::int64_t q = static_cast<std::int64_t>(f * 1024.0f + (f >= 0 ? 0.5f : -0.5f));
+    for (int b = 0; b < 8; ++b) {
+        h ^= static_cast<std::uint64_t>((q >> (b * 8)) & 0xff);
+        h *= 1099511628211ULL;
+    }
+}
+
+} // namespace detail
+
+/// A seeded random input stream of @p steps frames.
+inline std::vector<GameInput> randomInputStream(std::uint64_t seed, int steps) {
+    detail::FuzzLcg rng(seed);
+    std::vector<GameInput> in;
+    in.reserve(static_cast<std::size_t>(steps));
+    for (int i = 0; i < steps; ++i) in.push_back(GameInput{rng.axis(), rng.axis()});
+    return in;
+}
+
+/// Digest of running @p base for @p steps under the seeded input stream. Folds the player
+/// position, coin count, and status each frame, so any trajectory difference changes it.
+inline std::uint64_t simulateDigest(const DungeonGame& base, std::uint64_t seed, int steps,
+                                    float dt = 1.0f / 60.0f) {
+    DungeonGame game = base;
+    const std::vector<GameInput> in = randomInputStream(seed, steps);
+    std::uint64_t h = 1469598103934665603ULL; // FNV-1a offset basis
+    for (int i = 0; i < steps; ++i) {
+        game.update(in[static_cast<std::size_t>(i)], dt);
+        detail::hashFloat(h, game.playerPosition.x);
+        detail::hashFloat(h, game.playerPosition.z);
+        h ^= static_cast<std::uint64_t>(game.coinsCollected);
+        h *= 1099511628211ULL;
+        h ^= static_cast<std::uint64_t>(game.status);
+        h *= 1099511628211ULL;
+    }
+    return h;
+}
+
+struct FuzzReport {
+    int seedsChecked{0};
+    bool deterministic{true}; ///< every seed re-simulated to an identical digest.
+};
+
+/// Re-simulate @p base across @p nSeeds seeds and confirm each run reproduces its digest.
+inline FuzzReport fuzzDeterminism(const DungeonGame& base, std::uint64_t nSeeds, int steps,
+                                  float dt = 1.0f / 60.0f) {
+    FuzzReport r;
+    for (std::uint64_t s = 0; s < nSeeds; ++s) {
+        ++r.seedsChecked;
+        if (simulateDigest(base, s, steps, dt) != simulateDigest(base, s, steps, dt)) {
+            r.deterministic = false;
+            break;
+        }
+    }
+    return r;
+}
+
+/// A digest of one sim variant for a (seed, steps) pair.
+using SimDigestFn = std::function<std::uint64_t(std::uint64_t seed, int steps)>;
+
+struct DivergenceReport {
+    bool found{false};
+    std::uint64_t minimalSeed{0}; ///< smallest seed at which the two variants disagree.
+    int minimalSteps{0};          ///< shortest input prefix that still reproduces it.
+    int seedsChecked{0};
+};
+
+/// The shortest step prefix at @p seed for which @p a and @p b still disagree (they must
+/// disagree at @p maxSteps). A linear scan from 1 - the divergence's first appearance.
+inline int shrinkSteps(const SimDigestFn& a, const SimDigestFn& b, std::uint64_t seed, int maxSteps) {
+    for (int s = 1; s <= maxSteps; ++s)
+        if (a(seed, s) != b(seed, s)) return s;
+    return maxSteps;
+}
+
+/// Scan seeds ascending for the first (hence minimal) seed where @p a and @p b diverge, then
+/// shrink to the shortest failing input prefix. deterministic implementations report found==false.
+inline DivergenceReport fuzzDivergence(const SimDigestFn& a, const SimDigestFn& b,
+                                       std::uint64_t nSeeds, int steps) {
+    DivergenceReport r;
+    for (std::uint64_t s = 0; s < nSeeds; ++s) {
+        ++r.seedsChecked;
+        if (a(s, steps) != b(s, steps)) {
+            r.found = true;
+            r.minimalSeed = s;
+            r.minimalSteps = shrinkSteps(a, b, s, steps);
+            return r;
+        }
+    }
+    return r;
+}
+
+} // namespace game
+} // namespace IKore

--- a/tests/test_determinism_fuzz.cpp
+++ b/tests/test_determinism_fuzz.cpp
@@ -1,0 +1,107 @@
+// Determinism fuzzing at scale - issue #374.
+//
+// Drives the deterministic sim with large batches of seeded random input streams and asserts
+// every run re-simulates to an identical digest; then injects a nondeterminism bug and shows
+// the fuzzer catches it and reports a minimal repro (smallest seed + shortest failing input
+// prefix). Pure std + the header-only game core:
+//   g++ -std=c++17 -I src tests/test_determinism_fuzz.cpp -o test_determinism_fuzz
+
+#include "game/DeterminismFuzz.h"
+
+#include <cstdio>
+#include <set>
+#include <vector>
+
+using namespace IKore;
+using namespace IKore::game;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                               \
+    do {                                                          \
+        if (!(cond)) {                                            \
+            std::printf("FAIL (line %d): %s\n", __LINE__, #cond); \
+            ++g_failures;                                         \
+        }                                                         \
+    } while (0)
+
+// A representative playable arena: a walled box with coins, so random input produces varied,
+// wall-colliding trajectories.
+static DungeonGame arena() {
+    SceneDescription s;
+    auto wall = [&](float cx, float cz, float sx, float sz) {
+        world::Box b;
+        b.center = ecs::Vec3{cx, 0.0f, cz};
+        b.size = ecs::Vec3{sx, 3.0f, sz};
+        b.yaw = 0.0f;
+        s.wallBoxes.push_back(b);
+    };
+    wall(0, 6, 12, 0.5f);
+    wall(0, -6, 12, 0.5f);
+    wall(6, 0, 0.5f, 12);
+    wall(-6, 0, 0.5f, 12);
+    wall(2, 2, 1, 1); // interior obstacles
+    wall(-3, -1, 1, 1);
+    s.spawns.push_back(EntitySpawn{"player", ecs::Vec3{0, 0, 0}, 0.0f});
+    s.spawns.push_back(EntitySpawn{"coin", ecs::Vec3{3, 3, 0}, 0.0f});
+    s.spawns.push_back(EntitySpawn{"coin", ecs::Vec3{-3, 3, 0}, 0.0f});
+    s.spawns.push_back(EntitySpawn{"exit", ecs::Vec3{4, -4, 0}, 0.0f});
+    return loadGame(s);
+}
+
+int main() {
+    const DungeonGame base = arena();
+
+    // 1. The digest is stable and responds to the seed (the sim actually varies with input).
+    {
+        CHECK(simulateDigest(base, 42, 200) == simulateDigest(base, 42, 200));
+        std::set<std::uint64_t> digests;
+        for (std::uint64_t s = 0; s < 10; ++s) digests.insert(simulateDigest(base, s, 200));
+        CHECK(digests.size() >= 5); // distinct seeds -> mostly distinct trajectories
+    }
+
+    // 2. A large seeded batch re-simulates to identical digests (determinism at scale).
+    {
+        const FuzzReport r = fuzzDeterminism(base, /*nSeeds=*/500, /*steps=*/300);
+        std::printf("[info] fuzzDeterminism: %d seeds checked, deterministic=%d\n", r.seedsChecked,
+                    r.deterministic ? 1 : 0);
+        CHECK(r.seedsChecked == 500);
+        CHECK(r.deterministic);
+    }
+
+    // 3. A deterministic pair never diverges (no false positive).
+    {
+        const SimDigestFn ref = [&](std::uint64_t seed, int steps) {
+            return simulateDigest(base, seed, steps);
+        };
+        const DivergenceReport r = fuzzDivergence(ref, ref, 500, 300);
+        CHECK(!r.found);
+    }
+
+    // 4. An injected nondeterminism is caught with a minimal repro (smallest seed + shortest
+    //    failing input prefix). The bug perturbs only seeds divisible by 13 (>0), and only
+    //    once the trajectory reaches 5 steps.
+    {
+        const SimDigestFn ref = [&](std::uint64_t seed, int steps) {
+            return simulateDigest(base, seed, steps);
+        };
+        const SimDigestFn buggy = [&](std::uint64_t seed, int steps) {
+            std::uint64_t h = simulateDigest(base, seed, steps);
+            if (seed % 13 == 0 && seed > 0 && steps >= 5) h ^= 0x9E3779B97F4A7C15ULL;
+            return h;
+        };
+        const DivergenceReport r = fuzzDivergence(ref, buggy, 500, 300);
+        std::printf("[info] fuzzDivergence: found=%d minimalSeed=%llu minimalSteps=%d\n",
+                    r.found ? 1 : 0, static_cast<unsigned long long>(r.minimalSeed), r.minimalSteps);
+        CHECK(r.found);
+        CHECK(r.minimalSeed == 13);  // smallest divergent seed (ascending scan)
+        CHECK(r.minimalSteps == 5);  // shortest input prefix that reproduces it
+    }
+
+    if (g_failures == 0) {
+        std::printf("test_determinism_fuzz: all checks passed\n");
+        return 0;
+    }
+    std::printf("test_determinism_fuzz: %d check(s) failed\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Toward #374. Adds `src/game/DeterminismFuzz.h`, a seeded fuzzer over the deterministic sim so rare divergences are caught before launch.

- **`randomInputStream` / `simulateDigest`** drive the `DungeonGame` loop with a portable seeded LCG and fold each frame's trajectory into an FNV-1a digest, so a run is reproducible bit for bit and any difference shows.
- **`fuzzDeterminism`** re-simulates a large seeded batch and confirms every run reproduces its digest (determinism at scale).
- **`fuzzDivergence`** compares two sim variants, scanning seeds ascending to report the **minimal failing seed**, and **`shrinkSteps`** reduces it to the shortest failing input prefix - a minimal repro.

## Testing

`tests/test_determinism_fuzz.cpp` (registered in the headless suite, runs in ~0.3s):

- a **500-seed batch** re-simulates to identical digests (`deterministic == true`);
- a deterministic pair never diverges (no false positive);
- an **injected nondeterminism** bug (perturbs seeds divisible by 13 once the trajectory reaches 5 steps) is caught with a **minimal repro**: smallest seed `13`, shortest prefix `5` steps.

Passes standalone, via CMake/ctest, and clean under `-fsanitize=address,undefined`.

## Note

This delivers the `test_determinism_fuzz` acceptance (the headless-testable half). Performance budgets on representative scenes continue to build on the existing perf-regression gate (#295). The macOS build is now green on `main` (the #366 sol2 fix) but remains `continue-on-error` until the required-gate flip; all other gates should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_