### PR TITLE
Release: player guide, developer guide, and architecture map (#377)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,6 +76,35 @@ jobs:
           fi
         done
 
+    - name: Check the launch guides exist
+      run: |
+        echo "📚 Checking the top-level guides (#377)..."
+        for f in docs/PLAYER_GUIDE.md docs/DEVELOPER_ADD_A_MECHANIC.md docs/ARCHITECTURE.md; do
+          if [ -f "$f" ]; then echo "✅ $f"; else echo "❌ missing $f"; exit 1; fi
+        done
+
+    - name: Check internal doc links resolve
+      run: |
+        echo "🔗 Checking relative markdown links in README + docs/ ..."
+        rm -f /tmp/broken_links
+        for f in README.md docs/*.md; do
+          [ -f "$f" ] || continue
+          dir=$(dirname "$f")
+          grep -oE '\]\(([^)]+)\)' "$f" | sed -E 's/^\]\(//; s/\)$//' | while read -r target; do
+            case "$target" in http*|mailto:*|\#*) continue ;; esac
+            path="${target%%#*}"
+            [ -z "$path" ] && continue
+            if [ ! -e "$dir/$path" ]; then
+              echo "❌ $f: broken link -> $target"
+              echo broken >> /tmp/broken_links
+            fi
+          done
+        done
+        if [ -f /tmp/broken_links ]; then
+          echo "Broken internal links found."; exit 1
+        fi
+        echo "✅ all internal links resolve"
+
   spellcheck:
     name: Spell Check
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ The full strategy and rationale are in
 
 ---
 
+## Documentation
+
+Top-level guides for the two audiences a 1.0 needs, plus per-header docs throughout `src/`:
+
+- **[Player guide](docs/PLAYER_GUIDE.md)** - capture, play, share, and compete (campaign,
+  weekly, versus/FFA/co-op, editor, accessibility).
+- **[Developer guide: add a mechanic](docs/DEVELOPER_ADD_A_MECHANIC.md)** - the full path from
+  a drawn symbol to rendered pixels (spawn vocabulary -> `DungeonGame` -> CV -> solver ->
+  rollback digest -> render data), worked through the key/door mechanic.
+- **[Architecture map](docs/ARCHITECTURE.md)** - the headless-core + engine-wiring model,
+  determinism/replay-verifiability, and the CI gate topology.
+
+---
+
 ## Contributing
 
 Issues and pull requests are welcome. Development happens against feature branches;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,77 @@
+# Architecture map
+
+This is the mental model for the engine: how the pieces fit, why the simulation is
+deterministic and replay-verifiable, and how CI enforces all of it. For extending gameplay see
+[DEVELOPER_ADD_A_MECHANIC.md](DEVELOPER_ADD_A_MECHANIC.md); to play, see
+[PLAYER_GUIDE.md](PLAYER_GUIDE.md).
+
+## The headless-core + engine-wiring model
+
+Almost every gameplay and pipeline system is split in two:
+
+- A **headless core** - a header-only, `std`-only module under `src/` (e.g.
+  [`src/game/DungeonGame.h`](../src/game/DungeonGame.h),
+  [`src/game/Solver.h`](../src/game/Solver.h),
+  [`src/world/GeoJsonImporter.h`](../src/world/GeoJsonImporter.h)). It carries the rules and
+  the data, has no dependency on OpenGL / GLFW / ImGui, and is unit-tested in isolation.
+- **Engine wiring** - the renderer, Bullet physics, the audio subsystem, and the ImGui editor
+  that drive those cores in the live build.
+
+The payoff: the risky logic (movement, collision, solvability, rollback, CV) is exercised by
+fast headless tests, while the platform-specific glue stays thin. A new mechanic is written and
+tested entirely in a core header before any rendering exists.
+
+## Determinism and replay-verifiability
+
+The simulation is a pure function of its inputs. `DungeonGame::update(GameInput, dt)` mutates
+plain data with no clocks, no RNG-by-default, and no floating-point nondeterminism beyond what
+is quantized into the state digest. That gives three properties the whole game relies on:
+
+- **Reproducible** - the same seed / input stream yields a byte-identical trajectory. The
+  determinism fuzzer ([`src/game/DeterminismFuzz.h`](../src/game/DeterminismFuzz.h)) proves this
+  at scale and shrinks any divergence to a minimal repro.
+- **Rewindable** - the rollback core ([`src/game/DoodleRollback.h`](../src/game/DoodleRollback.h))
+  hashes each state (`stateDigest`) so a client can predict, mispredict, and re-simulate.
+- **Verifiable** - multiplayer results (Versus / FFA / co-op) and leaderboard runs are replays
+  re-simulated and checked against a recorded digest, so a tampered run fails verification
+  rather than being trusted.
+
+The capture pipeline feeds this: a photo or map extract becomes a `SceneDescription` (walls +
+`EntitySpawn`s), `loadGame` bakes it into a `DungeonGame`, and from there it is just the
+deterministic loop - so a captured level is immediately solvable, playable, shareable, and
+replay-verifiable.
+
+## Data flow, end to end
+
+```
+capture (photo / OSM / SVG)                     authoring (in-engine editor)
+        |                                                   |
+   CV / import  --> SceneDescription (walls + EntitySpawns) <--
+                                |
+                          loadGame()
+                                |
+                          DungeonGame  --update(GameInput, dt)-->  trajectory
+                          /     |      \                              |
+                    Solver   Rollback   RenderData                 digest
+                  (fairness) (rewind)  (draw colors)          (verify replays)
+```
+
+## CI gate topology
+
+Correctness is enforced by a fan of workflows under `.github/workflows/`:
+
+| Workflow | Gate |
+| --- | --- |
+| `ci.yml` | Full-engine build on Linux, Windows, and macOS (all required) + code-quality checks, rolled up into **Build Status**. |
+| `tests.yml` | The headless unit-test suite (the header-only cores). |
+| `sanitizers.yml` | The same suite under AddressSanitizer / UBSan (and the soak, #375). |
+| `gl-tests.yml` | GL/audio tests under Xvfb (offscreen FBO render + readback). |
+| `render-golden.yml` | Golden-image regression via EGL surfaceless render vs a committed PPM. |
+| `perf.yml` | Performance-regression gate on representative scenes. |
+| `analysis.yml` | CodeQL (c-cpp / python / actions). |
+| `docs.yml` | Documentation structure and link checks (this file). |
+| `release.yml` | Tag-driven per-platform packaging (CPack) + signed GitHub Release, with a PR dry-run. |
+
+A change lands only when Build Status and the headless/sanitizer/GL/golden/perf gates are
+green on all three platforms. macOS became a required gate again in #366 once the clang-21
+toolchain was restored.

--- a/docs/DEVELOPER_ADD_A_MECHANIC.md
+++ b/docs/DEVELOPER_ADD_A_MECHANIC.md
@@ -1,0 +1,74 @@
+# Developer guide: add a mechanic
+
+This walks the full path a new gameplay mechanic travels, from the symbol a player draws to the
+pixels it renders, using the **key / locked-door** mechanic (issue #319) as the worked example.
+Read [ARCHITECTURE.md](ARCHITECTURE.md) first for the headless-core model.
+
+Every step lives in a header-only core and is unit-tested before any rendering exists.
+
+## 1. Spawn vocabulary
+
+A captured or authored level is a `SceneDescription`: wall boxes plus a list of `EntitySpawn`
+(`{type, position, yaw}`), defined in [`src/game/DoodleScene.h`](../src/game/DoodleScene.h).
+Add your mechanic's spawn type(s) to the vocabulary. Keys and doors use indexed types so a key
+opens the matching door: `key@1`, `lock@1`.
+
+## 2. DungeonGame logic
+
+In [`src/game/DungeonGame.h`](../src/game/DungeonGame.h):
+
+- Add the data: a `struct Key { ecs::Vec3 position; int id; bool collected; }` and
+  `struct LockedDoor { world::Box box; int id; bool open; }`, plus `std::vector<Key> keys;` /
+  `std::vector<LockedDoor> lockedDoors;` on `DungeonGame`. Fields default to empty, so a level
+  without the mechanic plays byte-identically to before.
+- Parse the spawn in `loadGame()`: `detail::featureBase("key@1", id)` yields base `"key"` and
+  `id = 1`; push a `Key`; `"lock"` pushes a `LockedDoor` built from `detail::featureBox`.
+- Implement the rule in `update()`: when the player is within `playerRadius + keyRadius` of an
+  uncollected key, mark it collected and open every `LockedDoor` with the same `id`; a closed
+  door is solid in the collision test (`hitsWall` / `blocked`).
+
+Keep it a pure function of the inputs - no clocks, no ambient RNG - so determinism holds.
+
+## 3. CV symbol mapping
+
+So a drawn symbol becomes the spawn: the recognizer maps an ink glyph to a spawn type. The
+classifier lives in [`src/ml/GlyphNet.h`](../src/ml/GlyphNet.h) with a labeled corpus and an
+accuracy gate in [`src/ml/GlyphCorpus.h`](../src/ml/GlyphCorpus.h); indexed ids (the `@1`) come
+from digit recognition in [`src/game/GlyphDigits.h`](../src/game/GlyphDigits.h). Register the
+new label so a recognized glyph emits the right `EntitySpawn.type`.
+
+## 4. Solver / fairness
+
+Every level must be beatable. [`src/game/Solver.h`](../src/game/Solver.h) grids the level
+(walkable iff `hitsWall(center, playerRadius)` is false) and BFS/bitmask-searches for a clearing
+path, returning `solvable` and a `par`. It evaluates doors at the start state - a **closed door
+is impassable** - so a fair level never gates the only path behind a lock the solver cannot open.
+The auto-repair pass ([`src/game/LevelRepair.h`](../src/game/LevelRepair.h)) and the live editor
+fairness ([`src/game/LevelEditor.h`](../src/game/LevelEditor.h)) reuse the same solver.
+
+## 5. Rollback digest
+
+For rewind and replay-verification, the mechanic's state must fold into the state hash.
+[`src/game/DoodleRollback.h`](../src/game/DoodleRollback.h)'s `stateDigest` hashes the player,
+coins, and status; extend it to also fold key-collected and door-open flags, so a mispredicted
+key pickup diverges the digest and triggers a resync, and a replay that lies about a door fails
+verification.
+
+## 6. Render data
+
+Finally, give it a look. [`src/game/DungeonRenderData.h`](../src/game/DungeonRenderData.h)'s
+`renderColorForType` maps a type string to a `RenderColor`; add `"key"` and `"lockeddoor"`
+entries (and a colorblind-safe variant in
+[`src/game/AudioAccessibility.h`](../src/game/AudioAccessibility.h)), and bind a sound cue in
+`cueForEvent`. The renderer draws from this data; the core never mentions OpenGL.
+
+## Checklist
+
+- [ ] Spawn type in `DoodleScene` vocabulary and `loadGame` parsing.
+- [ ] Data + rule in `DungeonGame`, defaulting inert when absent.
+- [ ] CV label so a drawn glyph maps to the spawn.
+- [ ] Solver treats it correctly; a headless test asserts a fair level stays solvable.
+- [ ] State folded into the rollback digest.
+- [ ] Render color + sound cue.
+- [ ] A `tests/test_*.cpp` covering the rule, registered in `CMakeLists.txt`, green under the
+      headless and sanitizer suites.

--- a/docs/PLAYER_GUIDE.md
+++ b/docs/PLAYER_GUIDE.md
@@ -1,0 +1,51 @@
+# Player guide
+
+Doodlebound turns a drawing into a game you can play, share, and compete on. This is how.
+
+## Capture
+
+Draw a level on paper - walls as lines, and symbols for the pieces:
+
+- a **triangle** is your start, a **square** is the exit, a **circle** is a coin;
+- an **X** is an enemy, a **+** is a key (`+1` opens door `1`), a bar is a switch;
+- spikes are hazards, a box is a pushable block.
+
+Photograph it (or import an image, an OpenStreetMap area, or an SVG floor plan). The computer
+vision pipeline binarizes the ink, vectorizes the walls, recognizes the symbols, and builds a
+playable level. Every captured level is checked for **fairness** - it is guaranteed solvable
+before you play, and can be auto-repaired if a symbol landed somewhere unreachable.
+
+## Play
+
+Move with **WASD** or a **gamepad** left stick (rebindable in settings). Collect every coin,
+then reach the exit to win; avoid enemies and hazards. Keys open the doors with the matching
+number, switches flip toggle walls, and you can push blocks to clear a path.
+
+The **campaign** is a difficulty-ramped set of hand-tuned levels that introduce each mechanic in
+turn. A rotating **weekly challenge** picks a level for everyone that week, so scores are
+comparable.
+
+## Share
+
+Any level - captured or built in the in-engine **editor** - becomes a short **share code**.
+Send the code; anyone can import it and get the byte-identical level. Your **replays** share the
+same way, so you can send someone the exact run, not just the score.
+
+## Compete
+
+- **Leaderboards** rank the fastest clears; every submitted run is a replay that is
+  re-simulated and verified, so times are cheat-resistant.
+- **Versus** and **FFA** race players through the same level in real time over a rollback
+  netcode; **co-op** shares one world across several players.
+- Because the simulation is deterministic and every result is a verified replay, a spectator can
+  scrub any match or run frame by frame.
+
+## Accessibility
+
+Independent **master / music / SFX** volumes and a mute; **colorblind-safe palettes**
+(deuteranopia / protanopia / tritanopia) that keep every piece distinguishable by brightness,
+not just hue; DPI-aware UI scaling; and reduced-motion and cue-subtitle options - all in
+settings, and all persisted. The interface is localizable through a string table.
+
+For how the engine is built, see [ARCHITECTURE.md](ARCHITECTURE.md); to extend it, see
+[DEVELOPER_ADD_A_MECHANIC.md](DEVELOPER_ADD_A_MECHANIC.md).


### PR DESCRIPTION
## Summary

Toward #377. Publishes the three top-level guides a 1.0 needs, cross-linked from the README, and gates them in `docs.yml`.

- **[`docs/PLAYER_GUIDE.md`](../blob/claude/release-docs-377/docs/PLAYER_GUIDE.md)** - capture, play, share, and compete (campaign, weekly, versus/FFA/co-op, editor, accessibility).
- **`docs/DEVELOPER_ADD_A_MECHANIC.md`** - the full path a mechanic travels: **spawn vocabulary -> `DungeonGame` logic -> CV symbol mapping -> solver/fairness -> rollback digest -> render data**, worked through the **key/door** mechanic, linking the actual header at each step.
- **`docs/ARCHITECTURE.md`** - the headless-core + engine-wiring model, the determinism / replay-verifiability guarantees, an end-to-end data-flow diagram, and the CI gate topology table.
- **README** gains a Documentation section linking all three.
- **`docs.yml`** now checks the three guides exist and that **every relative markdown link** in the README and `docs/` resolves to a real file, so a broken or renamed link fails CI.

## Testing

Verified locally that every relative link in the new docs and the README section resolves on this branch. The added `docs.yml` steps parse as valid YAML (the pre-existing spellcheck word-list heredoc is unchanged).

The "add a mechanic" steps match the current code paths (`DoodleScene` vocabulary, `DungeonGame::loadGame` `key@id`/`lock@id` parsing, `Solver` closed-door handling, `DoodleRollback::stateDigest`, `DungeonRenderData::renderColorForType`).

macOS is now a required gate on `main`; all gates should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJjByUTeiST8sTfsfZYi74)_