### PR TITLE
Platform: make macOS a required build gate (#366, #378)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,10 @@ jobs:
   build:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    # macOS is informational for now: its runner ships a bleeding-edge toolchain
-    # (Xcode 26 / clang 21) that several pinned vendored deps predate - after the assimp
-    # fixes it still fails compiling sol2 v3.3.0's bundled optional, with more old deps
-    # likely behind it. Linux and Windows compile the full engine and stay required; the
-    # macOS clang-21 dependency work is tracked in #338 so it does not red-flag PRs.
-    continue-on-error: ${{ matrix.os == 'macos-latest' }}
+    # macOS is a required gate again (#366): the clang-21 blocker was the assimp workarounds
+    # plus sol2 v3.3.0's bundled optional<T&>, patched at configure time in CMakeLists, so the
+    # runner (Xcode 26 / clang 21) now compiles the full engine. All three platforms are
+    # required; #338 is resolved.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
   package:
     name: Package - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    # macOS packaging is informational until the clang-21 toolchain restore (#338 / #366).
-    continue-on-error: ${{ matrix.os == 'macos-latest' }}
+    # All platforms package as a required step now that the clang-21 toolchain is restored
+    # (#366 / #338): macOS builds the full engine, so its package is no longer informational.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Completes #366 (and the cross-platform half of #378). The clang-21 blocker tracked in #338 is resolved: the assimp workarounds plus the configure-time patch of sol2 v3.3.0's bundled `optional<T&>` (merged in #366) let the macOS runner (Xcode 26 / clang 21) compile the full engine and pass its tests - **confirmed by a green `Build on macos-latest` on `main`**.

This removes the `continue-on-error: ${{ matrix.os == 'macos-latest' }}` guard from both:
- `ci.yml` - the build matrix, so macOS is a **required gate** alongside Linux and Windows on every PR;
- `release.yml` - the packaging matrix, so the macOS package is produced as a required step.

## Verification

The sol2 fix landed on `main` in #366, whose PR showed `Build on macos-latest: success` (full-engine build, ~6.5 min). This PR is branched off that `main`, so its own macOS build exercises the required gate directly - it must pass here to merge, which is exactly the sign-off this change asserts.

Workflow-only change; no engine code is touched. `#338` can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_