### PR TITLE
Release: repair the docs gate and finalize 1.0.0 (#377, #378, #379)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
           echo "✅ README.md exists"
           
           # Check if README has essential sections
-          if grep -qi "# IKore Engine" README.md; then
+          if grep -qi "# Charta\|# IKore Engine" README.md; then
             echo "✅ Project title found"
           else
             echo "⚠️  Project title not found in README"
@@ -90,8 +90,11 @@ jobs:
         for f in README.md docs/*.md; do
           [ -f "$f" ] || continue
           dir=$(dirname "$f")
-          grep -oE '\]\(([^)]+)\)' "$f" | sed -E 's/^\]\(//; s/\)$//' | while read -r target; do
-            case "$target" in http*|mailto:*|\#*) continue ;; esac
+          # Strip fenced code blocks first: C++ lambdas like [](std::shared_ptr<T> x)
+          # would otherwise be picked up as markdown links.
+          awk '/^[[:space:]]*```/ { fenced = !fenced; next } !fenced' "$f" \
+            | grep -oE '\]\(([^)]+)\)' | sed -E 's/^\]\(//; s/\)$//' | while read -r target; do
+            case "$target" in http*|mailto:*|\#*|*" "*) continue ;; esac
             path="${target%%#*}"
             [ -z "$path" ] && continue
             if [ ! -e "$dir/$path" ]; then
@@ -123,32 +126,13 @@ jobs:
         echo "📝 Running spell check on documentation..."
         
         # Create a simple word list for technical terms
-        cat > .aspell.en.pws << EOF
-personal_ws-1.1 en 30
-OpenGL
-GLFW
-CMake
-GitHub
-IKore
-vcpkg
-macOS
-Ubuntu
-workflow
-backends
-renderer
-API
-APIs
-enum
-namespace
-bool
-hpp
-cpp
-inline
-const
-struct
-typedef
-templating
-EOF
+        {
+          echo "personal_ws-1.1 en 30"
+          printf '%s\n' \
+            OpenGL GLFW CMake GitHub IKore vcpkg macOS Ubuntu \
+            workflow backends renderer API APIs enum namespace bool \
+            hpp cpp inline const struct typedef templating
+        } > .aspell.en.pws
         
         find . -name "*.md" -not -path "./build/*" -not -path "./_deps/*" | while read md_file; do
           echo "Checking $md_file..."

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,14 +3,17 @@ name: Documentation
 on:
   push:
     branches: [ main ]
-    paths: 
+    paths:
       - '**.md'
       - 'docs/**'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches: [ main ]
     paths:
       - '**.md'
       - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
 
 jobs:
   docs-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ name: Release
 # - workflow_dispatch -> manual build+package (optionally publishing to a named tag).
 #
 # Signing is driven by CI secrets and degrades cleanly to an unsigned build when they are
-# absent (forks, dry runs). macOS is gated on the #338 toolchain restore and is informational.
+# absent (forks, dry runs). macOS packages as a required step since the #338/#366 toolchain
+# restore; the pre-1.0 dry-run evidence is recorded in docs/RELEASE_SIGNOFF_1.0.md (#378).
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to Doodlebound (the IKore engine) are recorded here. The for
 version is `project(IKoreEngine VERSION ...)` / `IKORE_RELEASE_VERSION` in `CMakeLists.txt`,
 surfaced to code through the generated `ikore/Version.h`.
 
-## [1.0.0-rc.1] - Release candidate
+## [1.0.0] - 2026-07-21
 
-The 1.0 release candidate: the capture-to-play engine, multiplayer, the content pipeline, and
-the platform/ship work are feature-complete and stabilizing under a bug-fix-only freeze.
+The 1.0 release: the capture-to-play engine, multiplayer, the content pipeline, and the
+platform/ship work are feature-complete. Everything below stabilized through the
+`1.0.0-rc.1` bug-fix-only freeze and ships unchanged in 1.0.0, plus the release-window
+fixes recorded under "Fixed".
 
 ### Added
 
@@ -40,5 +42,9 @@ the platform/ship work are feature-complete and stabilizing under a bug-fix-only
 ### Fixed
 
 - macOS builds of the scripting layer under Xcode 26 / clang 21 (sol2 `optional<T&>::emplace`).
+- The `docs.yml` documentation gate: the workflow file was invalid YAML (an unindented
+  heredoc) and had failed at startup on every run since it landed, so the #377 doc checks
+  never executed. The link checker also now skips fenced code blocks so C++ lambdas in the
+  implementation notes are not misread as markdown links (#415).
 
-[1.0.0-rc.1]: https://github.com/Ikey168/IKore-Engine/releases
+[1.0.0]: https://github.com/Ikey168/Charta/releases/tag/v1.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ project(IKoreEngine VERSION 1.0.0 LANGUAGES C CXX)
 # and is overridable from CI with -DIKORE_RELEASE_VERSION=<tag> so a tagged build stamps its
 # real version. project(VERSION ...) above holds the numeric components.
 if(NOT DEFINED IKORE_RELEASE_VERSION)
-    set(IKORE_RELEASE_VERSION "1.0.0-rc.1")
+    set(IKORE_RELEASE_VERSION "1.0.0")
 endif()
 
 # Generate the version header consumed by the engine / about screen, packaging, and the

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Charta
 
-[![CI/CD Pipeline](https://github.com/Ikey168/IKore-Engine/actions/workflows/ci.yml/badge.svg)](https://github.com/Ikey168/IKore-Engine/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/Ikey168/IKore-Engine/actions/workflows/analysis.yml/badge.svg)](https://github.com/Ikey168/IKore-Engine/actions/workflows/analysis.yml)
-[![Documentation](https://github.com/Ikey168/IKore-Engine/actions/workflows/docs.yml/badge.svg)](https://github.com/Ikey168/IKore-Engine/actions/workflows/docs.yml)
+[![Release](https://img.shields.io/github/v/release/Ikey168/Charta)](https://github.com/Ikey168/Charta/releases/latest)
+[![CI/CD Pipeline](https://github.com/Ikey168/Charta/actions/workflows/ci.yml/badge.svg)](https://github.com/Ikey168/Charta/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/Ikey168/Charta/actions/workflows/analysis.yml/badge.svg)](https://github.com/Ikey168/Charta/actions/workflows/analysis.yml)
+[![Documentation](https://github.com/Ikey168/Charta/actions/workflows/docs.yml/badge.svg)](https://github.com/Ikey168/Charta/actions/workflows/docs.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 > **From paper to playable: an engine that turns drawings, floor plans, and map

--- a/docs/RELEASE_SIGNOFF_1.0.md
+++ b/docs/RELEASE_SIGNOFF_1.0.md
@@ -21,7 +21,7 @@ below is from GitHub Actions runs on `main` and on the release PR
 | Performance gate | `perf.yml` | ✅ | n/a | n/a | budgets from #374 |
 | CodeQL / analysis | `analysis.yml` | ✅ | n/a | n/a | c-cpp, python, actions |
 | Documentation gate | `docs.yml` | ✅ | n/a | n/a | repaired in #415; guides + link check green |
-| Packaging (CPack) | `release.yml` | ✅ | ✅ | ✅ | build-only dispatch run on `main` (see below) |
+| Packaging (CPack) | `release.yml` | ✅ | ✅ | ✅ | PR dry-run on the release PR (see below) |
 
 ## `continue-on-error` audit
 
@@ -32,10 +32,10 @@ followed by an explicit fallback step. No **job** on any required workflow carri
 
 ## Packaged-artifact verification
 
-The `release.yml` pipeline (from #369) was exercised as a build-only `workflow_dispatch` on
-`main` ahead of tagging: all three platforms configured with the release version stamp,
-built the full `IKore` target in Release, and produced CPack artifacts (TGZ on Linux/macOS,
-ZIP on Windows). Signing degrades to unsigned automatically when the signing secrets are
+The `release.yml` pipeline (from #369) was exercised ahead of tagging via its PR dry-run
+path on the release PR (#415): all three platforms configured with the release version
+stamp, built the full `IKore` target in Release, and produced CPack artifacts (TGZ on
+Linux/macOS, ZIP on Windows) without publishing. Signing degrades to unsigned automatically when the signing secrets are
 absent; on the release tag the same pipeline signs when `MACOS_CERTIFICATE_P12` /
 `WINDOWS_CERTIFICATE_PFX` are configured.
 

--- a/docs/RELEASE_SIGNOFF_1.0.md
+++ b/docs/RELEASE_SIGNOFF_1.0.md
@@ -1,0 +1,69 @@
+# 1.0.0 Cross-Platform Sign-Off (#378)
+
+This document records the release sign-off for `v1.0.0`, as required by #378: the state of
+every required CI gate on all three platforms, the packaged-artifact verification, and the
+per-platform checklist, with the evidence for each item.
+
+Reference commit: the tip of `main` at tag time (see the `v1.0.0` tag). All gate evidence
+below is from GitHub Actions runs on `main` and on the release PR
+([#415](https://github.com/Ikey168/Charta/pull/415)); the full run history is under
+[Actions](https://github.com/Ikey168/Charta/actions?query=branch%3Amain).
+
+## Required gate matrix
+
+| Gate | Workflow | Linux | Windows | macOS | Notes |
+|---|---|---|---|---|---|
+| Build (full engine) | `ci.yml` | ✅ | ✅ | ✅ | macOS required since #366/#412 — no `continue-on-error` |
+| Headless unit tests | `tests.yml` | ✅ | n/a | n/a | headless cores, all `test_*` targets |
+| GL/audio runtime tests | `gl-tests.yml` | ✅ (Xvfb) | n/a | n/a | GL context + OpenAL paths |
+| ASan/UBSan | `sanitizers.yml` | ✅ | n/a | n/a | includes the bounded soak (#375) |
+| Golden-image regression | `render-golden.yml` | ✅ | n/a | n/a | |
+| Performance gate | `perf.yml` | ✅ | n/a | n/a | budgets from #374 |
+| CodeQL / analysis | `analysis.yml` | ✅ | n/a | n/a | c-cpp, python, actions |
+| Documentation gate | `docs.yml` | ✅ | n/a | n/a | repaired in #415; guides + link check green |
+| Packaging (CPack) | `release.yml` | ✅ | ✅ | ✅ | build-only dispatch run on `main` (see below) |
+
+## `continue-on-error` audit
+
+`grep -rn continue-on-error .github/workflows/` shows exactly two occurrences, both
+**step-level** fallbacks for the Windows vcpkg bootstrap (`ci.yml`, `release.yml`), each
+followed by an explicit fallback step. No **job** on any required workflow carries
+`continue-on-error` — including all macOS jobs (#366 closed the historical exception).
+
+## Packaged-artifact verification
+
+The `release.yml` pipeline (from #369) was exercised as a build-only `workflow_dispatch` on
+`main` ahead of tagging: all three platforms configured with the release version stamp,
+built the full `IKore` target in Release, and produced CPack artifacts (TGZ on Linux/macOS,
+ZIP on Windows). Signing degrades to unsigned automatically when the signing secrets are
+absent; on the release tag the same pipeline signs when `MACOS_CERTIFICATE_P12` /
+`WINDOWS_CERTIFICATE_PFX` are configured.
+
+## Per-platform checklist
+
+Automated coverage, exercised on every gate run:
+
+- [x] **Launch / runtime**: full-engine build on all three platforms; GL context, render
+  loop, and audio device paths exercised by `gl-tests.yml` (Linux/Xvfb).
+- [x] **Capture → play**: the CV pipeline and `DungeonGame` loop run headlessly in the unit
+  and soak suites (`test_soak` drives repeated capture→play→share cycles, #375).
+- [x] **Save / load**: unified save model with corruption-resistant writes covered by the
+  #370 tests, including mid-write interruption cases.
+- [x] **Share codes**: encode/import round-trip covered headlessly (#370); exercised in the
+  soak loop.
+- [x] **Input remapping / gamepad / DPI scaling**: #368 test suite (headless).
+- [x] **Determinism / multiplayer**: rollback digest equality fuzzed at scale (#374); match
+  loop exercised in the soak (#375).
+- [x] **Packaged build produced per platform**: `release.yml` dispatch evidence above.
+
+Manual, on-hardware verification (interactive play of the packaged build on a physical
+device: launch, camera capture, audio out, controller in-hand):
+
+- [ ] Linux · [ ] Windows · [ ] macOS — **not exercised in this sign-off**; the automated
+  equivalents above are the accepted evidence for 1.0.0. Anything found post-release is
+  handled as a 1.0.x patch.
+
+## Launch-blocking defects
+
+None open at tag time: the tracker's release-blocker list is empty (all milestone-26
+implementation issues closed via #400–#414; the docs-gate repair landed in #415).


### PR DESCRIPTION
## Summary

The release PR for `v1.0.0`. Two parts:

### 1. Repair the `docs.yml` documentation gate (#377)

The Documentation workflow had failed at startup (zero jobs) on every run since #414 merged: the aspell word-list heredoc body sat at column 0, breaking out of the `run: |` block scalar and making the workflow file invalid YAML — GitHub could not parse it, so none of the #377 documentation checks ever executed.

- Build the aspell personal dictionary with `printf` instead of an unindented heredoc.
- Strip fenced code blocks before scanning for markdown links: C++ lambdas like `[](std::shared_ptr<T> x)` in the older implementation notes were matched as broken links and would have failed the gate the moment the YAML parsed. Also skip targets containing spaces.
- Accept the post-rebrand `# Charta` title in the README structure check.
- Include the workflow file in its own path filter and add `workflow_dispatch`.

Verified on this PR: **Documentation Check and Spell Check both run and pass** for the first time since #414.

### 2. Finalize 1.0.0 (#378, #379)

- `IKORE_RELEASE_VERSION` promoted from `1.0.0-rc.1` to `1.0.0` (single version source, #376).
- `CHANGELOG.md`: rc section promoted to `[1.0.0] - 2026-07-21`, docs-gate repair recorded under Fixed.
- README badges repointed from the stale `IKore-Engine` slug to `Charta`, plus a release badge.
- `docs/RELEASE_SIGNOFF_1.0.md`: the #378 sign-off record — required gate matrix, `continue-on-error` audit, packaged-artifact verification, and the per-platform checklist distinguishing automated evidence from on-hardware testing.

After merge: tag `v1.0.0` to trigger the release pipeline (#369), then the post-release dev-version bump (#379).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bKbkPiEVWsNwE6QMLVWYF